### PR TITLE
Prefixes table name on search columns

### DIFF
--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -246,11 +246,13 @@ class Model implements FilterInterface
         if ($this->search != '') {
             $this->query = $this->query->where(function (Builder $query) {
                 /** @var Column $column */
+                $table=$query->getModel()->getTable();
+
                 foreach ($this->columns as $column) {
-                    $hasColumn = Schema::hasColumn($query->getModel()->getTable(), $column->field);
+                    $hasColumn = Schema::hasColumn($table, $column->field);
 
                     if ($column->searchable && $hasColumn) {
-                        $query->orWhere($column->field, 'like', '%' . $this->search . '%');
+                        $query->orWhere($table . '.' . $column->field, 'like', '%' . $this->search . '%');
                     }
                 }
 


### PR DESCRIPTION
Addresses #106 

When using joined tables as part of the datasource there is possibility of duplicate column names, eg `id` and `name`

When creating the search query, the column names are added to the query but not specifying the table name. This causes mysql to complain of ambiguous column names since the search is performed on the entire join, not the selected columns.

The PR uses the existing technique to determine the table name and then prefixes each column name with the table name