### PR TITLE
Fix ThemeBase View Paths

### DIFF
--- a/src/Themes/ThemeBase.php
+++ b/src/Themes/ThemeBase.php
@@ -6,11 +6,11 @@ class ThemeBase extends AbstractTheme
 {
     public string $name = "";
 
-    public string $base = "livewire-powergrid::components\\frameworks\\";
+    public string $base = "livewire-powergrid::components.frameworks.";
 
     public function root(): string
     {
-        return $this->base . "" . $this->name . "\\";
+        return $this->base . "" . $this->name . ".";
     }
 
     public function toggleable(): Components\Toggleable


### PR DESCRIPTION
This PR fix #43 


After debugging, I found that the `Theme Base` class was set to both `$base` and `root()` and `paths` using "\\" instead of "."

```php
class ThemeBase extends AbstractTheme
{
    public string $name = "";

    public string $base = "livewire-powergrid::components\\frameworks\\";

    public function root(): string
    {
        return $this->base . "" . $this->name . "\\";
    }
```

I refactored and set the values ​​using "." as a folder separator. With this, the error mentioned in the issue was solved.

```php
class ThemeBase extends AbstractTheme
{
    public string $name = "";

    public string $base = "livewire-powergrid::components.frameworks.";

    public function root(): string
    {
        return $this->base . "" . $this->name . ".";
    }
```
Tested changes in new installations of laravel. I got positive results on both Windows and Linux.

![powergrid_on_windows](https://user-images.githubusercontent.com/2080547/129134909-95f75399-6f76-4e46-94f9-0139a15256c9.gif)

