### PR TITLE
Fix Model name on datasource doc block

### DIFF
--- a/resources/stubs/table.fillable.stub
+++ b/resources/stubs/table.fillable.stub
@@ -47,7 +47,7 @@ final class {{ componentName }} extends PowerGridComponent
     /**
     * PowerGrid datasource.
     *
-    * @return  \Illuminate\Database\Eloquent\Builder<\App\Models\User>|null
+    * @return  \Illuminate\Database\Eloquent\Builder<\{{ modelName }}>|null
     */
     public function datasource(): ?Builder
     {

--- a/resources/stubs/table.model.stub
+++ b/resources/stubs/table.model.stub
@@ -47,7 +47,7 @@ final class {{ componentName }} extends PowerGridComponent
     /**
     * PowerGrid datasource.
     *
-    * @return  \Illuminate\Database\Eloquent\Builder<\App\Models\User>|null
+    * @return  \Illuminate\Database\Eloquent\Builder<\{{ modelName }}>|null
     */
     public function datasource(): ?Builder
     {


### PR DESCRIPTION
Hi Luan,

This PR fixes the doc block on `datasource()` which was hard-coded. Now, it should also cover the case where the Model lives in a non-standard folder.

Example:

```
    /**
    * PowerGrid datasource.
    *
    * @return  \Illuminate\Database\Eloquent\Builder<\App\Models\Foods\Fruit>|null
    */
    public function datasource(): ?Builder
    {
        return Fruit::query();
    }
```

Creation:


<img width="600" alt="CleanShot 2022-03-13 at 00 34 49@2x" src="https://user-images.githubusercontent.com/79267265/158038716-4f004482-af40-4ebb-a015-6637450f93e5.png">


Larastan on level `max`:


<img width="883" alt="CleanShot 2022-03-13 at 00 35 23@2x" src="https://user-images.githubusercontent.com/79267265/158038720-298a04fa-817b-4900-a48a-2804a0f8ac9d.png">

Greetings and thanks

Dan

