### PR TITLE
Refactor create command

### DIFF
--- a/src/Actions/FillableTable.php
+++ b/src/Actions/FillableTable.php
@@ -10,14 +10,18 @@ class FillableTable
     /**
     * @throws \Exception
     */
-    public static function create(string $modelName, string $modelLastName): string
+    public static function create(string $modelName, string $modelLastName, string $template = null): string
     {
 
         /** @var  \Illuminate\Database\Eloquent\Model $model*/
         $model = new $modelName();
 
-        $stub = File::get(__DIR__ . '/../../resources/stubs/table.fillable.stub');
-
+        if (!empty($template)) {
+            $stub =  File::get(base_path($template));
+        } else {
+            $stub = File::get(__DIR__ . '/../../resources/stubs/table.fillable.stub');
+        }
+    
         $getFillable = $model->getFillable();
 
         if (filled($model->getKeyName())) {

--- a/src/Actions/FillableTable.php
+++ b/src/Actions/FillableTable.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Actions;
+
+use Illuminate\Support\Facades\{File, Schema};
+use Illuminate\Support\Str;
+
+class FillableTable
+{
+    /**
+    * @throws \Exception
+    */
+    public static function create(string $modelName, string $modelLastName): string
+    {
+
+        /** @var  \Illuminate\Database\Eloquent\Model $model*/
+        $model = new $modelName();
+
+        $stub = File::get(__DIR__ . '/../../resources/stubs/table.fillable.stub');
+
+        $getFillable = $model->getFillable();
+
+        if (filled($model->getKeyName())) {
+            $getFillable = array_merge([$model->getKeyName()], $getFillable);
+        }
+
+        $getFillable = array_merge(
+            $getFillable,
+            ['created_at', 'updated_at']
+        );
+
+        $datasource = '';
+        $columns    = "[\n";
+
+        foreach ($getFillable as $field) {
+            if (in_array($field, $model->getHidden())) {
+                continue;
+            }
+
+            $conn = Schema::getConnection();
+
+            $conn->getDoctrineSchemaManager()
+                ->getDatabasePlatform()
+                ->registerDoctrineTypeMapping('enum', 'string');
+
+            if (Schema::hasColumn($model->getTable(), $field)) {
+                $column = $conn->getDoctrineColumn($model->getTable(), $field);
+
+                $title = Str::of($field)->replace('_', ' ')->upper();
+
+                if (in_array($column->getType()->getName(), ['datetime', 'date'])) {
+                    $columns .= '            Column::add()' . "\n" . '                ->title(\'' . $title . '\')' . "\n" . '                ->field(\'' . $field . '_formatted\', \'' . $field . '\')' . "\n" . '                ->searchable()' . "\n" . '                ->sortable()' . "\n" . '                ->makeInputDatePicker(\'' . $field . '\'),' . "\n\n";
+                }
+
+                if ($column->getType()->getName() === 'datetime') {
+                    $datasource .= "\n" . '            ->addColumn(\'' . $field . '_formatted\', function(' . $modelLastName . ' $model) { ' . "\n" . '                return Carbon::parse($model->' . $field . ')->format(\'d/m/Y H:i:s\');' . "\n" . '            })';
+
+                    continue;
+                }
+
+                if ($column->getType()->getName() === 'date') {
+                    $datasource .= "\n" . '            ->addColumn(\'' . $field . '_formatted\', function(' . $modelLastName . ' $model) { ' . "\n" . '                return Carbon::parse($model->' . $field . ')->format(\'d/m/Y\');' . "\n" . '            })';
+
+                    continue;
+                }
+
+                if ($column->getType()->getName() === 'boolean') {
+                    $datasource .= "\n" . '            ->addColumn(\'' . $field . '\')';
+                    $columns    .= '            Column::add()' . "\n" . '                ->title(\'' . $title . '\')' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->toggleable(),' . "\n\n";
+
+                    continue;
+                }
+
+                if (in_array($column->getType()->getName(), ['smallint', 'integer', 'bigint'])) {
+                    $datasource .= "\n" . '            ->addColumn(\'' . $field . '\')';
+                    $columns    .= '            Column::add()' . "\n" . '                ->title(\'' . $title . '\')' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->makeInputRange(),' . "\n\n";
+
+                    continue;
+                }
+
+                if ($column->getType()->getName() === 'string') {
+                    $datasource .= "\n" . '            ->addColumn(\'' . $field . '\')';
+                    $columns    .= '            Column::add()' . "\n" . '                ->title(\'' . $title . '\')' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->sortable()' . "\n" . '                ->searchable()' . "\n" . '                ->makeInputText(),' . "\n\n";
+
+                    continue;
+                }
+
+                $datasource .= "\n" . '            ->addColumn(\'' . $field . '\')';
+                $columns    .= '            Column::add()' . "\n" . '                ->title(\'' . $title . '\')' . "\n" . '                ->field(\'' . $field . '\')' . "\n" . '                ->sortable()' . "\n" . '                ->searchable(),' . "\n\n";
+            }
+        }
+
+        $columns .= "        ]\n";
+
+        $stub = str_replace('{{ datasource }}', $datasource, $stub);
+
+        return str_replace('{{ columns }}', $columns, $stub);
+    }
+}

--- a/src/Actions/Models.php
+++ b/src/Actions/Models.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Actions;
+
+use Illuminate\Support\Facades\File;
+
+class Models
+{
+    /**
+     * List files in Models folder
+     *
+     * @return array
+     */
+    public static function list(): array
+    {
+        $modelsFolder = app_path('Models');
+
+        $files = collect(File::allFiles($modelsFolder))
+            ->map(fn ($file) => $file->getFilenameWithoutExtension());
+
+        $files->map(function ($file) use (&$files) {
+            $files->push('App\\Models\\' . $file);
+        });
+
+        return  $files->toArray();
+    }
+}

--- a/src/Actions/Stubs.php
+++ b/src/Actions/Stubs.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Actions;
+
+use Illuminate\Support\Facades\File;
+
+class Stubs
+{
+    /**
+     * Load stub
+     *
+     * @param string $creationModel
+     * @param string|null $template
+     */
+    public static function load(string $creationModel, string $template = null): string
+    {
+        if (!empty($creationModel) && !empty($template)) {
+            return File::get(base_path($template));
+        }
+        
+        if (strtolower(trim($creationModel)) === 'm') {
+            return File::get(__DIR__ . '/../../resources/stubs/table.model.stub');
+        }
+
+        return File::get(__DIR__ . '/../../resources/stubs/table.collection.stub');
+    }
+}

--- a/src/Actions/TailwindForm.php
+++ b/src/Actions/TailwindForm.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Actions;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class TailwindForm
+{
+    /**
+     * Check if Tailwindform is installed
+     *
+     * @return string|null
+     */
+    public static function check()
+    {
+        $tailwindConfigFile = base_path() . '/' . 'tailwind.config.js';
+      
+        if (File::exists($tailwindConfigFile)) {
+            $fileContent = File::get($tailwindConfigFile);
+  
+            if (Str::contains($fileContent, "require('@tailwindcss/forms')") === true) {
+                return("\n💡 It seems you are using the plugin <comment>Tailwindcss/form</comment>.\n   Please check: <comment>https://livewire-powergrid.com/#/get-started/configure?id=_43-tailwind-forms</comment> for more information.");
+            }
+        }
+        
+        return null;
+    }
+}

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -201,9 +201,9 @@ class CreateCommand extends Command
     {
         $this->info("\n⚡ <comment>" . $this->componentFilename . '</comment> was successfully created at [<comment>App/' . $this->savedAt . '</comment>].');
        
-        $this->info("\n⚡ Your PowerGrid can be now included with the tag: <comment>" . $this->componentName . '</comment>');
+        $this->info("\n⚡ Your PowerGrid table can be now included with the tag: <comment>" . $this->componentName . '</comment>');
        
-        $this->info("\n\n⭐ Please consider <comment>starring</comment> our repository at <comment>https://github.com/Power-Components/livewire-powergrid</comment> ⭐\n");
+        $this->info("\n\n⭐ Please consider <comment>starring</comment> our repository at <comment>https://github.com/Power-Components/livewire-powergrid</comment>. ⭐\n");
     }
 
     protected function checkTailwindforms(): void

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -125,7 +125,7 @@ class CreateCommand extends Command
             }
             
             if ($this->useFilable && is_string($this->model) && is_string($this->modelName)) {
-                $this->stub = FillableTable::create($this->model, $this->modelName);
+                $this->stub = FillableTable::create($this->model, $this->modelName, strval($this->option('template')));
             }
         }
 

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -96,13 +96,6 @@ class CreateCommand extends Command
             if (empty($this->model)) {
                 throw new CreateCommandException('Error: You must inform the Model name or file path.');
             }
-            /*
-                        try {
-                            $model = new $this->model;
-                        } catch (\Exception $e) {
-                            throw new CreateCommandException('Invalid model given.');
-                        }
-            */
 
             $this->modelPath  = explode('\\', $this->model);
             $this->modelName  = strval(Arr::last($this->modelPath));

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Commands;
+
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use PowerComponents\LivewirePowerGrid\Helpers\InteractsWithVersions;
+
+class UpdateCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'powergrid:update';
+
+    protected $description = 'Check if there is a new version of PowerGrid.';
+
+    public function handle(): int
+    {
+        if (config('livewire-powergrid.check_version') === false) {
+            return self::SUCCESS;
+        }
+
+        try {
+            $ensureLatestVersion = new InteractsWithVersions();
+
+            $current = $ensureLatestVersion->ensureLatestVersion();
+
+            if (isset($current['version'])) {
+                if (version_compare($remote = $ensureLatestVersion->getLatestVersion(), $current['version']) > 0) {
+                    $this->info(" You are using an outdated version <comment>{$current['version']}</comment> of PowerGrid ⚡. Please consider upgrading to <comment>{$remote}</comment>");
+                    $this->info(" Released Date: <comment>{$current['release']}</comment>");
+                }
+            }
+        } catch (Exception $e) {
+            Log::debug($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Exceptions/CreateCommandException.php
+++ b/src/Exceptions/CreateCommandException.php
@@ -1,0 +1,10 @@
+<?php
+namespace PowerComponents\LivewirePowerGrid\Exceptions;
+
+use Exception;
+
+final class CreateCommandException extends Exception
+{
+    /** @var string */
+    protected $message = '';
+}

--- a/src/PowerGridEloquent.php
+++ b/src/PowerGridEloquent.php
@@ -46,6 +46,7 @@ final class PowerGridEloquent
             return null;
         }
 
+        /** @phpstan-ignore-next-line */
         return $this->collection->map(function (Model $model) {
             // We need to generate a set of columns, which are already registered in the object, based on the model.
             // To do this we iterate through each column and then resolve the closure.

--- a/src/PowerGridEloquent.php
+++ b/src/PowerGridEloquent.php
@@ -46,7 +46,6 @@ final class PowerGridEloquent
             return null;
         }
 
-        /** @phpstan-ignore-next-line */
         return $this->collection->map(function (Model $model) {
             // We need to generate a set of columns, which are already registered in the object, based on the model.
             // To do this we iterate through each column and then resolve the closure.

--- a/src/Providers/PowerGridServiceProvider.php
+++ b/src/Providers/PowerGridServiceProvider.php
@@ -4,7 +4,7 @@ namespace PowerComponents\LivewirePowerGrid\Providers;
 
 use Illuminate\Support\Facades\{Blade, View};
 use Illuminate\Support\ServiceProvider;
-use PowerComponents\LivewirePowerGrid\Commands\{CreateCommand, DemoCommand, PublishCommand};
+use PowerComponents\LivewirePowerGrid\Commands\{CreateCommand, DemoCommand, PublishCommand, UpdateCommand};
 use PowerComponents\LivewirePowerGrid\PowerGridManager;
 use PowerComponents\LivewirePowerGrid\Rules\RuleManager;
 use PowerComponents\LivewirePowerGrid\Themes\ThemeManager;
@@ -16,9 +16,10 @@ class PowerGridServiceProvider extends ServiceProvider
     public function boot(): void
     {
         if ($this->app->runningInConsole()) {
-            $this->commands([CreateCommand::class]);
             $this->commands([PublishCommand::class]);
+            $this->commands([UpdateCommand::class]);
             $this->commands([DemoCommand::class]);
+            $this->commands([CreateCommand::class]);
         }
 
         $this->publishViews();

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -20,7 +20,7 @@ it('creates a PowerGrid Model Table', function () {
         ->expectsQuestion($this->model_path_question, 'PowerComponents\LivewirePowerGrid\Tests\Models\Dish')
         ->expectsQuestion($this->use_fillable_question, 'yes')
         ->expectsOutput("\n⚡ DemoTable.php was successfully created at [App/Http/Livewire/].")
-        ->expectsOutput("\n⚡ Your PowerGrid can be now included with the tag: <livewire:demo-table/>");
+        ->expectsOutput("\n⚡ Your PowerGrid table can be now included with the tag: <livewire:demo-table/>");
 
     $this->assertFileExists($this->tableModelFilePath);
 
@@ -34,7 +34,7 @@ it('creates a PowerGrid Collection Table', function () {
         ->expectsQuestion($this->model_name_question, 'CollectionTable')
         ->expectsQuestion($this->datasource_question, 'C')
         ->expectsOutput("\n⚡ CollectionTable.php was successfully created at [App/Http/Livewire/].")
-        ->expectsOutput("\n⚡ Your PowerGrid can be now included with the tag: <livewire:collection-table/>");
+        ->expectsOutput("\n⚡ Your PowerGrid table can be now included with the tag: <livewire:collection-table/>");
 
     $this->assertFileExists($this->tableCollectionFilePath);
 
@@ -58,7 +58,7 @@ it('notifies about tailwind forms', function () {
         ->expectsQuestion($this->use_fillable_question, 'yes')
         ->expectsOutput("\n💡 It seems you are using the plugin Tailwindcss/form.\n   Please check: https://livewire-powergrid.com/#/get-started/configure?id=_43-tailwind-forms for more information.")
         ->expectsOutput("\n⚡ DemoTable.php was successfully created at [App/Http/Livewire/].")
-        ->expectsOutput("\n⚡ Your PowerGrid can be now included with the tag: <livewire:demo-table/>");
+        ->expectsOutput("\n⚡ Your PowerGrid table can be now included with the tag: <livewire:demo-table/>");
 
     File::delete($this->tableModelFilePath);
     File::delete($tailwindConfigFile);

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -20,7 +20,7 @@ it('creates a PowerGrid Model Table', function () {
         ->expectsQuestion($this->model_path_question, 'PowerComponents\LivewirePowerGrid\Tests\Models\Dish')
         ->expectsQuestion($this->use_fillable_question, 'yes')
         ->expectsOutput("\n⚡ DemoTable.php was successfully created at [App/Http/Livewire/].")
-        ->expectsOutput("\n⚡ Your PowerGrid can be now included with the tag: <livewire:demo-table/>\n");
+        ->expectsOutput("\n⚡ Your PowerGrid can be now included with the tag: <livewire:demo-table/>");
 
     $this->assertFileExists($this->tableModelFilePath);
 
@@ -34,7 +34,7 @@ it('creates a PowerGrid Collection Table', function () {
         ->expectsQuestion($this->model_name_question, 'CollectionTable')
         ->expectsQuestion($this->datasource_question, 'C')
         ->expectsOutput("\n⚡ CollectionTable.php was successfully created at [App/Http/Livewire/].")
-        ->expectsOutput("\n⚡ Your PowerGrid can be now included with the tag: <livewire:collection-table/>\n");
+        ->expectsOutput("\n⚡ Your PowerGrid can be now included with the tag: <livewire:collection-table/>");
 
     $this->assertFileExists($this->tableCollectionFilePath);
 
@@ -58,7 +58,7 @@ it('notifies about tailwind forms', function () {
         ->expectsQuestion($this->use_fillable_question, 'yes')
         ->expectsOutput("\n💡 It seems you are using the plugin Tailwindcss/form.\n   Please check: https://livewire-powergrid.com/#/get-started/configure?id=_43-tailwind-forms for more information.")
         ->expectsOutput("\n⚡ DemoTable.php was successfully created at [App/Http/Livewire/].")
-        ->expectsOutput("\n⚡ Your PowerGrid can be now included with the tag: <livewire:demo-table/>\n");
+        ->expectsOutput("\n⚡ Your PowerGrid can be now included with the tag: <livewire:demo-table/>");
 
     File::delete($this->tableModelFilePath);
     File::delete($tailwindConfigFile);
@@ -92,7 +92,7 @@ it('does not accept an empty table name', function () {
     $this->artisan('powergrid:create')
         ->expectsQuestion($this->model_name_question, '')
         ->expectsOutput('You must provide a name for your ⚡ PowerGrid Table!')
-        ->assertExitCode(0);
+        ->assertExitCode(1);
 
     $this->assertFileDoesNotExist($this->tableModelFilePath);
 });
@@ -103,8 +103,8 @@ it('accepts only [M]odel or [C]ollection', function () {
     $this->artisan('powergrid:create')
         ->expectsQuestion($this->model_name_question, 'DemoTable')
         ->expectsQuestion($this->datasource_question, 'Z')
-        ->expectsOutput('Please enter [M] for Model or [C] for Collection')
-        ->assertExitCode(0);
+        ->expectsOutput('Invalid option. Please enter [M] for model or [C] for Collection.')
+        ->assertExitCode(1);
 
     $this->assertFileDoesNotExist($this->tableModelFilePath);
 });
@@ -116,8 +116,8 @@ it('does not create a table with empty model', function () {
         ->expectsQuestion($this->model_name_question, 'DemoTable')
         ->expectsQuestion($this->datasource_question, 'M')
         ->expectsQuestion($this->model_path_question, '')
-        ->expectsOutput('Error: Model name is required.')
-        ->assertExitCode(0);
+        ->expectsOutput('Error: You must inform the Model name or file path.')
+        ->assertExitCode(1);
 
     $this->assertFileDoesNotExist($this->tableModelFilePath);
 
@@ -131,9 +131,8 @@ it('does not create a table with invalid model path', function () {
         ->expectsQuestion($this->model_name_question, 'DemoTable')
         ->expectsQuestion($this->datasource_question, 'M')
         ->expectsQuestion($this->model_path_question, 'xyz-model')
-        ->expectsQuestion($this->use_fillable_question, 'yes')
-        ->expectsOutput('Error: "xyz-model" Invalid model path. Path must be like: "\App\Models\User"')
-        ->assertExitCode(0);
+        ->expectsOutput('Error: Could not find "xyz-model" class.')
+        ->assertExitCode(1);
 
     $this->assertFileDoesNotExist($this->tableModelFilePath);
 


### PR DESCRIPTION
Hi Luan,

This PR proposes a refactor on `powergrid:create` command.

My main motivation for the change is to guarantee the code maintainability in this command. 

In addition, I have:

- Fixed: The "M" for model was not default when giving a blank answered.
- Enhanced: The command will halt when an invalid model is given.
- Separated the Update into `powergrid:update` command.
- Small improvements on grammar/text.
- We also now suggest the Repo starring ⭐

We still have a lot of room for refactoring. We can give some attention to the actions and the way they get data. This is a first step.

Please review it thoroughly and let me know if any changes are required.

![Capto_Capture 2022-03-17_02-29-12_AM](https://user-images.githubusercontent.com/79267265/158719693-4f66ec58-5d77-4f3b-9ae2-660429891f86.png)


Greetings and thanks,

Dan

