### PR TITLE
withSum() & withAvg() not working for calculated data Bug Fixed.

### DIFF
--- a/resources/views/components/actions-header.blade.php
+++ b/resources/views/components/actions-header.blade.php
@@ -2,6 +2,7 @@
 @props([
     'actions' => null,
     'theme' => null,
+    'row' => null,
 ])
 <div class="w-full md:w-auto">
     <div class="sm:flex sm:flex-row">

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -8,7 +8,7 @@ use PowerComponents\LivewirePowerGrid\{Button};
 
 class Helpers
 {
-    public function makeParameters(Button $action, Model $entry): array
+    public function makeParameters(Button $action, ?Model $entry = null): array
     {
         $parameters = [];
         foreach ($action->param as $param => $value) {

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -282,7 +282,7 @@ class PowerGridComponent extends Component
         $results = $results->orderBy($sortField, $this->sortDirection);
 
         if ($this->headerTotalColumn || $this->footerTotalColumn) {
-            $this->withoutPaginatedData = $results->get();
+            $this->withoutPaginatedData = $this->transform($results->getCollection());
         }
 
         if ($this->perPage > 0) {

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -49,7 +49,7 @@ class PowerGridComponent extends Component
     /** @var \Illuminate\Database\Eloquent\Collection|array|Builder $datasource */
     public $datasource;
 
-    /** @var \Illuminate\Database\Eloquent\Collection|array|Builder $withoutPaginatedData */
+    /** @var \Illuminate\Support\Collection $withoutPaginatedData */
     public $withoutPaginatedData;
 
     public bool $toggleColumns = false;
@@ -282,7 +282,7 @@ class PowerGridComponent extends Component
         $results = $results->orderBy($sortField, $this->sortDirection);
 
         if ($this->headerTotalColumn || $this->footerTotalColumn) {
-            $this->withoutPaginatedData = $this->transform($results->getCollection());
+            $this->withoutPaginatedData = $this->transform($results->get());
         }
 
         if ($this->perPage > 0) {


### PR DESCRIPTION
When trying to get the sum and average of calculated data fields 'Column not found:' error fixed.

<img width="1108" alt="Screen Shot 2022-01-13 at 2 45 52 PM" src="https://user-images.githubusercontent.com/42486161/149299154-2f0da42b-2472-46ca-93f4-c51b1cbdaa23.png">

<img width="1545" alt="Screen Shot 2022-01-13 at 2 48 10 PM" src="https://user-images.githubusercontent.com/42486161/149299226-c144fdb2-4745-4224-8fad-fb08a046f7dc.png">


Cause of error: $withoutPaginatedData was assigned without running transform(). Thus, calculated data fields was never passed to $withoutPadginatedData. Hence, the error.

`$this->withoutPaginatedData = $results->get();`
Changed to:
`$this->withoutPaginatedData = $this->transform($results->get());`

Fixed the bug.

Thank you
- Shisham Chudal