### PR TITLE
fix: withCount should only count "valid" records

### DIFF
--- a/resources/views/components/table-footer.blade.php
+++ b/resources/views/components/table-footer.blade.php
@@ -27,7 +27,10 @@
             <td class="{{ $theme->table->tdBodyClassTotalColumns . ' '.$column->bodyClass ?? '' }}"
                 style=" {{ $theme->table->tdBodyStyleTotalColumns .' '.$column->bodyStyle ?? ''  }}">
                 @if ($column->count['footer'])
-                    <span>{{ $column->count['label'] }}: {{ $withoutPaginatedData->collect()->count($field) }}</span>
+                    <span>{{ $column->count['label'] }}: {{ $withoutPaginatedData->collect()
+                    ->reject(function($data) use($field) { return empty($data->$field); })
+                    ->count($field) }}
+                    </span>
                     <br>
                 @endif
                 @if ($column->sum['footer'] && is_numeric($withoutPaginatedData[0][$field]))

--- a/resources/views/components/table-header.blade.php
+++ b/resources/views/components/table-header.blade.php
@@ -27,7 +27,10 @@
             <td class="{{ $theme->table->tdBodyClassTotalColumns . ' '.$column->bodyClass ?? '' }}"
                 style=" {{$theme->table->tdBodyStyleTotalColumns . ' '.$column->bodyStyle ?? ''  }}">
                 @if ($column->count['header'])
-                    <span>{{ $column->count['label'] }}: {{ $withoutPaginatedData->collect()->count($field) }}</span>
+                    <span>{{ $column->count['label'] }}: {{ $withoutPaginatedData->collect()
+                    ->reject(function($data) use($field) { return empty($data->$field); })
+                    ->count($field) }}
+                    </span>
                     <br>
                 @endif
                 @if ($column->sum['header'] && is_numeric($withoutPaginatedData[0][$field]))


### PR DESCRIPTION
I believe the `withCount` could  be potentially misleading the user by displaying a record count instead of a count of "valid" values.

**User story 1**: As a manager, I want to know in a quick glance how many `active` users are in Ohio.

<img width="1435" alt="wrong" src="https://user-images.githubusercontent.com/79267265/149430712-f9742de0-0e26-44ea-ade1-3a33d69fb486.png">

The count is 13 `active` users and 13 records found. 

We can already notice  some users with `active = no` (`false`), so it doesn't really make 13 people.

I believe the correct would be:

<img width="1434" alt="right" src="https://user-images.githubusercontent.com/79267265/149430718-c1be8245-55fe-4655-a4b1-d6d44751ba99.png">

In this example, we have a total of 13 records in Ohio and 8 of them have `active = yes`. We see 6 displayed and 2 are in the next page.

In my opinion, the `withCount` should not count empty (blank, null or false) records.

For instance, I want to see how many users have the filled up the "State":

<img width="1440" alt="state" src="https://user-images.githubusercontent.com/79267265/149430732-51ba9916-c1d1-43c9-a6f0-eedf6e5170f6.png">

We have 8 records with the State filled up and 2 with `Blank` and `Null`.

If a more complex scenario is presented, the user will probably use the Record Count (1 of 10, 10 records found).

An idea for the future, we could also have a modifier on `withCount` to show the opposite, in other words, the invalid/empty records.

What do you think @luanfreitasdev and @shishamchudal?

Thanks
