### PR TITLE
[Enhancement] `addColumn` dot notation

### DIFF
--- a/src/PowerGridEloquent.php
+++ b/src/PowerGridEloquent.php
@@ -32,6 +32,7 @@ final class PowerGridEloquent
      */
     public function addColumn(string $field, Closure $closure = null): PowerGridEloquent
     {
+        /** @phpstan-ignore-next-line */
         $this->columns[$field] = $closure ?? fn ($model) => e(data_get($model, $field));
 
         return $this;

--- a/src/PowerGridEloquent.php
+++ b/src/PowerGridEloquent.php
@@ -32,7 +32,7 @@ final class PowerGridEloquent
      */
     public function addColumn(string $field, Closure $closure = null): PowerGridEloquent
     {
-        $this->columns[$field] = $closure ?? fn ($model) => e($model->{$field});
+        $this->columns[$field] = $closure ?? fn ($model) => e(data_get($model, $field));
 
         return $this;
     }

--- a/src/PowerGridEloquent.php
+++ b/src/PowerGridEloquent.php
@@ -32,8 +32,7 @@ final class PowerGridEloquent
      */
     public function addColumn(string $field, Closure $closure = null): PowerGridEloquent
     {
-        /** @phpstan-ignore-next-line */
-        $this->columns[$field] = $closure ?? fn ($model) => e(data_get($model, $field));
+        $this->columns[$field] = $closure ?? fn ($model) => e(strval(data_get($model, $field)));
 
         return $this;
     }


### PR DESCRIPTION
I quite often to show relation data without needing to manipulate it, however i need to pass closure and return the relation data, for example:
```php
->addColumn('seller_name', function (Order $order) {
    return e($order->seller->name);
})
```

it would be nice if we could do something like
```php
->addColumn('seller.name')
```

this PR add the ability to use dot notation on `addColumn`