### PR TITLE
Adds formatting feature on Count, Sum and Avg.

### DIFF
--- a/resources/views/components/table-footer.blade.php
+++ b/resources/views/components/table-footer.blade.php
@@ -26,18 +26,39 @@
         <td class="{{ $theme->table->tdBodyClassTotalColumns . ' '.$column->bodyClass ?? '' }}"
             style="{{ $column->hidden === true ? 'display:none': '' }}; {{ $theme->table->tdBodyStyleTotalColumns .' '.$column->bodyStyle ?? ''  }}">
             @if ($column->count['footer'])
-                <span>{{ $column->count['label'] }}: {{ $withoutPaginatedData->collect()
+                @php
+                    $count = $withoutPaginatedData->collect()
                     ->reject(function($data) use($field) { return empty($data->$field); })
-                    ->count($field) }}
+                    ->count($field);
+                    
+                    if (is_callable($column->count['formatter'])) {
+                       $count = call_user_func($column->count['formatter'], $count);
+                    }
+                @endphp
+                <span>{{ $column->count['label'] }}: {{ $count }}
                     </span>
                 <br>
             @endif
             @if ($column->sum['footer'] && is_numeric($withoutPaginatedData[0][$field]))
-                <span>{{ $column->sum['label'] }}: {{ $withoutPaginatedData->collect()->sum($field) }}</span>
+                @php
+                    $sum = $withoutPaginatedData->collect()->sum($field);
+                    
+                    if (is_callable($column->sum['formatter'])) {
+                        $sum = call_user_func($column->sum['formatter'], $sum);
+                    }
+                @endphp
+                <span>{{ $column->sum['label'] }}: {{ $sum }}</span>
                 <br>
             @endif
             @if ($column->avg['footer'] && is_numeric($withoutPaginatedData[0][$column->dataField]))
-                <span>{{ $column->avg['label'] }}: {{ $withoutPaginatedData->collect()->avg($field) }}</span>
+                @php
+                   $avg = round($withoutPaginatedData->collect()->avg($field), $column->avg['rounded']);
+                    
+                    if (is_callable($column->avg['formatter'])) {
+                        $avg = call_user_func($column->avg['formatter'], $avg);
+                    }
+                @endphp
+                <span>{{ $column->avg['label'] }}: {{ $avg }}</span>
                 <br>
             @endif
         </td>

--- a/resources/views/components/table-header.blade.php
+++ b/resources/views/components/table-header.blade.php
@@ -26,18 +26,39 @@
         <td class="{{ $theme->table->tdBodyClassTotalColumns . ' '.$column->bodyClass ?? '' }}"
             style="{{ $column->hidden === true ? 'display:none': '' }}; {{$theme->table->tdBodyStyleTotalColumns . ' '.$column->bodyStyle ?? ''  }}">
             @if ($column->count['header'])
-                <span>{{ $column->count['label'] }}: {{ $withoutPaginatedData->collect()
-                    ->reject(function($data) use($field) { return empty($data->$field); })
-                    ->count($field) }}
+                @php
+                    $count = $withoutPaginatedData->collect()
+                        ->reject(function($data) use($field) { return empty($data->$field); })
+                        ->count($field);
+                        
+                    if (is_callable($column->count['formatter'])) {
+                        $count = call_user_func($column->count['formatter'], $count);
+                    }
+                @endphp
+                <span>{{ $column->count['label'] }}: {{ $count }}
                     </span>
                 <br>
             @endif
             @if ($column->sum['header'] && is_numeric($withoutPaginatedData[0][$field]))
-                <span>{{ $column->sum['label'] }}: {{ $withoutPaginatedData->collect()->sum($field) }}</span>
+                @php
+                    $sum = $withoutPaginatedData->collect()->sum($field);
+                    
+                    if (is_callable($column->sum['formatter'])) {
+                        $sum = call_user_func($column->sum['formatter'], $sum);
+                    }
+                @endphp
+                <span>{{ $column->sum['label'] }}: {{ $sum }}</span>
                 <br>
             @endif
             @if ($column->avg['header'] && is_numeric($withoutPaginatedData[0][$field]))
-                <span>{{ $column->avg['label'] }}: {{ round($withoutPaginatedData->collect()->avg($field), $column->avg['rounded']) }}</span>
+                @php
+                   $avg = round($withoutPaginatedData->collect()->avg($field), $column->avg['rounded']);
+
+                    if (is_callable($column->avg['formatter'])) {
+                        $avg = call_user_func($column->avg['formatter'], $avg);
+                    }
+                @endphp
+                <span>{{ $column->avg['label'] }}: {{ $avg }}</span>
                 <br>
             @endif
         </td>

--- a/src/Column.php
+++ b/src/Column.php
@@ -35,18 +35,22 @@ final class Column
     public bool $sortable = false;
 
     public array $sum = [
-        'header' => false,
-        'footer' => false,
+        'header'    => false,
+        'footer'    => false,
+        'formatter' => null,
     ];
 
     public array $count = [
-        'header' => false,
-        'footer' => false,
+        'header'    => false,
+        'footer'    => false,
+        'formatter' => null,
     ];
 
     public array $avg = [
-        'header' => false,
-        'footer' => false,
+        'header'    => false,
+        'footer'    => false,
+        'formatter' => null,
+        'rounded'   => 0,
     ];
 
     public array $inputs = [];
@@ -126,9 +130,23 @@ final class Column
      */
     public function withSum(string $label = 'Sum', bool $header = true, bool $footer = true): Column
     {
-        $this->sum['label']             = $label;
-        $this->sum['header']            = $header;
-        $this->sum['footer']            = $footer;
+        $this->sum['label']                = $label;
+        $this->sum['header']               = $header;
+        $this->sum['footer']               = $footer;
+
+        return $this;
+    }
+
+    /**
+     * Format SUM output
+    *
+    * @param callable $formatFunction
+    *
+     * @return $this
+     */
+    public function formatSum(callable $formatFunction): Column
+    {
+        $this->sum['formatter']            = $formatFunction;
 
         return $this;
     }
@@ -140,9 +158,23 @@ final class Column
      */
     public function withCount(string $label = 'Count', bool $header = true, bool $footer = true): Column
     {
-        $this->count['label']  = $label;
-        $this->count['header'] = $header;
-        $this->count['footer'] = $footer;
+        $this->count['label']                = $label;
+        $this->count['header']               = $header;
+        $this->count['footer']               = $footer;
+        
+        return $this;
+    }
+    
+    /**
+     * Format Count output
+    *
+    * @param callable $formatFunction
+    *
+     * @return $this
+     */
+    public function formatCount(callable $formatFunction): Column
+    {
+        $this->count['formatter']            = $formatFunction;
 
         return $this;
     }
@@ -158,6 +190,20 @@ final class Column
         $this->avg['header']     = $header;
         $this->avg['footer']     = $footer;
         $this->avg['rounded']    = $rounded;
+
+        return $this;
+    }
+    
+    /**
+      * Format Avg output
+     *
+     * @param callable $formatFunction
+     *
+      * @return $this
+      */
+    public function formatAvg(callable $formatFunction): Column
+    {
+        $this->avg['formatter']            = $formatFunction;
 
         return $this;
     }

--- a/tests/DishesTable.php
+++ b/tests/DishesTable.php
@@ -154,8 +154,11 @@ class DishesTable extends PowerGridComponent
                 ->title(__('Preço'))
                 ->field('price_BRL')
                 ->withSum('Sum Price', false, true)
-                ->withCount('Count Price', false, true)
+                ->formatSum(fn ($sum) => 'R$ ' . number_format($sum, 2, '.', ','))
+                ->withCount('Count', false, true)
+                ->formatCount(fn ($count) => number_format($count, 2, '.', ''))
                 ->withAvg('Avg Price', false, true)
+                ->formatAvg(fn ($avg) => 'R$ ' . number_format($avg, 2, '.', ','))
                 ->editOnClick($canEdit, 'price')
                 ->makeInputRange('price', '.', ','),
 

--- a/tests/DishesTableWithJoin.php
+++ b/tests/DishesTableWithJoin.php
@@ -152,8 +152,11 @@ class DishesTableWithJoin extends PowerGridComponent
                 ->title(__('Preço'))
                 ->field('price_BRL')
                 ->withSum('Sum Price', false, true)
-                ->withCount('Count Price', false, true)
+                ->formatSum(fn ($sum) => 'R$ ' . number_format($sum, 2, '.', ','))
+                ->withCount('Count', false, true)
+                ->formatCount(fn ($count) => number_format($count, 2, '.', ''))
                 ->withAvg('Avg Price', false, true)
+                ->formatAvg(fn ($avg) => 'R$ ' . number_format($avg, 2, '.', ','))
                 ->editOnClick($canEdit)
                 ->makeInputRange('price', '.', ','),
 

--- a/tests/Feature/WithSumTest.php
+++ b/tests/Feature/WithSumTest.php
@@ -18,30 +18,30 @@ it('calculate "count" on id field', function (string $component, object $params)
         ->assertSee('Count ID: 1');
 })->with('themes with name field');
 
-it('calculate "sum" on price field', function (string $component, object $params) {
+it('calculates and formats "sum" on price field', function (string $component, object $params) {
     livewire($component)
         ->call($params->theme)
-        ->assertSeeHtml('<span>Sum Price: 15000.6</span>')
+        ->assertSeeHtml('<span>Sum Price: R$ 15,000.60</span>')
         ->set('search', 'Dish C')
-        ->assertSeeHtml('<span>Sum Price: 300.5</span>')
+        ->assertSeeHtml('<span>Sum Price: R$ 300.50</span>')
         ->set('search', 'Dish F')
-        ->assertSeeHtml('<span>Sum Price: 600</span>');
+        ->assertSeeHtml('<span>Sum Price: R$ 600.00</span>');
 })->with('themes with name field');
 
-it('calculate "count" on price field', function (string $component, object $params) {
+it('calculates and formats "count" on price field', function (string $component, object $params) {
     livewire($component)
         ->call($params->theme)
-        ->assertSeeHtml('Count Price: 12')
+        ->assertSeeHtml('Count: 12.00')
         ->set('search', 'Dish C')
-        ->assertSeeHtml('Count Price: 1')
+        ->assertSeeHtml('Count: 1.00')
         ->set('search', 'Dish F')
-        ->assertSeeHtml('Count Price: 1');
+        ->assertSeeHtml('Count: 1.00');
 })->with('themes with name field');
 
-it('calculate "avg" on price field', function (string $component, object $params) {
+it('calculates and formats "avg" on price field', function (string $component, object $params) {
     livewire($component)
         ->call($params->theme)
-        ->assertSeeHtml('<span>Avg Price: 1250.05</span>');
+        ->assertSeeHtml('<span>Avg Price: R$ 1,250.05</span>');
 })->with('themes with name field');
 
 /**


### PR DESCRIPTION
Hello Luan,

This PR adds the possibility to format the output on `->withSum()`, `->withCount()` and `->withAvg()`.

The formatting feature has been discussed before, and it was now mentioned again in Issue https://github.com/Power-Components/livewire-powergrid/issues/281.

These 3 methods have been bloated with boolean parameters, and I think adding one more for formatting would complicate the developer experience. For this reason, I have decided to include new methods: `->formatSum()`, `->formatCount()` and `->formatAvg()`.

Each method requires a `callable` allowing the user to use different native functions across PHP versions, custom packages or any specific formatting adopted in his application.

Usage:

```php
Column::add()
    ->title(__('Price'))
    ->field('price_BRL')
    ->editOnClick($canEdit),
    ->makeInputRange('price', ".", ",")
    ->withSum('Total', true, true)
    ->formatSum(fn ($sum) => AccountingExample::format($sum, 'R$')),
```

This approach would result in something like:

<img width="1430" alt="CleanShot 2022-02-18 at 12 02 42@2x" src="https://user-images.githubusercontent.com/79267265/154670706-7139e948-30bb-45a8-a075-550fc69482f5.png">

Also,  I have noticed `round()` was being called in the header but not in the footer on `withAvg`. I have added it.

Thanks

