### PR TITLE
[Feature] `makeInputEnum`

### DIFF
--- a/resources/views/components/filters/select.blade.php
+++ b/resources/views/components/filters/select.blade.php
@@ -21,7 +21,10 @@
                         data-live-search="{{ data_get($select, 'live-search') }}">
                     <option value="">{{ trans('livewire-powergrid::datatable.select.all') }}</option>
                     @foreach(data_get($select, 'data_source') as $relation)
-                        <option value="{{ data_get($relation, 'id')  }}">{{ $relation[data_get($select, 'display_field') ] }}</option>
+                        @php $key = isset($relation['id']) ? 'id' : 'value' @endphp
+                        <option value="{{ data_get($relation, $key) }}">
+                            {{ $relation[data_get($select, 'display_field') ] }}
+                        </option>
                     @endforeach
                 </select>
                 <div class="{{ $theme->relativeDivClass }}">

--- a/src/Column.php
+++ b/src/Column.php
@@ -2,7 +2,7 @@
 
 namespace PowerComponents\LivewirePowerGrid;
 
-use Illuminate\Support\Collection;
+use Illuminate\Support\{Collection, Str};
 
 final class Column
 {
@@ -245,12 +245,12 @@ final class Column
     }
 
     /**
-    * Hide the column
-    *
-    * @param bool $isHidden default: true
-    *
-    * @return Column
-    */
+     * Hide the column
+     *
+     * @param bool $isHidden default: true
+     *
+     * @return Column
+     */
     public function hidden(bool $isHidden = true, bool $isForceHidden = true): Column
     {
         $this->hidden      = $isHidden;
@@ -311,6 +311,18 @@ final class Column
         }
 
         return $this;
+    }
+
+    /**
+     * @param array<string, bool> $settings
+     * @return Column
+     */
+    public function makeInputEnum(array $enumCases, string $dataField = null, array $settings = []): Column
+    {
+        $dataSource = collect($enumCases)->map(fn ($case) => (array) $case);
+        $dataField ??= Str::snake(class_basename($enumCases[0]));
+
+        return $this->makeInputSelect($dataSource, 'value', $dataField, $settings);
     }
 
     /**


### PR DESCRIPTION
This PR adds a new feature of `makeInputEnum` to `Column` as discussed in #264

with this feature, we can use enum as a filter
```php
Column::add()
    ->title('Role')
    ->field('role_value', 'role')
    ->sortable()
    ->makeInputEnum(Role::cases()),
```

by default, `makeInputEnum` will use the snake case of the enum name for the dataField, but it can be customized by passing the desired dataField to the second parameter
```php
    ->makeInputEnum(Role::cases(), 'user_role'),
```