### PR TITLE
Model autocomplete on powergrid:create command

### DIFF
--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -66,7 +66,7 @@ class CreateCommand extends Command
         $modelLastName = '';
 
         if (strtolower($creationModel) === 'm') {
-            $modelName = $this->ask('Enter your Model path (E.g., <comment>App\Models\User</comment> or <comment>User</comment>)');
+            $modelName = $this->anticipate('Enter your Model name or file path (E.g., <comment>User</comment> or <comment>App\Models\User</comment>)', $this->listModels());
 
             if (empty($modelName)) {
                 $this->error('Could not create, Model path is missing');
@@ -282,6 +282,20 @@ class CreateCommand extends Command
         $stub = str_replace('{{ datasource }}', $datasource, $stub);
 
         return str_replace('{{ columns }}', $columns, $stub);
+    }
+    
+    /**
+     * List files in Models folder
+     *
+     * @return array
+     */
+    private function listModels(): array
+    {
+        $modelsFolder = app_path('Models');
+
+        return collect(File::allFiles($modelsFolder))
+            ->map(fn ($file) => $file->getFilenameWithoutExtension())
+            ->toArray();
     }
 
     private function checkTailwindForms(): void

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -7,7 +7,7 @@ beforeEach(function () {
     $this->tableCollectionFilePath  = getLaravelDir() . 'app/Http/Livewire/CollectionTable.php';
     $this->model_name_question      = 'What is the name of your new ⚡ PowerGrid Table (E.g., <comment>UserTable</comment>)?';
     $this->datasource_question      = 'Create Datasource with <comment>[M]</comment>odel or <comment>[C]</comment>ollection? (Default: Model)';
-    $this->model_path_question      = 'Enter your Model path (E.g., <comment>App\Models\User</comment> or <comment>User</comment>)';
+    $this->model_path_question      = 'Enter your Model name or file path (E.g., <comment>User</comment> or <comment>App\Models\User</comment>)';
     $this->use_fillable_question    = 'Create columns based on Model\'s <comment>fillable</comment> property?';
 });
 


### PR DESCRIPTION
Hi Luan,

This feature introduces autocomplete on Model name on `powergrid:create` command.

Users can autocomplete while typing or pressing the ↑ key.

Although it is a small change, I hope it can clarify the process for novice users.

![CleanShot 2022-01-21 at 15 50 05](https://user-images.githubusercontent.com/79267265/150549590-5c92f87d-e120-41e0-8b47-3c7b9b8f2d02.gif)

The models are listed through `app_path('Models')` and their filenames.

Thanks
