### PR TITLE
Reset page while entering new search

### DIFF
--- a/src/Traits/Filter.php
+++ b/src/Traits/Filter.php
@@ -70,6 +70,8 @@ trait Filter
         $this->filters['number'][$field]['start']     = $value;
         $this->filters['number'][$field]['thousands'] = $thousands;
         $this->filters['number'][$field]['decimal']   = $decimal;
+        
+        $this->resetPage();
     }
 
     /**
@@ -83,6 +85,8 @@ trait Filter
         $this->filters['number'][$field]['end']       = $value;
         $this->filters['number'][$field]['thousands'] = $thousands;
         $this->filters['number'][$field]['decimal']   = $decimal;
+        
+        $this->resetPage();
     }
 
     /**
@@ -92,6 +96,8 @@ trait Filter
     public function filterInputText(string $field, string $value): void
     {
         $this->filters['input_text'][$field] = $value;
+        
+        $this->resetPage();
     }
 
     /**
@@ -101,6 +107,8 @@ trait Filter
     public function filterBoolean(string $field, string $value): void
     {
         $this->filters['boolean'][$field] = $value;
+        
+        $this->resetPage();
     }
 
     /**
@@ -110,5 +118,7 @@ trait Filter
     public function filterInputTextOptions(string $field, string $value): void
     {
         $this->filters['input_text_options'][$field] = $value;
+        
+        $this->resetPage();
     }
 }


### PR DESCRIPTION
When navigated to a page greater than 1 and did a new search, search results could be only on page 1 and not visible anymore. Navigation is also not possible in this situation.