### PR TITLE
Fix PHP Fatal error: Class 'Doctrine\DBAL\Driver\PDOMySql\Driver' not found in by adding support for doctrine/dbal^2.12.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php": "^7.4.1 | ^8.0 | ^8.1",
         "livewire/livewire": "^2.4",
         "box/spout": "^3",
-        "doctrine/dbal": "^3.1"
+        "doctrine/dbal": "^3.1|^2.12.1"
     },
     "scripts": {
         "cs-fixer": "./vendor/bin/php-cs-fixer fix --verbose --dry-run --using-cache=no --stop-on-violation",


### PR DESCRIPTION
Problem:

```
PHP Fatal error: Class 'Doctrine\DBAL\Driver\PDOMySql\Driver' not found in /var/www/vhosts/profexpress.com/v2/dev/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php on line 64 [Symfony\Component\Debug\Exception\FatalErrorException] Class 'Doctrine\DBAL\Driver\PDOMySql\Driver' not found
```

Solution:

See https://laracasts.com/discuss/channels/laravel/class-doctrinedbaldriverpdomysqldriver-not-found?page=1&replyId=667814