### PR TITLE
add clear button on search input for tailwind css

### DIFF
--- a/resources/views/components/frameworks/tailwind/search.blade.php
+++ b/resources/views/components/frameworks/tailwind/search.blade.php
@@ -11,6 +11,15 @@
                    style="padding-left: 36px !important;"
                    class="block w-full float-right bg-gray-50 text-gray-700 border border-gray-300 rounded py-2 px-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500 pl-10 dark:bg-gray-500 dark:text-gray-200 dark:placeholder-gray-200 dark:border-gray-500"
                    placeholder="{{ trans('livewire-powergrid::datatable.placeholders.search') }}">
+            @if($search)
+                <span class="absolute inset-y-0 right-0 flex items-center pl-1">
+                    <span class="p-1 -mt-1 focus:outline-none focus:shadow-outline cursor-pointer">
+                        <a wire:click.prevent="$set('search','')">
+                            <x-livewire-powergrid::icons.x class="text-gray-300 dark:text-gray-200"/>
+                        </a>
+                    </span>
+                </span>
+            @endif
         </div>
 
     </div>


### PR DESCRIPTION
I added clear button for search entry. But since I don't use bootstrap, I was only able to add it for tailwind css. Similarly, the filter.blade.php file in the bootstrap5 folder needs to be added for bootstrap.