### PR TITLE
feat: add selectable/editable dropdown

### DIFF
--- a/resources/views/components/editable_dropdown.blade.php
+++ b/resources/views/components/editable_dropdown.blade.php
@@ -1,0 +1,30 @@
+@inject('helperClass','PowerComponents\LivewirePowerGrid\Helpers\Helpers')
+@props([
+'primaryKey' => null,
+'row' => null,
+'field' => null,
+'theme' => null,
+'currentTable' => null,
+'tableName' => null,
+'options' => []
+])
+<div x-cloak
+     x-data='pgEditable({
+       tableName: "{{ $tableName }}",
+       id: "{{ $row->{$primaryKey} }}",
+       dataField: "{{ $field }}",
+       content: "{{ $helperClass->resolveContent($currentTable, $field, $row) }}",
+       options: {!! json_encode($options) !!}
+             })'>
+    <div>
+        <select
+                class="{{ $theme->inputClass }} p-2"
+                x-on:change="save()"
+                x-ref="editable"
+                x-model="content">
+            @foreach($options as $key => $value)
+                <option value="{{ $key }}">{{ $value }}</option>
+            @endforeach
+        </select>
+    </div>
+</div>

--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -1,13 +1,13 @@
 @inject('helperClass','PowerComponents\LivewirePowerGrid\Helpers\Helpers')
 
 @props([
-    'theme' => null,
-    'row' => null,
-    'primaryKey' => null,
-    'columns' => null,
-    'currentTable' => null,
-    'tableName' => null,
-    'totalColumn' => null,
+'theme' => null,
+'row' => null,
+'primaryKey' => null,
+'columns' => null,
+'currentTable' => null,
+'tableName' => null,
+'totalColumn' => null,
 ])
 @foreach($columns as $column)
     @php
@@ -18,21 +18,34 @@
     <td class="{{ $theme->table->tdBodyClass . ' '.$column->bodyClass ?? '' }}"
         style="{{ $column->hidden === true ? 'display:none': '' }}; {{ $theme->table->tdBodyStyle . ' '.$column->bodyStyle ?? '' }}"
     >
+
         @if($column->editable === true && !str_contains($field, '.'))
             <span class="{{ $theme->clickToCopy->spanClass }}">
-                        <x-livewire-powergrid::editable
+                @if ($column->editableType === 'dropdown')
+                    <x-livewire-powergrid::editable_dropdown
+                            :tableName="$tableName"
+                            :primaryKey="$primaryKey"
+                            :currentTable="$currentTable"
+                            :row="$row"
+                            :options="$column->editableOptions"
+                            :theme="$theme->editable"
+                            :field="$field"/>
+                @else
+                    <x-livewire-powergrid::editable
                             :tableName="$tableName"
                             :primaryKey="$primaryKey"
                             :currentTable="$currentTable"
                             :row="$row"
                             :theme="$theme->editable"
                             :field="$field"/>
-                        @if($column->clickToCopy)
+                @endif
+
+                @if($column->clickToCopy)
                     <x-livewire-powergrid::click-to-copy
-                        :row="$row"
-                        :field="$content"
-                        :label="data_get($column->clickToCopy, 'label') ?? null"
-                        :enabled="data_get($column->clickToCopy, 'enabled') ?? false"/>
+                            :row="$row"
+                            :field="$content"
+                            :label="data_get($column->clickToCopy, 'label') ?? null"
+                            :enabled="data_get($column->clickToCopy, 'enabled') ?? false"/>
                 @endif
                 </span>
         @elseif(count($column->toggleable) > 0)
@@ -44,10 +57,10 @@
                     </div>
                     @if($column->clickToCopy)
                     <x-livewire-powergrid::click-to-copy
-                        :row="$row"
-                        :field="$content"
-                        :label="data_get($column->clickToCopy, 'label') ?? null"
-                        :enabled="data_get($column->clickToCopy, 'enabled') ?? false"/>
+                            :row="$row"
+                            :field="$content"
+                            :label="data_get($column->clickToCopy, 'label') ?? null"
+                            :enabled="data_get($column->clickToCopy, 'enabled') ?? false"/>
                 @endif
                 </span>
         @endif

--- a/src/Column.php
+++ b/src/Column.php
@@ -34,6 +34,10 @@ final class Column
 
     public bool $sortable = false;
 
+    public array $editableOptions = [];
+
+    public string $editableType = 'input';
+
     public array $sum = [
         'header' => false,
         'footer' => false,
@@ -335,6 +339,18 @@ final class Column
         if (filled($dataField)) {
             $this->dataField = $dataField;
         }
+
+        return $this;
+    }
+
+    /**
+     * @param array $options
+     */
+    public function editableDropdown(array $options = []): Column
+    {
+        $this->editableType = 'dropdown';
+
+        $this->editableOptions = $options;
 
         return $this;
     }


### PR DESCRIPTION
This feature allows to inline edit with a dropdown, to enable this you just need to call "editableDropdown" and pass available options with key and value. Like this example below.

```
   Column::add()
                ->title(__('Delivery Estimate'))
                ->field('delivery_estimate')
                ->sortable()
                ->editOnClick($canEdit)
                ->editableDropdown([
                    1 => 'Delivery Yesterday',
                    2 => 'Delivery Today',
                    3 => 'Delivery Tomorrow',
                ])
```