### PR TITLE
Fix testCase

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Orchestra\Testbench\TestCase;
+use PowerComponents\LivewirePowerGrid\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,12 +3,14 @@
 namespace PowerComponents\LivewirePowerGrid\Tests;
 
 use PowerComponents\LivewirePowerGrid\Providers\PowerGridServiceProvider;
+use Livewire\LivewireServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
     protected function getPackageProviders($app)
     {
         return [
+            LivewireServiceProvider::class,
             PowerGridServiceProvider::class
         ];
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,8 +4,9 @@ namespace PowerComponents\LivewirePowerGrid\Tests;
 
 use PowerComponents\LivewirePowerGrid\Providers\PowerGridServiceProvider;
 use Livewire\LivewireServiceProvider;
+use \Orchestra\Testbench\TestCase as BaseTestCase;
 
-class TestCase extends \Orchestra\Testbench\TestCase
+class TestCase extends BaseTestCase
 {
     protected function getPackageProviders($app)
     {


### PR DESCRIPTION
Hello Luan,

This PR should fix the `Target class [livewire] does not exist` error.



Greetings and thanks,


![dan](https://user-images.githubusercontent.com/79267265/134786246-59e89e8f-760f-4fc0-8938-9bf1b42280c2.png)

