### PR TITLE
added yoruba translation file

### DIFF
--- a/resources/lang/yr/datatable.php
+++ b/resources/lang/yr/datatable.php
@@ -1,0 +1,49 @@
+<?php
+
+return [
+    'buttons' => [
+        'filter' => 'àlẹmọ',
+    ],
+    'labels' => [
+        'action'           => 'Awọn Igbese',
+        'results_per_page' => 'Esi Ni oju-iwe',
+        'clear_filter'     => 'Ko àlẹmọ',
+        'no_data'          => 'Ko si awọn igbasilẹ ti a rii',
+        'all'              => 'Gbogbo e',
+        'selected'         => 'Oun To Mu',
+    ],
+    'placeholders' => [
+        'search' => 'Wa...',
+        'select' => 'Mu akoko Kan',
+    ],
+    'pagination' => [
+        'showing' => 'Afihan',
+        'to'      => 'Si',
+        'of'      => 'ti',
+        'results' => 'Esi',
+        'all'     => 'Gbogbo e',
+    ],
+    'multi_select' => [
+        'select' => 'Mu',
+        'all'    => 'Gbogbo e',
+    ],
+    'select' => [
+        'select' => 'Mu',
+        'all'    => 'Gbogbo e',
+    ],
+    'boolean_filter' => [
+        'all' => 'Gbogbo e',
+    ],
+    'input_text_options' => [
+        'is'           => 'Ni',
+        'is_not'       => 'kiise',
+        'contains'     => 'Ninu',
+        'contains_not' => 'Ko Si Ninu',
+        'starts_with'  => 'Bere Pelu',
+        'ends_with'    => 'Pari Pelu',
+    ],
+    'export' => [
+        'exporting' => 'jọwọ duro!',
+        'completed' => 'O ti setan! Awọn faili rẹ ti šetan fun igbasilẹ',
+    ],
+];


### PR DESCRIPTION
Yoruba (/ˈjɒrʊbə/; Yor. Èdè Yorùbá; Ajami: عِدعِ يوْرُبا‎) is a language spoken in West Africa, most prominently Southwestern Nigeria. It is spoken by the ethnic Yoruba people. The number of Yoruba speakers is stated as roughly 50 million, plus about 2 million second-language speakers. As a pluricentric language, it is primarily spoken in a dialectal area spanning Nigeria with smaller migrated communities in Cote d'Ivoire, Sierra Leone, and The Gambia.

Yoruba vocabulary is also used in the Afro-Brazilian religion known as Candomblé, in the Caribbean religion of Santería in the form of the liturgical Lucumí language and various Afro-American religions of North America. Practitioners of these religions in the Americas no longer speak or understand the Yorùbá language, rather they use remnants of Yorùbá language for singing songs that for them are shrouded in mystery. Usage of a lexicon of Yorùbá words and short phrases during ritual is also common, but they have gone through changes due to the fact that Yorùbá is no longer a vernacular for them and fluency is not required.

As the principal Yoruboid language, Yoruba is most closely related to the languages Itsekiri (spoken in the Niger Delta) and Igala (spoken in central Nigeria).
