### PR TITLE
Friendly alert on Tailwind Forms

### DIFF
--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -138,6 +138,9 @@ class CreateCommand extends Command
 
         if ($createTable) {
             File::put($path, $stub);
+            
+            $this->checkTailwindForms();
+
             $this->info("\n⚡ <comment>" . $filename . '</comment> was successfully created at [<comment>App/' . $savedAt . '</comment>].');
             $this->info("\n⚡ Your PowerGrid can be now included with the tag: <comment>" . $component_name . "</comment>\n");
         }
@@ -221,5 +224,18 @@ class CreateCommand extends Command
         }
 
         return File::get(__DIR__ . '/../../resources/stubs/table.stub');
+    }
+
+    protected function checkTailwindForms(): void
+    {
+        $tailwindConfigFile = base_path() . '/' . 'tailwind.config.js';
+  
+        if (File::exists($tailwindConfigFile)) {
+            $fileContent    = File::get($tailwindConfigFile);
+
+            if (Str::contains($fileContent, "require('@tailwindcss/forms')") === true) {
+                $this->info("\n💡 It seems you are using the plugin <comment>Tailwindcss/form</comment>.\n   Please check: <comment>https://livewire-powergrid.docsforge.com/main/configure/#43-tailwind-forms</comment> for more information.");
+            }
+        }
     }
 }

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -26,6 +26,29 @@ it('creates a PowerGrid Table', function () {
     File::delete($this->tableFilePath);
 });
 
+it('notifies about tailwind forms', function () {
+    File::delete($this->tableFilePath);
+
+    $tailwindConfigFile = base_path() . '/' . 'tailwind.config.js';
+
+    $content = "module.exports = { theme: { // ... }, plugins: [ require('@tailwindcss/forms'), // ... ], }";
+    
+    File::delete($tailwindConfigFile);
+    File::put($tailwindConfigFile, $content);
+
+    $this->artisan('powergrid:create')
+        ->expectsQuestion($this->model_name_question, 'DemoTable')
+        ->expectsQuestion($this->datasource_question, 'M')
+        ->expectsQuestion($this->model_path_question, 'PowerComponents\LivewirePowerGrid\Tests\Models\Dish')
+        ->expectsQuestion($this->use_fillable_question, 'yes')
+        ->expectsOutput("\n💡 It seems you are using the plugin Tailwindcss/form.\n   Please check: https://livewire-powergrid.docsforge.com/main/configure/#43-tailwind-forms for more information.")
+        ->expectsOutput("\n⚡ DemoTable.php was successfully created at [App/Http/Livewire/].")
+        ->expectsOutput("\n⚡ Your PowerGrid can be now included with the tag: <livewire:demo-table/>\n");
+
+    File::delete($this->tableFilePath);
+    File::delete($tailwindConfigFile);
+});
+
 it('publishes the Demo Table', function () {
     $tableFile =  getLaravelDir() . 'app/Http/Livewire/PowerGridDemoTable.php';
     $viewsFile =  getLaravelDir() . 'resources/views/powergrid-demo.blade.php';


### PR DESCRIPTION
Hi Luan,

We might benefit from a small friendly alert about Tailwind forms. 

The alert suggests a visit to the doc:

<img width="803" alt="alert" src="https://user-images.githubusercontent.com/79267265/139952808-c8d7feaf-44d2-4281-8624-e4d013c4293f.png">

Greetings and thanks

Dan