### PR TITLE
fix orderBy string numbers

### DIFF
--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -329,7 +329,7 @@ class PowerGridComponent extends Component
                     ->setFilters($this->filters)
                     ->filterContains()
                     ->filter();
-            })->orderBy($this->sortField, $this->sortDirection);
+            })->orderByRaw("LENGTH($this->sortField) $this->sortDirection");
 
         if ($this->perPage > 0) {
             $results = $results->paginate($this->perPage);

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -329,7 +329,7 @@ class PowerGridComponent extends Component
                     ->setFilters($this->filters)
                     ->filterContains()
                     ->filter();
-            })->orderByRaw("LENGTH($this->sortField) $this->sortDirection");
+            })->orderByRaw("$this->sortField+0 $this->sortDirection")->orderBy($this->sortField, $this->sortDirection);
 
         if ($this->perPage > 0) {
             $results = $results->paginate($this->perPage);


### PR DESCRIPTION
Currently the sorting of "orderBy" string numbers does this here  1,10,10a,11,12,...

With the adjustment, the sorting then fits: 1,2,3,4,5,6,6a,...