### PR TITLE
Use post as the default action method

### DIFF
--- a/resources/views/components/actions.blade.php
+++ b/resources/views/components/actions.blade.php
@@ -31,7 +31,7 @@
                     @if(strtolower($action->method) !== ('get'))
                         <form target="{{ $action->target }}"
                               action="{{ route($action->route, $parameters) }}"
-                              method="{{ $action->target }}">
+                              method="post">
                             @method($action->method)
                             @csrf
                             <button type="submit"


### PR DESCRIPTION
At the moment, while the method is not ```get``` then the form is set with what's in the ```target```. I think this is a bug. For ```delete```, ```put```, or ```patch``` request should be wrapped inside a ```post``` request.