### PR TITLE
feature: rm-views composer command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,13 @@
         "doctrine/dbal": "^3.1"
     },
     "scripts": {
+        "rm-views": "rm -rf ./vendor/orchestra/testbench-core/laravel/resources/views/vendor/livewire-powergrid/",
         "cs-fixer": "./vendor/bin/php-cs-fixer fix --verbose --dry-run --using-cache=no --stop-on-violation",
         "fix": "./vendor/bin/php-cs-fixer fix",
-        "test":  "@test:sqlite",
+        "test": [
+            "@rm-views",
+            "@test:sqlite"
+        ],
         "test:sqlite": "./vendor/bin/pest --configuration phpunit.sqlite.xml",
         "test:mysql":  "./vendor/bin/pest --configuration phpunit.mysql.xml",
         "test:pgsql":  "./vendor/bin/pest --configuration phpunit.pgsql.xml",


### PR DESCRIPTION
We have often encountered problems when testing because of cached views in `/vendor/orchestra/testbench-core/laravel/resources/views/vendor/livewire-powergrid/`. I think this can even confuse new contributors, making them waste time.

I propose the script command `composer rm-views` to remove this directory, and I suggest running it always with `composer test`.

<img width="809" alt="CleanShot 2022-01-14 at 02 06 42@2x" src="https://user-images.githubusercontent.com/79267265/149433640-9aceef1f-876b-4c05-926d-489d47026fb4.png">

