### PR TITLE
emitTo action, tr lang fix, non-array parameters send to event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ composer.lock
 .phpunit.result.cache
 .php-cs-fixer.cache
 /node_modules
+
+pnpm-lock.yaml

--- a/resources/lang/tr/datatable.php
+++ b/resources/lang/tr/datatable.php
@@ -41,11 +41,16 @@ return [
         'contains_not' => 'İçermeyen',
         'starts_with'  => 'Başlayan',
         'ends_with'    => 'Biten',
-        'is_null'      => 'is_null',
-        'is_not_null'  => 'is_not_null',
-        'is_blank'     => 'is_blank',
-        'is_not_blank' => 'is_not_blank',
-        'is_empty'     => 'is_empty',
-        'is_not_empty' => 'is_not_empty',
+        'is_null'      => 'Yok olan',
+        'is_not_null'  => 'Yok olmayan',
+        'is_blank'     => 'Boş olan',
+        'is_not_blank' => 'Boş olmayan',
+        'is_empty'     => 'Boş olan',
+        'is_not_empty' => 'Boş olmayan',
+
+    ],
+    'export' => [
+        'exporting' => 'Lütfen bekleyin!',
+        'completed' => 'Dışa aktarım tamamlandı! Dosyalarınız indirmek için hazır',
     ],
 ];

--- a/resources/views/components/actions-header.blade.php
+++ b/resources/views/components/actions-header.blade.php
@@ -8,10 +8,20 @@
         @foreach($actions as $action)
             <div class="sm:mr-2 mb-2 w-auto">
                 @php
-                    $parameters = $helperClass->makeActionParameters($action->param);
+                    if($action->singleParam) {
+                        $parameters = $helperClass->makeActionParameter($action->param);
+                    } else {
+                        $parameters = $helperClass->makeActionParameters($action->param);
+                    }
                 @endphp
-                @if($action->event !== '')
+                @if($action->event !== '' && $action->to === '')
                     <a wire:click='$emit("{{ $action->event }}", @json($parameters))'
+                       target="{{ $action->target }}"
+                       class="{{ filled($action->class) ? $action->class : $theme->actions->headerBtnClass }}">
+                        {!! $action->caption !!}
+                    </a>
+                @elseif($action->event !== '' && $action->to !== '')
+                    <a wire:click='$emitTo("{{ $action->to }}", "{{ $action->event }}", @json($parameters))'
                        target="{{ $action->target }}"
                        class="{{ filled($action->class) ? $action->class : $theme->actions->headerBtnClass }}">
                         {!! $action->caption !!}

--- a/resources/views/components/actions.blade.php
+++ b/resources/views/components/actions.blade.php
@@ -11,7 +11,11 @@
                 style="{{ $theme->table->tdBodyStyle }}">
                 @php
                     $class            = filled($action->class) ? $action->class : $theme->actions->headerBtnClass;
-                    $actionParameters = $helperClass->makeActionParameters($action->param, $row);
+                    if($action->singleParam) {
+                        $actionParameters = $helperClass->makeActionParameter($action->param, $row);
+                    } else {
+                        $actionParameters = $helperClass->makeActionParameters($action->param, $row);
+                    }
                     $rules            = $helperClass->makeActionRules($action, $row);
 
                     $ruleRedirect     = data_get($rules, 'redirect');
@@ -33,7 +37,9 @@
                      style="display: {{ $ruleHide ? 'none': 'block' }}"
                 >
                     @if((filled($action->event) || filled($action->view)) && is_null($ruleRedirect))
-                        <button @if(isset($event['event']) && blank($action->view)) wire:click='$emit("{{ $event['event'] }}", @json($event['params']))'
+                        <button @if(isset($event['event']) && blank($action->view) && blank($action->to)) wire:click='$emit("{{ $event['event'] }}", @json($event['params']))'
+                            @endif
+                            @if(isset($event['event']) && blank($action->view) && filled($action->to)) wire:click='$emitTo("{{ $action->to }}", "{{ $event['event'] }}", @json($event['params']))'
                             @endif
                             @if($action->view) wire:click='$emit("openModal", "{{$action->view}}", @json($actionParameters))'
                             @endif

--- a/src/Button.php
+++ b/src/Button.php
@@ -22,6 +22,10 @@ final class Button
 
     public string $target = '_blank';
 
+    public string $to = '';
+
+    public bool $singleParam = false;
+
     /**
      *
      * @var array<int, string> $param
@@ -59,12 +63,14 @@ final class Button
     /**
      * @param string $route
      * @param array<int, string> $param
+     * @param boolean $singleParam parameter is single parameter
      * @return $this
      */
-    public function route(string $route, array $param): Button
+    public function route(string $route, array $param, bool $singleParam = false): Button
     {
         $this->route = $route;
         $this->param = $param;
+        $this->singleParam = $singleParam;
 
         return $this;
     }
@@ -95,12 +101,14 @@ final class Button
      * openModal
      * @param string $component modal component
      * @param array<int, string> $param modal parameters
+     * @param boolean $singleParam parameter is single parameter
      * @return $this
      */
-    public function openModal(string $component, array $param): Button
+    public function openModal(string $component, array $param, bool $singleParam = false): Button
     {
         $this->view   = $component;
         $this->param  = $param;
+        $this->singleParam = $singleParam;
         $this->method = 'get';
         $this->route  = '';
         $this->event  = '';
@@ -112,12 +120,33 @@ final class Button
      * emit
      * @param string $event event name
      * @param array<int, string> $param parameters
+     * @param boolean $singleParam parameter is single parameter
      * @return $this
      */
-    public function emit(string $event, array $param): Button
+    public function emit(string $event, array $param, bool $singleParam = false): Button
     {
         $this->event   = $event;
         $this->param   = $param;
+        $this->singleParam = $singleParam;
+        $this->route   = '';
+
+        return $this;
+    }
+
+    /**
+     * emitTo
+     * @param string $to component
+     * @param string $event event name
+     * @param array<int, string> $param parameters
+     * @param boolean $singleParam parameter is single parameter
+     * @return $this
+     */
+    public function emitTo(string $to, string $event, array $param, bool $singleParam = false): Button
+    {
+        $this->to      = $to;
+        $this->event   = $event;
+        $this->param   = $param;
+        $this->singleParam = $singleParam;
         $this->route   = '';
 
         return $this;

--- a/src/Button.php
+++ b/src/Button.php
@@ -68,8 +68,8 @@ final class Button
      */
     public function route(string $route, array $param, bool $singleParam = false): Button
     {
-        $this->route = $route;
-        $this->param = $param;
+        $this->route       = $route;
+        $this->param       = $param;
         $this->singleParam = $singleParam;
 
         return $this;
@@ -106,12 +106,12 @@ final class Button
      */
     public function openModal(string $component, array $param, bool $singleParam = false): Button
     {
-        $this->view   = $component;
-        $this->param  = $param;
+        $this->view        = $component;
+        $this->param       = $param;
         $this->singleParam = $singleParam;
-        $this->method = 'get';
-        $this->route  = '';
-        $this->event  = '';
+        $this->method      = 'get';
+        $this->route       = '';
+        $this->event       = '';
 
         return $this;
     }
@@ -125,10 +125,10 @@ final class Button
      */
     public function emit(string $event, array $param, bool $singleParam = false): Button
     {
-        $this->event   = $event;
-        $this->param   = $param;
+        $this->event       = $event;
+        $this->param       = $param;
         $this->singleParam = $singleParam;
-        $this->route   = '';
+        $this->route       = '';
 
         return $this;
     }
@@ -143,11 +143,11 @@ final class Button
      */
     public function emitTo(string $to, string $event, array $param, bool $singleParam = false): Button
     {
-        $this->to      = $to;
-        $this->event   = $event;
-        $this->param   = $param;
+        $this->to          = $to;
+        $this->event       = $event;
+        $this->param       = $param;
         $this->singleParam = $singleParam;
-        $this->route   = '';
+        $this->route       = '';
 
         return $this;
     }

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -40,6 +40,25 @@ class Helpers
     }
 
     /**
+     * @param array $params
+     * @param Model|\stdClass|null $row
+     * @return mixed
+     */
+    public function makeActionParameter(array $params = [], $row = null)
+    {
+        $parameters = [];
+
+        foreach ($params as $param => $value) {
+            if ($row && filled($row->{$value})) {
+                $parameters[$param] = $row->{$value};
+            } else {
+                $parameters[$param] = $value;
+            }
+        }
+        return $parameters[0];
+    }
+
+    /**
      * @param string|Button $action
      * @param Model|\stdClass $row
      * @return array

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -55,6 +55,7 @@ class Helpers
                 $parameters[$param] = $value;
             }
         }
+
         return $parameters[0];
     }
 

--- a/tests/DishesTable.php
+++ b/tests/DishesTable.php
@@ -206,6 +206,12 @@ class DishesTable extends PowerGridComponent
                 ->class('text-center')
                 ->emit('deletedEvent', ['dishId' => 'id'])
                 ->method('delete'),
+
+            Button::add('destroy_for_emit_to')
+                ->caption(__('Delete'))
+                ->class('text-center')
+                ->emitTo('dishes-table', 'deletedEvent', ['dishId' => 'id'])
+                ->method('delete'),
         ];
     }
 

--- a/tests/DishesTableWithJoin.php
+++ b/tests/DishesTableWithJoin.php
@@ -206,6 +206,12 @@ class DishesTableWithJoin extends PowerGridComponent
                 ->class('text-center')
                 ->emit('deletedEvent', ['dishId' => 'id'])
                 ->method('delete'),
+
+            Button::add('destroy_for_emit_to')
+                ->caption(__('Delete'))
+                ->class('text-center')
+                ->emitTo('dishes-table', 'deletedEvent', ['dishId' => 'id'])
+                ->method('delete'),
         ];
     }
 

--- a/tests/Feature/ActionsTest.php
+++ b/tests/Feature/ActionsTest.php
@@ -44,3 +44,23 @@ it('properly displays "deletedEvent" on delete button', function (string $compon
         ->call('deletedEvent', ['dishId' => 6])
         ->assertPayloadSet('eventId', ['dishId' => 6]);
 })->with('themes');
+
+it('properly displays "deletedEvent" on delete button from emitTo', function (string $component, object $params) {
+    livewire($component)
+        ->call($params->theme)
+        //page 1
+        ->set('perPage', 5)
+        ->assertSeeHtml('$emitTo("dishes-table", "deletedEvent", {"dishId":1})')
+        ->assertDontSeeHtml('$emitTo("dishes-table", "deletedEvent", {"dishId":6})')
+        ->assertPayloadNotSet('eventId', ['dishId' => 1])
+        ->call('deletedEvent', ['dishId' => 1])
+        ->assertPayloadSet('eventId', ['dishId' => 1])
+
+        //page 2
+        ->call('setPage', 2)
+        ->assertSeeHtml('$emitTo("dishes-table", "deletedEvent", {"dishId":6})')
+        ->assertDontSeeHtml('$emitTo("dishes-table", "deletedEvent", {"dishId":1})')
+        ->assertPayloadNotSet('deletedEvent', ['dishId' => 6])
+        ->call('deletedEvent', ['dishId' => 6])
+        ->assertPayloadSet('eventId', ['dishId' => 6]);
+})->with('themes');


### PR DESCRIPTION
Added action for Livewire emitTo event. Turkish language fixes. Boolean singleParam parameter has been added so that the parameters sent to the actions can be sent in non-array form.