### PR TITLE
[FIX] Publish language file according to Laravel version

### DIFF
--- a/src/Providers/PowerGridServiceProvider.php
+++ b/src/Providers/PowerGridServiceProvider.php
@@ -67,9 +67,7 @@ class PowerGridServiceProvider extends ServiceProvider
             __DIR__ . '/../../resources/config/livewire-powergrid.php' => config_path($this->packageName . '.php'),
         ], 'livewire-powergrid-config');
 
-        $this->publishes([
-            __DIR__ . '/../../resources/lang' => resource_path('lang/vendor/' . $this->packageName),
-        ], $this->packageName . '-lang');
+        $this->publishes([__DIR__ . '/../../resources/lang' => lang_path('vendor/' . $this->packageName)], $this->packageName . '-lang');
     }
 
     private function createDirectives(): void

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -219,8 +219,8 @@ it('publishes views file', function () {
     File::delete($dirPath);
 });
 
-it('publishes lang file', function () {
-    $dirPath = getLaravelDir() . 'resources/lang/vendor/livewire-powergrid';
+it('publishes the language file in the lang path', function () {
+    $dirPath = lang_path('vendor/livewire-powergrid');
 
     File::delete($dirPath);
 


### PR DESCRIPTION
Hi Luan,

This PR is a reaction to the Issue https://github.com/Power-Components/livewire-powergrid/issues/372 and it makes PowerGrid publish the language file to Laravel's language path.

When running `php artisan vendor:publish --tag=livewire-powergrid-lang`:

Laravel 8x

```shell
Copied Directory [/vendor/power-components/livewire-powergrid/resources/lang] To [/resources/lang/vendor/livewire-powergrid]
Publishing complete
```


Laravel 9x

```shell
Copied Directory [/vendor/power-components/livewire-powergrid/resources/lang] To [/lang/vendor/livewire-powergrid]
Publishing complete.
```

Greetings and Thanks

