### PR TITLE
Add "uses" & fix typo

### DIFF
--- a/resources/stubs/PowerGridDemoTable.stub
+++ b/resources/stubs/PowerGridDemoTable.stub
@@ -113,7 +113,7 @@ class PowerGridDemoTable extends PowerGridComponent
     |--------------------------------------------------------------------------
     |  Include Columns
     |--------------------------------------------------------------------------
-    | Include the columns aaded columns, making them visible on the Table.
+    | Include the columns added columns, making them visible on the Table.
     | Each column can be configured with properties, filters, actions...
     |
     */

--- a/resources/stubs/table.fillable.stub
+++ b/resources/stubs/table.fillable.stub
@@ -4,7 +4,9 @@ namespace App\Http\Livewire{{ subFolder }};
 
 use {{ modelName }};
 use Illuminate\Support\Carbon;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\Eloquent\Builder;
+use PowerComponents\LivewirePowerGrid\Button;
 use PowerComponents\LivewirePowerGrid\Column;
 use PowerComponents\LivewirePowerGrid\PowerGrid;
 use PowerComponents\LivewirePowerGrid\PowerGridEloquent;
@@ -71,7 +73,7 @@ class {{ componentName }} extends PowerGridComponent
     |--------------------------------------------------------------------------
     |  Include Columns
     |--------------------------------------------------------------------------
-    | Include the columns aaded columns, making them visible on the Table.
+    | Include the columns added columns, making them visible on the Table.
     | Each column can be configured with properties, filters, actions...
     |
     */

--- a/resources/stubs/table.model.stub
+++ b/resources/stubs/table.model.stub
@@ -4,7 +4,9 @@ namespace App\Http\Livewire{{ subFolder }};
 
 use {{ modelName }};
 use Illuminate\Support\Carbon;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\Eloquent\Builder;
+use PowerComponents\LivewirePowerGrid\Button;
 use PowerComponents\LivewirePowerGrid\Column;
 use PowerComponents\LivewirePowerGrid\PowerGrid;
 use PowerComponents\LivewirePowerGrid\PowerGridEloquent;
@@ -77,7 +79,7 @@ class {{ componentName }} extends PowerGridComponent
     |--------------------------------------------------------------------------
     |  Include Columns
     |--------------------------------------------------------------------------
-    | Include the columns aaded columns, making them visible on the Table.
+    | Include the columns added columns, making them visible on the Table.
     | Each column can be configured with properties, filters, actions...
     |
     */

--- a/resources/stubs/table.stub
+++ b/resources/stubs/table.stub
@@ -3,6 +3,8 @@
 namespace App\Http\Livewire{{ subFolder }};
 
 use Illuminate\Support\Collection;
+use Illuminate\Database\QueryException;
+use PowerComponents\LivewirePowerGrid\Button;
 use PowerComponents\LivewirePowerGrid\Column;
 use PowerComponents\LivewirePowerGrid\PowerGrid;
 use PowerComponents\LivewirePowerGrid\PowerGridCollection;
@@ -60,7 +62,7 @@ class {{ componentName }} extends PowerGridComponent
     |--------------------------------------------------------------------------
     |  Include Columns
     |--------------------------------------------------------------------------
-    | Include the columns aaded columns, making them visible on the Table.
+    | Include the columns added columns, making them visible on the Table.
     | Each column can be configured with properties, filters, actions...
     |
     */


### PR DESCRIPTION
Hi Luan,

Fixing a typo on a comment, and I suggest adding the "use" `\QueryException` and `Button`. 
Some users might forget or not know how to import classes and thus have a bumpy experience.

Greetings and thanks, 

Dan