### PR TITLE
add searchableRaw

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -32,6 +32,8 @@ final class Column
 
     public bool $searchable = false;
 
+    public string $searchableRaw = '';
+
     public bool $sortable = false;
 
     public array $sum = [
@@ -118,11 +120,23 @@ final class Column
     /**
      * Makes the column searchable
      *
-     * @return Column
      */
     public function searchable(): Column
     {
         $this->searchable = true;
+
+        return $this;
+    }
+
+    /**
+     * Makes the column searchable with SQL Raw
+     *
+    */
+    public function searchableRaw(string $sql): Column
+    {
+        $this->searchable();
+
+        $this->searchableRaw = $sql;
 
         return $this;
     }

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -263,10 +263,8 @@ class Model implements ModelFilterInterface
 
                 /** @var Column $column */
                 foreach ($this->columns as $column) {
-                    /** @var string $searchable */
-                    $searchable = data_get($column, 'searchable');
-                    /** @var string $field */
-                    $field      = data_get($column, 'dataField') ?: data_get($column, 'field');
+                    $searchable = strval(data_get($column, 'searchable'));
+                    $field      = strval(data_get($column, 'dataField')) ?: strval(data_get($column, 'field'));
 
                     if ($searchable && $field) {
                         if (str_contains($field, '.')) {
@@ -281,6 +279,10 @@ class Model implements ModelFilterInterface
 
                         if ($hasColumn) {
                             $query->orWhere($table . '.' . $field, SqlSupport::like(), '%' . $this->search . '%');
+                        }
+
+                        if ($sqlRaw = strval(data_get($column, 'searchableRaw'))) {
+                            $query->orWhereRaw($sqlRaw . ' ' . SqlSupport::like() . ' "%' . $this->search . '%"');
                         }
                     }
                 }

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -282,7 +282,7 @@ class Model implements ModelFilterInterface
                         }
 
                         if ($sqlRaw = strval(data_get($column, 'searchableRaw'))) {
-                            $query->orWhereRaw($sqlRaw . ' ' . SqlSupport::like() . ' "%' . $this->search . '%"');
+                            $query->orWhereRaw($sqlRaw . ' ' . SqlSupport::like() . ' \'%' . $this->search . '%\'');
                         }
                     }
                 }

--- a/tests/DishesSearchableRawTable.php
+++ b/tests/DishesSearchableRawTable.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+use PowerComponents\LivewirePowerGrid\Tests\Models\Dish;
+use PowerComponents\LivewirePowerGrid\Traits\ActionButton;
+use PowerComponents\LivewirePowerGrid\{Column,
+    Footer,
+    Header,
+    PowerGrid,
+    PowerGridComponent,
+    PowerGridEloquent};
+
+class DishesSearchableRawTable extends PowerGridComponent
+{
+    use ActionButton;
+
+    public string $database = '';
+
+    public function setUp(): array
+    {
+        $this->showCheckBox();
+
+        return [
+            Header::make()
+                ->showSearchInput(),
+
+            Footer::make()
+                ->showPerPage()
+                ->showRecordCount(),
+        ];
+    }
+
+    public function datasource(): Builder
+    {
+        $searchableRaw  = match ($this->database) {
+            'sqlite' => 'STRFTIME("%d/%m/%Y", dishes.produced_at) as produced_at_formatted',
+            'mysql'  => 'DATE_FORMAT(dishes.produced_at, "%d/%m/%Y") as produced_at_formatted',
+            'pgsql'  => 'to_char(dishes.produced_at, \'DD/MM/YYYY\')::text as produced_at_formatted',
+            default  => ''
+        };
+
+        return Dish::query()
+            ->join('categories', function ($categories) {
+                $categories->on('dishes.category_id', '=', 'categories.id');
+            })
+            ->select('dishes.*', 'categories.name as category_name', DB::raw($searchableRaw));
+    }
+
+    public function addColumns(): PowerGridEloquent
+    {
+        return PowerGrid::eloquent()
+            ->addColumn('id')
+            ->addColumn('name')
+            ->addColumn('produced_at_formatted');
+    }
+
+    public function columns(): array
+    {
+        $searchableRaw  = match ($this->database) {
+            'sqlite' => 'STRFTIME("%d/%m/%Y", dishes.produced_at)',
+            'mysql'  => 'DATE_FORMAT(dishes.produced_at, "%d/%m/%Y")',
+            'pgsql'  => 'to_char(dishes.produced_at, \'DD/MM/YYYY\')::text',
+            default  => ''
+        };
+
+        return [
+            Column::make('ID', 'id')
+                ->searchable()
+                ->sortable(),
+
+            Column::make('Prato', 'name')
+                ->searchable()
+                ->editOnClick()
+                ->clickToCopy(true)
+                ->makeInputText('name')
+                ->placeholder('Prato placeholder')
+                ->sortable(),
+
+            Column::make('Produced At Formatted', 'produced_at_formatted')
+                ->searchableRaw($searchableRaw)
+                ->sortable(),
+        ];
+    }
+
+    public function bootstrap()
+    {
+        config(['livewire-powergrid.theme' => 'bootstrap']);
+    }
+
+    public function tailwind()
+    {
+        config(['livewire-powergrid.theme' => 'tailwind']);
+    }
+}

--- a/tests/Feature/SearchableRawTest.php
+++ b/tests/Feature/SearchableRawTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use function Pest\Livewire\livewire;
+
+it('searches data using whereRaw on sqlite', function (string $component, object $params) {
+    livewire($component, ['database' => 'sqlite'])
+        ->call($params->theme)
+        ->set('search', '09/09/2021')
+        ->assertSee('Polpetone Filé Mignon')
+        ->assertDontSee('Barco-Sushi Simples')
+        ->assertDontSee('No records found');
+})->with('searchable-raw')->requiresSQLite();
+
+it('searches data using whereRaw on mysql', function (string $component, object $params) {
+    livewire($component, ['database' => 'mysql'])
+        ->call($params->theme)
+        ->set('search', '09/09/2021')
+        ->assertSee('Polpetone Filé Mignon')
+        ->assertDontSee('Barco-Sushi Simples')
+        ->assertDontSee('No records found');
+})->with('searchable-raw')->requiresMySQL();
+
+it('searches data using whereRaw on pgsql', function (string $component, object $params) {
+    livewire($component, ['database' => 'pgsql'])
+        ->call($params->theme)
+        ->set('search', '09/09/2021')
+        ->assertSee('Polpetone Filé Mignon')
+        ->assertDontSee('Barco-Sushi Simples')
+        ->assertDontSee('No records found');
+})->with('searchable-raw')->requiresPostgreSQL();

--- a/tests/Feature/SearchableRawTest.php
+++ b/tests/Feature/SearchableRawTest.php
@@ -8,16 +8,31 @@ it('searches data using whereRaw on sqlite', function (string $component, object
         ->set('search', '09/09/2021')
         ->assertSee('Polpetone Filé Mignon')
         ->assertDontSee('Barco-Sushi Simples')
-        ->assertDontSee('No records found');
+        ->assertDontSee('No records found')
+        # 09/09/2022
+        ->set('search', '09/09/2022')
+        ->assertSee('No records found')
+        # 06/2026
+        ->set('search', '06/2026')
+        ->assertSee('Francesinha')
+        ->assertDontSee('Polpetone Filé Mignon');
 })->with('searchable-raw')->requiresSQLite();
 
 it('searches data using whereRaw on mysql', function (string $component, object $params) {
     livewire($component, ['database' => 'mysql'])
         ->call($params->theme)
+        ->call($params->theme)
         ->set('search', '09/09/2021')
         ->assertSee('Polpetone Filé Mignon')
         ->assertDontSee('Barco-Sushi Simples')
-        ->assertDontSee('No records found');
+        ->assertDontSee('No records found')
+        # 09/09/2022
+        ->set('search', '09/09/2022')
+        ->assertSee('No records found')
+        # 06/2026
+        ->set('search', '06/2026')
+        ->assertSee('Francesinha')
+        ->assertDontSee('Polpetone Filé Mignon');
 })->with('searchable-raw')->requiresMySQL();
 
 it('searches data using whereRaw on pgsql', function (string $component, object $params) {
@@ -26,5 +41,12 @@ it('searches data using whereRaw on pgsql', function (string $component, object 
         ->set('search', '09/09/2021')
         ->assertSee('Polpetone Filé Mignon')
         ->assertDontSee('Barco-Sushi Simples')
-        ->assertDontSee('No records found');
+        ->assertDontSee('No records found')
+        # 09/09/2022
+        ->set('search', '09/09/2022')
+        ->assertSee('No records found')
+        # 06/2026
+        ->set('search', '06/2026')
+        ->assertSee('Francesinha')
+        ->assertDontSee('Polpetone Filé Mignon');
 })->with('searchable-raw')->requiresPostgreSQL();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,22 +1,21 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Pest\PendingObjects\TestCall;
 use PowerComponents\LivewirePowerGrid\Tests\Models\Dish;
 use PowerComponents\LivewirePowerGrid\Tests\TestCase;
-use PowerComponents\LivewirePowerGrid\{
-    Column,
+use PowerComponents\LivewirePowerGrid\{Column,
     PowerGridComponent,
     Tests\DishesActionRulesTable,
     Tests\DishesActionTable,
     Tests\DishesCalculationsTable,
     Tests\DishesCollectionTable,
-    Tests\DishesDetailRowTable,
     Tests\DishesEnumTable,
     Tests\DishesMakeTable,
+    Tests\DishesSearchableRawTable,
     Tests\DishesTable,
-    Tests\DishesTableWithJoin
-};
+    Tests\DishesTableWithJoin};
 
 uses(TestCase::class)->in(__DIR__);
 
@@ -47,7 +46,6 @@ function powergrid(): PowerGridComponent
     $component             = new PowerGridComponent(1);
     $component->datasource = Dish::query();
     $component->columns    = $columns;
-    $component->perPage    = 10;
 
     return $component;
 }
@@ -163,6 +161,11 @@ dataset('themes with collection table', [
     [DishesCollectionTable::class, 'bootstrap'],
 ]);
 
+dataset('searchable-raw', [
+    'tailwind'  => [DishesSearchableRawTable::class, (object) ['theme' => 'tailwind']],
+    'bootstrap' => [DishesSearchableRawTable::class, (object) ['theme' => 'bootstrap']],
+]);
+
 /**
  * Skip tests based on minimum PHP Version
  *
@@ -173,6 +176,33 @@ function onlyFromPhp(string $version): mixed
 {
     if (version_compare(PHP_VERSION, $version, '<')) {
         test()->markTestSkipped('This test requires PHP ' . $version);
+    }
+
+    return test();
+}
+
+function requiresMySQL()
+{
+    if (DB::getDriverName() !== 'mysql') {
+        test()->markTestSkipped('This test requires MySQL database');
+    }
+
+    return test();
+}
+
+function requiresSQLite()
+{
+    if (DB::getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('This test requires SQLite database');
+    }
+
+    return test();
+}
+
+function requiresPostgreSQL()
+{
+    if (DB::getDriverName() !== 'pgsql') {
+        test()->markTestSkipped('This test requires PostgreSQL database');
     }
 
     return test();


### PR DESCRIPTION
This PR allows you to add a sql string to do custom searches with `whereRaw`

https://github.com/Power-Components/livewire-powergrid/issues/443

```php
public function datasource()
{
     $searchableRaw  = match ($this->database) {
            'sqlite' => 'STRFTIME("%d/%m/%Y", dishes.produced_at) as produced_at_formatted',
            'mysql'  => 'DATE_FORMAT(dishes.produced_at, "%d/%m/%Y") as produced_at_formatted',
            'pgsql'  => 'to_char(dishes.produced_at, \'DD/MM/YYYY\')::text as produced_at_formatted',
            default  => ''
     };

     return Dish::query()
          ->join('categories', function ($categories) {
              $categories->on('dishes.category_id', '=', 'categories.id');
          })
          ->select('dishes.*', 'categories.name as category_name', DB::raw($searchableRaw));
}

 /// ...
public function columns(): array
{
       $searchableRaw  = match ($this->database) {
            'sqlite' => 'STRFTIME("%d/%m/%Y", dishes.produced_at)',
            'mysql'  => 'DATE_FORMAT(dishes.produced_at, "%d/%m/%Y")',
            'pgsql'  => 'to_char(dishes.produced_at, \'DD/MM/YYYY\')::text',
            default  => ''
        };

        return [
            Column::add()
                ->title('Produced At Formatted')
                ->field('produced_at_formatted')
                ->searchableRaw($searchableRaw)
                ->sortable(),
        ];
}
```