### PR TITLE
remove function "setPage"

### DIFF
--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -378,10 +378,4 @@ class PowerGridComponent extends Component
         })->toArray();
     }
 
-    public function setPage($page)
-    {
-        $this->page = $page;
-
-        $this->checkboxAll = false;
-    }
 }


### PR DESCRIPTION
Because of this function "setPage" the pagination no longer works in the table, have removed this for me and lo and behold the pagination works again. :)

Because there is the function "setPage($page, $pageName = 'page')" in the Livewire package.