### PR TITLE
SqlSupport refactoring

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,7 +20,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: powergridtest
         ports:
-         - 3308:3306
+         - 3307:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
       postgres:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,7 +27,7 @@ jobs:
         image: postgres:9.6
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: password
           POSTGRES_DB: powergridtest
         ports:
         - 5433:5432

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -24,7 +24,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
       postgres:
-        image: postgres:10.8
+        image: postgres:9.6
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/tests/Feature/Helpers/SqlSupportTest.php
+++ b/tests/Feature/Helpers/SqlSupportTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use PowerComponents\LivewirePowerGrid\Helpers\SqlSupport;
+
+it('finds database name', function () {
+    expect(SqlSupport::getDatabaseName())->not->toBeNull();
+});
+
+it('finds database version', function () {
+    expect(SqlSupport::getDatabaseVersion())->not->toBeNull();
+});
+
+it('returns sortField', function (array $data) {
+    expect(SqlSupport::getSortSqlByDriver('field', $data['db'], $data['version']))
+        ->toBe($data['expected']);
+})->with([
+    [['db' => 'sqlite', 'version' => '3.36.0',  'expected' => 'CAST(field AS INTEGER)']],
+    [['db' => 'mysql', 'version' => '5.5.59-MariaDB',  'expected' => 'field+0']],
+    [['db' => 'mysql', 'version' => '5.4.1',  'expected' => 'field+0']],
+    [['db' => 'mysql', 'version' => '5.7.36', 'expected' => 'field+0']],
+    [['db' => 'mysql', 'version' => '8.0.3',  'expected' => 'field+0']],
+    [['db' => 'mysql', 'version' => '8.0.4',  'expected' => "CAST(NULLIF(REGEXP_REPLACE(field, '[[:alpha:]]+', ''), '') AS SIGNED INTEGER)"]],
+    [['db' => 'mysql', 'version' => '8.0.5',  'expected' => "CAST(NULLIF(REGEXP_REPLACE(field, '[[:alpha:]]+', ''), '') AS SIGNED INTEGER)"]],
+    [['db' => 'pgsql', 'version' => '9.6.24',  'expected' => "CAST(NULLIF(REGEXP_REPLACE(field, '\D', '', 'g'), '') AS INTEGER)"]],
+    [['db' => 'pgsql', 'version' => '13.5',  'expected' => "CAST(NULLIF(REGEXP_REPLACE(field, '\D', '', 'g'), '') AS INTEGER)"]],
+    [['db' => 'pgsql', 'version' => '15.5',  'expected' => "CAST(NULLIF(REGEXP_REPLACE(field, '\D', '', 'g'), '') AS INTEGER)"]],
+    [['db' => 'sqlsrv', 'version' => '9.2',  'expected' => "CAST(SUBSTRING(field, PATINDEX('%[a-z]%', field), LEN(field)-PATINDEX('%[a-z]%', field)) AS INT)"]],
+    [['db' => 'sqlsrv', 'version' => '14.00.3421',  'expected' => "CAST(SUBSTRING(field, PATINDEX('%[a-z]%', field), LEN(field)-PATINDEX('%[a-z]%', field)) AS INT)"]],
+    [['db' => 'sqlsrv', 'version' => '20.80',  'expected' => "CAST(SUBSTRING(field, PATINDEX('%[a-z]%', field), LEN(field)-PATINDEX('%[a-z]%', field)) AS INT)"]],
+    [['db' => 'unsupported-db', 'version' => '29.00.00',  'expected' => 'field+0']],
+
+]);

--- a/tests/Feature/Helpers/SqlSupportTest.php
+++ b/tests/Feature/Helpers/SqlSupportTest.php
@@ -10,6 +10,29 @@ it('finds database version', function () {
     expect(SqlSupport::getDatabaseVersion())->not->toBeNull();
 });
 
+it('returns the proper "LIKE" syntax', function () {
+    $driver = SqlSupport::getDatabaseDriverName();
+        
+    expect(SqlSupport::like())
+        ->when(
+            $driver === 'mysql',
+            fn ($syntax) => $syntax->toBe('LIKE')
+        )
+        ->when(
+            $driver === 'sqlite',
+            fn ($syntax) => $syntax->toBe('LIKE')
+        )
+        ->when(
+            $driver === 'sqlsrv',
+            fn ($syntax) => $syntax->toBe('LIKE')
+        )
+        ->when(
+            $driver === 'pgsql',
+            fn ($syntax) => $syntax->toBe('ILIKE')
+        )
+        ->not->toBeNull();
+});
+
 it('returns sortField', function (array $data) {
     expect(SqlSupport::getSortSqlByDriver('field', $data['db'], $data['version']))
         ->toBe($data['expected']);

--- a/tests/Feature/Helpers/SqlSupportTest.php
+++ b/tests/Feature/Helpers/SqlSupportTest.php
@@ -2,8 +2,8 @@
 
 use PowerComponents\LivewirePowerGrid\Helpers\SqlSupport;
 
-it('finds database name', function () {
-    expect(SqlSupport::getDatabaseName())->not->toBeNull();
+it('finds database driver name', function () {
+    expect(SqlSupport::getDatabaseDriverName())->not->toBeNull();
 });
 
 it('finds database version', function () {


### PR DESCRIPTION
Hi Luan,

According to [Laravel 8x - Database](https://laravel.com/docs/8.x/database) PowerGrid should be supporting:

- MySQL 5.7+ (Version Policy)
- PostgreSQL 9.6+ (Version Policy)
- SQLite 3.8.8+
- SQL Server 2017+ (Version Policy)

I wrote a test to verify the `sortField` syntax for  database + version. I do not remember if we had an alternative solution for the `field+0`. For the moment, I left it as default for situations:


<img width="784" alt="Screenshot 2021-11-26 at 16 09 10" src="https://user-images.githubusercontent.com/79267265/143600672-aa9d7c7d-bfba-4ab1-9c99-0648c1398300.png">

All tests passing, could not test Sql Server locally.

<img width="209" alt="Screenshot 2021-11-26 at 16 09 35" src="https://user-images.githubusercontent.com/79267265/143600687-b9124e04-1d93-44d9-8908-07903d9b8ba7.png">

Static analysis also OK on the desired level.

<img width="923" alt="Screenshot 2021-11-26 at 16 09 51" src="https://user-images.githubusercontent.com/79267265/143600690-8178cf3c-e3f2-4832-9ab7-2114c04b044f.png">

@vs0uz4 I have not touched the docker-compose; however, I think it would be best to also downgrade it to make sure tests run in the minimum supported database.

Hopefully, it solves the compatibility problem.

Thanks

