### PR TITLE
[tests] Fix wrong column type in migrations

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -38,7 +38,7 @@ class TestCase extends BaseTestCase
             $table->boolean('in_stock')->default(false);
             $table->string('stored_at');
             $table->boolean('active')->default(true);
-            $table->date('produced_at');
+            $table->datetime('produced_at');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Column is specified as date, but datetime was loaded  into it.