### PR TITLE
feature: [wip] implementation of the rescue functionality of the database server version used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,11 +45,13 @@
         "test:sqlite": "./vendor/bin/pest --configuration phpunit.sqlite.xml",
         "test:mysql":  "./vendor/bin/pest --configuration phpunit.mysql.xml",
         "test:pgsql":  "./vendor/bin/pest --configuration phpunit.pgsql.xml",
+        "test:sqlsrv":  "./vendor/bin/pest --configuration phpunit.sqlsrv.xml",
         "test:types": "./vendor/bin/phpstan analyse --ansi --memory-limit=-1",
         "test:dbs": [
             "@test:sqlite",
             "@test:mysql",
-            "@test:pgsql"
+            "@test:pgsql",
+            "@test:sqlsrv"
         ],
         "check": [
             "@cs-fixer",

--- a/phpunit.mysql.xml
+++ b/phpunit.mysql.xml
@@ -14,7 +14,7 @@
     <server name="APP_ENV" value="testing"/>
     <server name="DB_DRIVER" value="mysql"/>
     <server name="DB_HOST" value="127.0.0.1"/>
-    <server name="DB_PORT" value="3308"/>
+    <server name="DB_PORT" value="3307"/>
     <server name="DB_USERNAME" value="root"/>
     <server name="DB_PASSWORD" value="password"/>
     <server name="DB_DATABASE" value="powergridtest"/>

--- a/phpunit.pgsql.xml
+++ b/phpunit.pgsql.xml
@@ -20,7 +20,7 @@
         <server name="DB_HOST" value="127.0.0.1"/>
         <server name="DB_PORT" value="5433"/>
         <server name="DB_USERNAME" value="postgres"/>
-        <server name="DB_PASSWORD" value="postgres"/>
+        <server name="DB_PASSWORD" value="password"/>
         <server name="DB_DATABASE" value="powergridtest"/>
     </php>
 </phpunit>

--- a/phpunit.sqlsrv.xml
+++ b/phpunit.sqlsrv.xml
@@ -14,9 +14,9 @@
     <server name="APP_ENV" value="testing"/>
     <server name="DB_DRIVER" value="sqlsrv"/>
     <server name="DB_HOST" value="127.0.0.1"/>
-    <server name="DB_PORT" value="3308"/>
-    <server name="DB_USERNAME" value="root"/>
-    <server name="DB_PASSWORD" value="password"/>
-    <server name="DB_DATABASE" value="powergridtest"/>
+    <server name="DB_PORT" value="1434"/>
+    <server name="DB_USERNAME" value="sa"/>
+    <server name="DB_PASSWORD" value="yourStrong(!)Password"/>
+    <server name="DB_DATABASE" value="tempdb"/>
   </php>
 </phpunit>

--- a/src/Helpers/SqlSupport.php
+++ b/src/Helpers/SqlSupport.php
@@ -2,8 +2,8 @@
 
 namespace PowerComponents\LivewirePowerGrid\Helpers;
 
-use Illuminate\Support\Facades\{DB, Schema};
 use Exception;
+use Illuminate\Support\Facades\{DB, Schema};
 
 class SqlSupport
 {

--- a/src/Helpers/SqlSupport.php
+++ b/src/Helpers/SqlSupport.php
@@ -2,7 +2,8 @@
 
 namespace PowerComponents\LivewirePowerGrid\Helpers;
 
-use Illuminate\Support\Facades\{DB, Log, Schema};
+use Illuminate\Support\Facades\{DB, Schema};
+use Exception;
 
 class SqlSupport
 {
@@ -63,7 +64,7 @@ class SqlSupport
     }
 
     /**
-     * @param string $sortFieldType
+     * @param string|null $sortFieldType
      * @return bool
      */
     public static function isValidSortFieldType(?string $sortFieldType): bool
@@ -78,7 +79,7 @@ class SqlSupport
     /**
      * @param string $sortField
      * @return string
-     * @throws \Exception
+     * @throws Exception
      */
     public static function getSortFieldType(string $sortField): ?string
     {
@@ -88,12 +89,21 @@ class SqlSupport
         }
 
         if (!Schema::hasColumn($data[0], $data[1])) {
-            throw new \Exception("There is no column with name '$data[1]' on table '$data[0]'. Please see: https://livewire-powergrid.docsforge.com/main/include-columns/#fieldstring-field-string-datafield");
+            throw new Exception("There is no column with name '$data[1]' on table '$data[0]'. Please see: https://livewire-powergrid.docsforge.com/main/include-columns/#fieldstring-field-string-datafield");
         }
 
         return Schema::getConnection()
             ->getDoctrineColumn($data[0], $data[1])
             ->getType()
             ->getName();
+    }
+
+    /**
+     * @return string
+     */
+    public static function getDriverVersion(): string
+    {
+        return DB::getPdo()
+            ->getAttribute(constant('PDO::ATTR_SERVER_VERSION'));
     }
 }

--- a/src/Helpers/SqlSupport.php
+++ b/src/Helpers/SqlSupport.php
@@ -101,7 +101,7 @@ class SqlSupport
     /**
      * @return string
      */
-    public static function getDriverVersion(): string
+    public static function getServerVersion(): string
     {
         return DB::getPdo()
             ->getAttribute(constant('PDO::ATTR_SERVER_VERSION'));


### PR DESCRIPTION
Due to some differences between the versions of some databases, I am proposing the use of a feature, where you tell us the version of the database server so we can customize and optimize the `SQL` responsible for sorting alphanumeric records

**getServerVersion()**
![Captura de tela de 2021-11-26 01-53-52](https://user-images.githubusercontent.com/2080547/143528855-bed87666-1d7e-4e5b-a6b0-9ea4e76e53a5.png)

With the help of this method, when we use the `getSortSqlByDriver` method to retrieve a specific `SQL` from one of the databases supported by laravel, in order to sort alphanumeric values more efficiently, we can tell the method not only the `driver` being used, but also the `version` of the database server being used. This way we can be more categorical in customizing the sorts.

**ATTENTION**
As I had suggested in PR(#149), I am in the current proposal, adjusting the database access ports, for each scenario currently created. This change concerns the following test scenario files:
- phpunit.mysql.xml
- phpunit.pgsql.xml
- phpunit.sqlsrv.xml

> So, to run the tests on one or all of the database scenarios with the help of the `Docker` containers, no changes to the files mentioned above are required.

Taking advantage of the port settings, I added another scenario for testing, this time for supporting the `MS SQL Server` database. These changes can be seen in the `composer.json` file.