### PR TITLE
chore[PowerGridComponent]: added eventRefresh to listeners

### DIFF
--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -55,9 +55,10 @@ class PowerGridComponent extends Component
 
     protected $listeners = [
         'eventChangeDatePiker' => 'eventChangeDatePiker',
-        'eventChangeInput'     => 'eventChangeInput',
-        'eventToggleChanged'   => 'eventChangeInput',
-        'eventMultiSelect'     => 'eventMultiSelect'
+        'eventChangeInput' => 'eventChangeInput',
+        'eventToggleChanged' => 'eventChangeInput',
+        'eventMultiSelect' => 'eventMultiSelect',
+        'eventRefresh' => '$refresh',
     ];
 
     /**


### PR DESCRIPTION
Added eventRefresh because when we use a child modal component and wanna refresh the parent component screen, it wasn't possible.