### PR TITLE
add action button title/tooltip text

### DIFF
--- a/resources/views/components/actions-header.blade.php
+++ b/resources/views/components/actions-header.blade.php
@@ -17,18 +17,21 @@
                 @if($action->event !== '' && $action->to === '')
                     <a wire:click='$emit("{{ $action->event }}", @json($parameters))'
                        target="{{ $action->target }}"
+                       title="{{ $action->tooltip }}"
                        class="{{ filled($action->class) ? $action->class : $theme->actions->headerBtnClass }}">
                         {!! $action->caption !!}
                     </a>
                 @elseif($action->event !== '' && $action->to !== '')
                     <a wire:click='$emitTo("{{ $action->to }}", "{{ $action->event }}", @json($parameters))'
                        target="{{ $action->target }}"
+                       title="{{ $action->tooltip }}"
                        class="{{ filled($action->class) ? $action->class : $theme->actions->headerBtnClass }}">
                         {!! $action->caption !!}
                     </a>
                 @elseif($action->view !== '')
                     <a wire:click='$emit("openModal", "{{$action->view}}", @json($parameters))'
                        target="{{ $action->target }}"
+                       title="{{ $action->tooltip }}"
                        class="{{ filled($action->class) ? $action->class : $theme->actions->headerBtnClass }}">
                         {!! $action->caption !!}
                     </a>
@@ -40,12 +43,14 @@
                             @method($action->method)
                             @csrf
                             <button type="submit"
+                                    title="{{ $action->tooltip }}"
                                     class="{{ filled( $action->class) ? $action->class : $theme->actions->headerBtnClass }}">
                                 {!! $action->caption ?? '' !!}
                             </button>
                         </form>
                     @else
                         <a href="{{ route($action->route, $parameters) }}"
+                           title="{{ $action->tooltip }}"
                            target="{{ $action->target }}"
                            class="{{ filled($action->class) ? $action->class : $theme->actions->headerBtnClass }}">
                             {!! $action->caption !!}

--- a/resources/views/components/actions.blade.php
+++ b/resources/views/components/actions.blade.php
@@ -73,6 +73,7 @@
                             @endif
 
                             @if($ruleDisabled) disabled @endif
+                            title="{{ $action->tooltip }}"
                             class="{{ $class }}"
                         >
                             {!! $ruleCaption ?? $action->caption !!}
@@ -84,6 +85,7 @@
                            @else
                            href="{{ $ruleRedirect['url'] }}" target="{{ $ruleRedirect['target'] }}"
                            @endif
+                           title="{{ $action->tooltip }}"
                            class="{{ $class }}">
                             {!! $ruleCaption ?? $action->caption !!}
                         </a>
@@ -97,6 +99,7 @@
                                 @method($action->method)
                                 @csrf
                                 <button type="submit"
+                                        title="{{ $action->tooltip }}"
                                         @if($ruleDisabled) disabled @endif class="{{ $class }}">
                                     {!! $ruleCaption ?? $action->caption !!}
                                 </button>
@@ -104,6 +107,7 @@
                         @else
                             <a href="{{ route($action->route, $actionParameters) }}"
                                target="{{ $action->target }}"
+                               title="{{ $action->tooltip }}"
                                class="{{ $class }}"
                             >
                                 {!! $ruleCaption ?? $action->caption !!}

--- a/src/Button.php
+++ b/src/Button.php
@@ -24,6 +24,8 @@ final class Button
 
     public string $to = '';
 
+    public string $tooltip = '';
+
     public bool $singleParam = false;
 
     /**
@@ -173,6 +175,18 @@ final class Button
     public function target(string $target): Button
     {
         $this->target = $target;
+
+        return $this;
+    }
+
+    /**
+     * tooltip
+     * @param string $tooltip
+     * @return $this
+     */
+    public function tooltip(string $tooltip): Button
+    {
+        $this->tooltip = $tooltip;
 
         return $this;
     }


### PR DESCRIPTION
I noticed the mouse hover tooltip missing in the Grid action buttons and made some additions. Maybe a more beautiful looking tooltip can be added to the css framework used in the future.

**Use:**
```php
Button::add('view')
      ->class('fas fa-eye cursor-pointer text-green-500 px-1 py-1.5 m-1 text-sm')
      ->openModal('modules.system.workspace.view', [0 => 'id'])
      ->can(auth()->user()?->can('system.workspace.view'))
      ->tooltip('View'),
```

I got the following error while checking. phpstan gives an error even though the relevant line is ignored. I'm doing PR because it's not about the additions I made.

![Screenshot_2022-03-10_02-07-13](https://user-images.githubusercontent.com/7466590/157554327-c6bffbc6-e0db-4456-a342-b4566c3c5416.png)




**Resource :**
[https://www.w3schools.com/tags/att_global_title.asp](https://www.w3schools.com/tags/att_global_title.asp)