### PR TITLE
Remove rm-views and deletes views cache before each test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,13 +39,9 @@
         "doctrine/dbal": "^3.1"
     },
     "scripts": {
-        "rm-views": "rm -rf ./vendor/orchestra/testbench-core/laravel/resources/views/vendor/livewire-powergrid/",
         "cs-fixer": "./vendor/bin/php-cs-fixer fix --verbose --dry-run --using-cache=no --stop-on-violation",
         "fix": "./vendor/bin/php-cs-fixer fix",
-        "test": [
-            "@rm-views",
-            "@test:sqlite"
-        ],
+        "test": "@test:sqlite",
         "test:sqlite": "./vendor/bin/pest --configuration phpunit.sqlite.xml",
         "test:mysql":  "./vendor/bin/pest --configuration phpunit.mysql.xml",
         "test:pgsql":  "./vendor/bin/pest --configuration phpunit.pgsql.xml",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,7 @@ namespace PowerComponents\LivewirePowerGrid\Tests;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Application;
-use Illuminate\Support\Facades\{DB, Schema};
+use Illuminate\Support\Facades\{DB, File, Schema};
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use function Pest\Faker\faker;
@@ -13,14 +13,37 @@ use PowerComponents\LivewirePowerGrid\Providers\PowerGridServiceProvider;
 
 class TestCase extends BaseTestCase
 {
+    protected static $isRunningTests = false;
+
     protected function setUp(): void
     {
         parent::setUp();
 
+        $this->clearViewsCache();
         $this->migrations();
         $this->seeders();
     }
 
+    /**
+     * Delete PowerGrid cached views
+     *
+     * @return void
+     */
+    protected function clearViewsCache(): void
+    {
+        if (self::$isRunningTests === true) {
+            return;
+        }
+        
+        $viewsFolder = base_path() . '/resources/views/vendor/livewire-powergrid/';
+
+        $viewsFolderPath = str_replace('/', DIRECTORY_SEPARATOR, $viewsFolder);
+            
+        File::deleteDirectory($viewsFolderPath);
+            
+        self::$isRunningTests = true;
+    }
+    
     protected function migrations(): void
     {
         Schema::dropIfExists('dishes');


### PR DESCRIPTION
Hi Luan,

This PR removes `composer rm-views` due to incompatibly with MS Windows as detected in the PR https://github.com/Power-Components/livewire-powergrid/pull/249.

I propose to delete the views folder `vendor/orchestra/testbench-core/laravel/resources/views/vendor/livewire-powergrid` automatically before running tests. 

Thanks
 