### PR TITLE
Improve Create and Demo commands

### DIFF
--- a/src/Commands/Concerns/RenderAscii.php
+++ b/src/Commands/Concerns/RenderAscii.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Commands\Concerns;
+
+trait RenderAscii
+{
+    /**
+     * PowerGrid name in Ascii Art
+     */
+    public function renderPowergridAscii(): void
+    {
+        $this->newLine();
+        
+        $this->line(<<<EOT
+
+            <fg=yellow> __</>     <fg=green>____                          ______     _     __</>
+            <fg=yellow>/ /_,</>  <fg=green>/ __ \____ _      _____  _____/ ____/____(_)___/ /</>
+            <fg=yellow>/_ ,'</> <fg=green>/ /_/ / __ \ | /| / / _ \/ ___/ / __/ ___/ / __  / </>
+            <fg=yellow>/'</>   <fg=green>/ ____/ /_/ / |/ |/ /  __/ /  / /_/ / /  / / /_/ /  </>
+                <fg=green>/_/    \____/|__/|__/\___/_/   \____/_/  /_/\__,_/   </>  
+        EOT);
+
+        $this->newLine(2);
+    }
+}

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -196,7 +196,7 @@ class CreateCommand extends Command
        
         $this->info("\n⚡ Your PowerGrid table can be now included with the tag: <comment>" . $this->componentName . '</comment>');
        
-        $this->info("\n\n⭐ Please consider <comment>starring</comment> our repository at <comment>https://github.com/Power-Components/livewire-powergrid</comment>. ⭐\n");
+        $this->info("\n\n⭐ Please consider <comment>starring</comment> our repository at <comment>https://github.com/Power-Components/livewire-powergrid</comment> ⭐\n");
     }
 
     protected function checkTailwindforms(): void

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -44,9 +44,9 @@ class CreateCommand extends Command
 
     public function handle(): int
     {
-        $this->call('powergrid:update');
-
         $this->renderPowergridAscii();
+
+        $this->call('powergrid:update');
 
         try {
             $this->askTableName();

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -6,10 +6,13 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\{File};
 use Illuminate\Support\{Arr, Str};
 use PowerComponents\LivewirePowerGrid\Actions\{FillableTable, Models, Stubs, TailwindForm};
+use PowerComponents\LivewirePowerGrid\Commands\Concerns\RenderAscii;
 use PowerComponents\LivewirePowerGrid\Exceptions\CreateCommandException;
 
 class CreateCommand extends Command
 {
+    use RenderAscii;
+
     /** @var string */
     protected $signature = 'powergrid:create {--template= : name of the file that will be used as a template}';
 
@@ -43,6 +46,8 @@ class CreateCommand extends Command
     {
         $this->call('powergrid:update');
 
+        $this->renderPowergridAscii();
+
         try {
             $this->askTableName();
             $this->askDatasource();
@@ -62,7 +67,7 @@ class CreateCommand extends Command
 
     protected function askTableName(): void
     {
-        $this->tableName = strval($this->ask('What is the name of your new ⚡ PowerGrid Table (E.g., <comment>UserTable</comment>)?', ''));
+        $this->tableName = strval($this->ask('What is the name of your Table Component? (E.g., <comment>UserTable</comment>)', 'PowergridTable'));
 
         if (empty(trim(strval($this->tableName))) || !is_string($this->tableName)) {
             throw new CreateCommandException('You must provide a name for your ⚡ PowerGrid Table!');
@@ -91,7 +96,7 @@ class CreateCommand extends Command
         $this->stub = Stubs::load($this->datasourceOption, strval($this->option('template')));
 
         if (strtolower($this->datasourceOption) === 'm') {
-            $this->model = strval($this->anticipate('Enter your Model name or file path (E.g., <comment>User</comment> or <comment>App\Models\User</comment>)', Models::list(), ''));
+            $this->model = strval($this->anticipate('Enter your Model name or file path (E.g., <comment>User</comment> or <comment>App\Models\User</comment>)', Models::list(), 'User'));
 
             if (empty($this->model)) {
                 throw new CreateCommandException('Error: You must inform the Model name or file path.');
@@ -192,6 +197,8 @@ class CreateCommand extends Command
 
     protected function showCreated(): void
     {
+        $this->output->title('Component is ready!');
+
         $this->info("\n⚡ <comment>" . $this->componentFilename . '</comment> was successfully created at [<comment>App/' . $this->savedAt . '</comment>].');
        
         $this->info("\n⚡ Your PowerGrid table can be now included with the tag: <comment>" . $this->componentName . '</comment>');

--- a/src/Commands/DemoCommand.php
+++ b/src/Commands/DemoCommand.php
@@ -4,6 +4,7 @@ namespace PowerComponents\LivewirePowerGrid\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 
 class DemoCommand extends Command
 {
@@ -11,20 +12,32 @@ class DemoCommand extends Command
 
     protected $description = 'Generate a PowerGrid demo Table.';
 
-    private string $stubPath = __DIR__ . '/../../resources/stubs/';
+    protected string $stubPath = __DIR__ . '/../../resources/stubs/';
 
-    public function handle(): void
+    protected string $tableFileName;
+
+    protected string $viewFileName;
+
+    protected string $livewirePath;
+
+    protected string $fullLivewirePath;
+
+    protected string $viewFolder;
+    
+    protected string $link = 'https://github.com/Power-Components/livewire-powergrid';
+
+    public function handle(): int
     {
-        $tableFileName = 'PowerGridDemoTable';
-        $viewFileName  = 'powergrid-demo.blade';
+        $this->tableFileName = 'PowerGridDemoTable';
+        $this->viewFileName  = 'powergrid-demo.blade';
 
-        $livewirePath     = 'Http/Livewire/';
-        $fullLivewirePath = app_path($livewirePath);
+        $this->livewirePath      = 'Http/Livewire/';
+        $this->fullLivewirePath  = app_path($this->livewirePath);
 
-        $viewFolder = 'resources/views';
+        $this->viewFolder  = 'resources/views';
 
-        if (!is_dir($fullLivewirePath)) {
-            (new Filesystem())->makeDirectory($fullLivewirePath);
+        if (!is_dir($this->fullLivewirePath)) {
+            (new Filesystem())->makeDirectory($this->fullLivewirePath);
         }
 
         $url = config('app.url');
@@ -35,14 +48,45 @@ class DemoCommand extends Command
         
         $stub = str_replace('{{ url }}', $url, $this->stubPath);
 
-        file_put_contents($fullLivewirePath . $tableFileName . '.php', file_get_contents($stub . $tableFileName . '.stub'));
-        file_put_contents($this->laravel->basePath($viewFolder) . '/' . $viewFileName . '.php', file_get_contents($stub . $viewFileName . '.stub'));
+        file_put_contents($this->fullLivewirePath . $this->tableFileName . '.php', file_get_contents($stub . $this->tableFileName . '.stub'));
+        file_put_contents($this->laravel->basePath($this->viewFolder) . '/' . $this->viewFileName . '.php', file_get_contents($stub . $this->viewFileName . '.stub'));
 
-        $this->info('⚡ *** PowerGrid Demo Table is ready! ***');
-        $this->info("\n⚡ <comment>{$tableFileName}.php</comment> was successfully created at [<comment>App/{$livewirePath}</comment>]");
-        $this->info("\n⚡ <comment>{$viewFileName}.php</comment> was successfully created at [<comment>{$viewFolder}/</comment>]");
-        $this->info("\n⚡ *** Usage ***");
-        $this->info("\n<comment>➤</comment> You must include <comment>Route::view('/powergrid', 'powergrid-demo');</comment> in <comment>routes/web.php</comment> file.");
-        $this->info("\n<comment>➤</comment> Visit <comment>" . config('app.url') . "/powergrid</comment>. Enjoy it!\n");
+        $this->welcomeBox();
+
+        $this->instructions();
+
+        return self::SUCCESS;
+    }
+
+    protected function instructions(): void
+    {
+        $this->info(
+            "<comment>➤</comment> <comment>{$this->tableFileName}.php</comment> was successfully created at [<comment>App/{$this->livewirePath }</comment>]\n"
+        );
+            
+        $this->info("<comment>➤</comment> <comment>{$this->viewFileName}.php</comment> was successfully created at [<comment>{$this->viewFolder }/</comment>]\n");
+        
+        $this->output->newLine();
+
+        $this->output->title('<info>Next steps</info>');
+
+        $this->info("\n<comment>1.</comment> You must include <comment>Route::view('/powergrid', 'powergrid-demo');</comment> in your <comment>routes/web.php</comment> file.");
+        $this->info("\n<comment>2.</comment> Serve your project. For example, run <comment>php artisan serve</comment>.");
+        $this->info("\n<comment>3.</comment> Visit <comment>" . config('app.url') . '/powergrid</comment> to view the Demo Table.');
+        $this->info("\n\n⭐ Please consider <comment>starring</comment> our repository at <href={$this->link}>{$this->link}</> ⭐\n");
+    }
+
+    protected function welcomeBox(): void
+    {
+        $this->output->newLine();
+
+        $infoStyle = new OutputFormatterStyle('black', 'green');
+        
+        $this->output->getFormatter()->setStyle('msg', $infoStyle);
+    
+        $message =  $this->getHelper('formatter')->formatBlock(['', '⚡ Welcome to PowerGrid! ⚡', ''], 'msg', true);
+        $this->output->writeln($message);
+
+        $this->output->newLine(2);
     }
 }

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -27,8 +27,9 @@ class UpdateCommand extends Command
 
             if (isset($current['version'])) {
                 if (version_compare($remote = $ensureLatestVersion->getLatestVersion(), $current['version']) > 0) {
-                    $this->info(" You are using an outdated version <comment>{$current['version']}</comment> of PowerGrid ⚡. Please consider upgrading to <comment>{$remote}</comment>");
-                    $this->info(" Released Date: <comment>{$current['release']}</comment>");
+                    $this->info("✨ You are using an outdated ⚡ PowerGrid ⚡ version (<comment>{$current['version']}</comment>).");
+
+                    $this->info("   Please consider upgrading to <comment>{$remote}</comment>, released at: <comment>{$current['release']}</comment>\n\n");
                 }
             }
         } catch (Exception $e) {

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\File;
 beforeEach(function () {
     $this->tableModelFilePath       = getLaravelDir() . 'app/Http/Livewire/DemoTable.php';
     $this->tableCollectionFilePath  = getLaravelDir() . 'app/Http/Livewire/CollectionTable.php';
-    $this->model_name_question      = 'What is the name of your new ⚡ PowerGrid Table (E.g., <comment>UserTable</comment>)?';
+    $this->model_name_question      = 'What is the name of your Table Component? (E.g., <comment>UserTable</comment>)';
     $this->datasource_question      = 'Create Datasource with <comment>[M]</comment>odel or <comment>[C]</comment>ollection? (Default: Model)';
     $this->model_path_question      = 'Enter your Model name or file path (E.g., <comment>User</comment> or <comment>App\Models\User</comment>)';
     $this->use_fillable_question    = 'Create columns based on Model\'s <comment>fillable</comment> property?';

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -72,13 +72,13 @@ it('publishes the Demo Table', function () {
     File::delete($viewsFile);
 
     $this->artisan('powergrid:demo')
-        ->expectsOutput('⚡ *** PowerGrid Demo Table is ready! ***')
-        ->expectsOutput("\n⚡ PowerGridDemoTable.php was successfully created at [App/Http/Livewire/]")
-        ->expectsOutput("\n⚡ powergrid-demo.blade.php was successfully created at [resources/views/]")
-        ->expectsOutput("\n⚡ *** Usage ***")
-        ->expectsOutput("\n➤ You must include Route::view('/powergrid', 'powergrid-demo'); in routes/web.php file.")
-        ->expectsOutput("\n➤ Visit http://localhost/powergrid. Enjoy it!\n");
-
+        ->expectsOutput("➤ PowerGridDemoTable.php was successfully created at [App/Http/Livewire/]\n")
+        ->expectsOutput("➤ powergrid-demo.blade.php was successfully created at [resources/views/]\n")
+        ->expectsOutput("\n1. You must include Route::view('/powergrid', 'powergrid-demo'); in your routes/web.php file.")
+        ->expectsOutput("\n2. Serve your project. For example, run php artisan serve.")
+        ->expectsOutput("\n3. Visit http://localhost/powergrid to view the Demo Table.")
+        ->expectsOutput("\n\n⭐ Please consider starring our repository at https://github.com/Power-Components/livewire-powergrid ⭐\n");
+        
     $this->assertFileExists($tableFile);
     $this->assertFileExists($viewsFile);
 


### PR DESCRIPTION
Hi Luan,

This PR makes the commands `powergrid:demo` and `powergrid:create` more user-friendly.

## Demo Command

- I have turned phrases into steps, therefore providing clearer instructions on how to proceed.
- Some cosmetic changes.
- I have also included the starring repository message.

### Before

<img width="797" alt="before" src="https://user-images.githubusercontent.com/79267265/159400409-c284321c-8b7b-44b1-b074-8798ce1344ee.png">

### After

<img width="869" alt="after" src="https://user-images.githubusercontent.com/79267265/159400435-f513e9ca-17c8-426f-a96c-75d2552a8dad.png">

## Create Command

- Added Ascii art
- Pre-filled all options, so user can click all the way through without exceptions. (Assuming that there is a User Model  🙃)  

### Before

<img width="1008" alt="CleanShot 2022-03-22 at 12 00 43@2x" src="https://user-images.githubusercontent.com/79267265/159467351-8c6c2adc-4b11-4103-b7fb-fadc53280978.png">

### After

<img width="1008" alt="CleanShot 2022-03-22 at 11 56 39@2x" src="https://user-images.githubusercontent.com/79267265/159467105-5583b4b4-dad2-4e50-8be7-db66db825451.png">

Thanks