### PR TITLE
Method createFromFillable refactored for more databases support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     "require": {
         "php": "^7.4|^8",
         "livewire/livewire": "^2.4",
-        "box/spout": "^3"
+        "box/spout": "^3",
+        "doctrine/dbal": "^3.1"
     },
     "scripts": {
         "pest-test": "./vendor/bin/pest"

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -2,7 +2,6 @@
 
 namespace PowerComponents\LivewirePowerGrid\Commands;
 
-use function PHPSTORM_META\type;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -132,39 +131,39 @@ class CreateCommand extends Command
                 continue;
             }
 
-            $type = Schema::getConnection()->getDoctrineColumn($model->getTable(), $field);
+            $column = Schema::getConnection()->getDoctrineColumn($model->getTable(), $field);
 
             $title = Str::of($field)->replace('_', ' ')->upper();
 
-            if ($type->getType()->getName() === 'datetime')  {
+            if ($column->getType()->getName() === 'datetime')  {
                 $dataSource .= "\n" . '            ->addColumn(\'' . $field . '_formatted\', function(' . $modelLastName . ' $model) { ' . "\n" . '                return Carbon::parse($model->' . $field . ')->format(\'d/m/Y H:i:s\');' . "\n" . '            })';
                 $columns .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '_formatted\')' . "\n" . '                ->searchable()' . "\n" . '                ->sortable()' . "\n" . '                ->makeInputDatePicker(\'' . $field . '\'),' . "\n\n";
 
                 continue;
             }
 
-            if ($type->getType()->getName() === 'date') {
+            if ($column->getType()->getName() === 'date') {
                 $dataSource .= "\n" . '            ->addColumn(\'' . $field . '_formatted\', function(' . $modelLastName . ' $model) { ' . "\n" . '                return Carbon::parse($model->' . $field . ')->format(\'d/m/Y\');' . "\n" . '            })';
                 $columns .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '_formatted\')' . "\n" . '                ->searchable()' . "\n" . '                ->sortable()' . "\n" . '                ->makeInputDatePicker(\'' . $field . '\'),' . "\n\n";
 
                 continue;
             }
 
-            if ($type->getType()->getName() === 'boolean') {
+            if ($column->getType()->getName() === 'boolean') {
                 $dataSource .= "\n" . '            ->addColumn(\'' . $field . '\')';
                 $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->toggleable(),' . "\n\n";
 
                 continue;
             }
 
-            if (in_array($type->getType()->getName(), ['smallint', 'integer', 'bigint'])) {
+            if (in_array($column->getType()->getName(), ['smallint', 'integer', 'bigint'])) {
                 $dataSource .= "\n" . '            ->addColumn(\'' . $field . '\')';
                 $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->makeInputRange(),' . "\n\n";
 
                 continue;
             }
 
-            if ($type->getType()->getName() === 'string') {
+            if ($column->getType()->getName() === 'string') {
                 $dataSource .= "\n" . '            ->addColumn(\'' . $field . '\')';
                 $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->sortable()' . "\n" . '                ->searchable()' . "\n" . '                ->makeInputText(),' . "\n\n";
 

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -2,11 +2,12 @@
 
 namespace PowerComponents\LivewirePowerGrid\Commands;
 
+use function PHPSTORM_META\type;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
 
 class CreateCommand extends Command
 {
@@ -117,8 +118,11 @@ class CreateCommand extends Command
     {
         $model          = new $modelName();
         $stub           = File::get(__DIR__ . '/../../resources/stubs/table.fillable.stub');
-        $getFillable    = array_merge([$model->getKeyName()], $model->getFillable());
-        $getFillable    = array_merge($getFillable, ['created_at', 'updated_at']);
+        $getFillable    = array_merge(
+                            [$model->getKeyName()],
+                            $model->getFillable(),
+                            ['created_at', 'updated_at']
+                        );
 
         $dataSource     = "";
         $columns        = "[\n";
@@ -127,34 +131,48 @@ class CreateCommand extends Command
             if (in_array($field, $model->getHidden())) {
                 continue;
             }
-            $type = Arr::first(Arr::where(DB::select('describe ' . $model->getTable()), function ($info) use ($field) {
-                return ($info->Field === $field) ? $info->Type : '';
-            }))->Type;
+
+            $type = Schema::getConnection()->getDoctrineColumn($model->getTable(), $field);
 
             $title = Str::of($field)->replace('_', ' ')->upper();
 
-            if (in_array($type, ['timestamp', 'datetime'])) {
+            if ($type->getType()->getName() === 'datetime')  {
                 $dataSource .= "\n" . '            ->addColumn(\'' . $field . '_formatted\', function(' . $modelLastName . ' $model) { ' . "\n" . '                return Carbon::parse($model->' . $field . ')->format(\'d/m/Y H:i:s\');' . "\n" . '            })';
-
                 $columns .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '_formatted\')' . "\n" . '                ->searchable()' . "\n" . '                ->sortable()' . "\n" . '                ->makeInputDatePicker(\'' . $field . '\'),' . "\n\n";
+
+                continue;
             }
 
-            if ($type === 'tinyint(1)') {
+            if ($type->getType()->getName() === 'date') {
+                $dataSource .= "\n" . '            ->addColumn(\'' . $field . '_formatted\', function(' . $modelLastName . ' $model) { ' . "\n" . '                return Carbon::parse($model->' . $field . ')->format(\'d/m/Y\');' . "\n" . '            })';
+                $columns .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '_formatted\')' . "\n" . '                ->searchable()' . "\n" . '                ->sortable()' . "\n" . '                ->makeInputDatePicker(\'' . $field . '\'),' . "\n\n";
+
+                continue;
+            }
+
+            if ($type->getType()->getName() === 'boolean') {
                 $dataSource .= "\n" . '            ->addColumn(\'' . $field . '\')';
                 $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->toggleable(),' . "\n\n";
 
                 continue;
             }
-            if ($type === 'int(11)') {
+
+            if (in_array($type->getType()->getName(), ['smallint', 'integer', 'bigint'])) {
                 $dataSource .= "\n" . '            ->addColumn(\'' . $field . '\')';
                 $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->makeInputRange(),' . "\n\n";
 
                 continue;
             }
-            if (!in_array($type, ['timestamp', 'datetime'])) {
+
+            if ($type->getType()->getName() === 'string') {
                 $dataSource .= "\n" . '            ->addColumn(\'' . $field . '\')';
-                $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->sortable()' . "\n" . '                ->searchable(),' . "\n\n";
+                $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->sortable()' . "\n" . '                ->searchable()' . "\n" . '                ->makeInputText(),' . "\n\n";
+
+                continue;
             }
+
+            $dataSource .= "\n" . '            ->addColumn(\'' . $field . '\')';
+            $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->sortable()' . "\n" . '                ->searchable(),' . "\n\n";
         }
 
         $columns .= "        ]\n";


### PR DESCRIPTION
`createFromFillable` method refactored to support the databases provided by the laravel framework.

As the method initially made use of DB::select, using the SQL `describe table_name`, but describe is not supported by PostgreSQL for example so I decided to use Facade Schema's `getDoctrineColumn` method.

`getDoctrineColumn` method returns the instance of `\Doctrine\DBAL\Schema\Column` class.

Couple of methods from \Doctrine\DBAL\Schema\Column class:

```php
$type->getName();    // returns string
$type->getNotnull(); // returns true/false
$type->getDefault(); // returns string or null
$type->getType();    // returns instance of \Doctrine\DBAL\Types\Type
$type->getLength();  // returns int or null
``` 
The method that interests us is the `getType`, but in the future if we need to check if a certain column is nullable or for example its size, we will have this flexibility.

In this way, all information about the column is retrieved with:

```php
$column = Schema::getConnection()->getDoctrineColumn($model->getTable(), $field);
```

And column type checks, we can easily retrieve as follows:
```php
$column->getType()->getName()  // returns a string containing the column type
```

Therefore, the column type checks, where we actually formatted and assembled the livewire powergrid component, looked like this

```php
if ($column->getType()->getName() === 'datetime')  {
    $dataSource .= "\n" . '            ->addColumn(\'' . $field . '_formatted\', function(' . $modelLastName . ' $model) { ' . "\n" . '                return Carbon::parse($model->' . $field . ')->format(\'d/m/Y H:i:s\');' . "\n" . '            })';
    $columns .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '_formatted\')' . "\n" . '                ->searchable()' . "\n" . '                ->sortable()' . "\n" . '                ->makeInputDatePicker(\'' . $field . '\'),' . "\n\n";

    continue;
}

if ($column->getType()->getName() === 'date') {
    $dataSource .= "\n" . '            ->addColumn(\'' . $field . '_formatted\', function(' . $modelLastName . ' $model) { ' . "\n" . '                return Carbon::parse($model->' . $field . ')->format(\'d/m/Y\');' . "\n" . '            })';
    $columns .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '_formatted\')' . "\n" . '                ->searchable()' . "\n" . '                ->sortable()' . "\n" . '                ->makeInputDatePicker(\'' . $field . '\'),' . "\n\n";

    continue;
}

if ($column->getType()->getName() === 'boolean') {
    $dataSource .= "\n" . '            ->addColumn(\'' . $field . '\')';
    $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->toggleable(),' . "\n\n";

    continue;
}

if (in_array($column->getType()->getName(), ['smallint', 'integer', 'bigint'])) {
    $dataSource .= "\n" . '            ->addColumn(\'' . $field . '\')';
    $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->makeInputRange(),' . "\n\n";

    continue;
}

if ($column->getType()->getName() === 'string') {
    $dataSource .= "\n" . '            ->addColumn(\'' . $field . '\')';
    $columns    .= '            Column::add()' . "\n" . '                ->title(__(\'' . $title . '\'))' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->sortable()' . "\n" . '                ->searchable()' . "\n" . '                ->makeInputText(),' . "\n\n";

    continue;
}
```

To test the changes made, I created a repository with code for a demo laravel application. This repository can be found at URL `https://github.com/vs0uz4/powergrid-demo`.

For information, the migration code that creates the table used in the tests is shown below

```php
public function up()
{
    Schema::create('categories', function (Blueprint $table) {
        $table->id();
        $table->integer('code');
        $table->string('name');
        $table->string('description');
        $table->tinyInteger('status')->default(0);
        $table->boolean('enabled')->default(false);
        $table->timestamps();
        $table->date('publication_at');
        $table->dateTime('enabled_at');
    });
}
```

And by way of comparison, the values ​​referring to the types of columns returned using the `describe` SQL sentence or using the `getDoctrineColumn()` method are displayed in the table below.

![tabela de tipos de colunas](https://user-images.githubusercontent.com/2080547/129648220-2e8a5371-a48f-4cab-9cc4-f01242dc312f.png)

⚠️  As you can see problems with **MS SQL Server** support were encountered.

As the demo application uses `Laravel Sail` and it does not support the Microsoft database, it was not possible to reproduce the tests in this environment.

> 📓 However, in the near future, I intend to create the application environment with MS SQL Server support and I will be giving greater feedbaks.

For information, follow the structures of the `category` table in the tested databases.

**MySQL**
![mysql_categories_table](https://user-images.githubusercontent.com/2080547/129648816-fd2c8a41-7c25-4d0d-ba2a-05c44b360b47.png)

**PostgreSQL**
![postgresql_categories_table](https://user-images.githubusercontent.com/2080547/129648839-d5fdb3d9-eb35-4680-a014-bad0613476b6.png)

**SQLite**
![sqlite_categories_table](https://user-images.githubusercontent.com/2080547/129648844-b7f0962e-e821-4420-98c9-d0a4ba6c0520.png)

**Result is!**
![powergrid](https://user-images.githubusercontent.com/2080547/129649287-0cb98c54-8875-4483-823b-87df079d2236.png)


