### PR TITLE
Allow multiple attributes in action rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "pestphp/pest-plugin-faker": "^1.0",
         "pestphp/pest-plugin-livewire": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.2",
-        "nunomaduro/larastan": "^1.0 | ^2.1"
+        "nunomaduro/larastan": "^1.0 | ^2.1",
+        "laradumps/laradumps": "^0.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5105b3c5fd4f80ee63e2ff11574614c4",
+    "content-hash": "009ae145f8d6268dc924335e181fe329",
     "packages": [
         {
             "name": "brick/math",
@@ -6073,6 +6073,66 @@
             "time": "2022-04-13T08:02:27+00:00"
         },
         {
+            "name": "laradumps/laradumps",
+            "version": "v0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laradumps/laradumps.git",
+                "reference": "304df290675baf5f79fa40601243476ca1c46085"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laradumps/laradumps/zipball/304df290675baf5f79fa40601243476ca1c46085",
+                "reference": "304df290675baf5f79fa40601243476ca1c46085",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.8",
+                "illuminate/support": "^8.18 | ^9.0",
+                "nunomaduro/larastan": "^1.0 | ^2.1",
+                "orchestra/testbench": "^6.17 | ^7.0",
+                "pestphp/pest": "^1.21",
+                "symfony/var-dumper": "^5.4 | ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "LaraDumps\\LaraDumps\\LaraDumpsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LaraDumps\\LaraDumps\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luan Freitas",
+                    "email": "luanfreitas10@protonmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Dump Component for Laravel.",
+            "homepage": "https://github.com/laradumps/laradumps",
+            "support": {
+                "issues": "https://github.com/laradumps/laradumps/issues",
+                "source": "https://github.com/laradumps/laradumps/tree/v0.1.2"
+            },
+            "time": "2022-06-21T16:44:14+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.5.0",
             "source": {
@@ -10193,5 +10253,5 @@
         "php": "^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -28,10 +28,12 @@ class Helpers
         $parameters = [];
 
         foreach ($params as $param => $value) {
-            if ($row && filled($row->{$value})) {
-                $parameters[$param] = $row->{$value};
-            } else {
-                $parameters[$param] = $value;
+            if (is_string($value)) {
+                if ($row && filled($row->{$value})) {
+                    $parameters[$param] = $row->{$value};
+                } else {
+                    $parameters[$param] = $value;
+                }
             }
         }
 

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -28,12 +28,10 @@ class Helpers
         $parameters = [];
 
         foreach ($params as $param => $value) {
-            if (is_string($value)) {
-                if ($row && filled($row->{$value})) {
-                    $parameters[$param] = $row->{$value};
-                } else {
-                    $parameters[$param] = $value;
-                }
+            if ($row && filled($row->{$value})) {
+                $parameters[$param] = $row->{$value};
+            } else {
+                $parameters[$param] = $value;
             }
         }
 

--- a/src/Rules/RuleActions.php
+++ b/src/Rules/RuleActions.php
@@ -57,9 +57,9 @@ class RuleActions
     /**
      * Sets the button's given attribute to the given value.
      */
-    public function setAttribute(string $attribute = null, string $value = null): RuleActions
+    public function setAttribute(string $attribute = null, string|array $value = null): RuleActions
     {
-        $this->rule['setAttribute'] = [
+        $this->rule['setAttribute'][] = [
             'attribute' => $attribute,
             'value'     => $value,
         ];

--- a/tests/DishesActionRulesTable.php
+++ b/tests/DishesActionRulesTable.php
@@ -152,6 +152,12 @@ class DishesActionRulesTable extends PowerGridComponent
             Rule::button('edit-stock-for-rules')
                 ->when(fn (Dish $dish) => $dish->id == 10)
                 ->bladeComponent('livewire-powergrid::icons.arrow', ['dish-id' => 'id']),
+
+            Rule::button('edit-stock-for-rules')
+                ->when(fn (Dish $dish) => (bool) $dish->id == 11)
+                ->setAttribute('class', 'bg-custom-300')
+                ->setAttribute('title', 'Title changed by setAttributes')
+                ->setAttribute('wire:click', ['test', ['param1' => 1, 'dishId' => 'id']]),
         ];
     }
 

--- a/tests/Feature/ActionRulesTest.php
+++ b/tests/Feature/ActionRulesTest.php
@@ -115,3 +115,12 @@ it('add rule \'bladeComponent\' when dish-id == 10', function (string $component
         ->assertSeeHtml('<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />')
         ->assertDontSeeHtml('<svg dish-id="1"');
 })->with('rules');
+
+it('add many \'setAttributes\' when dish-id == 11', function (string $component, object $params) {
+    livewire($component, ['join' => $params->join])
+        ->call($params->theme)
+        ->set('search', 'Bife à Parmegiana')
+        ->assertSee('class="text-center bg-custom-300"', false)
+        ->assertSee('title="Title changed by setAttributes"', false)
+        ->assertSee('wire:click="test({&quot;dishId&quot;:11})', false);
+})->with('rules')->only();

--- a/tests/Feature/ActionRulesTest.php
+++ b/tests/Feature/ActionRulesTest.php
@@ -61,7 +61,7 @@ it('add rule \'disable\' when dishId == 9', function (string $component, object 
         ->assertSeeHtmlInOrder([
             '<a',
             'disabled',
-            'class="text-center"',
+            'class="text-center bg-custom-300"',
         ]);
 })->with('rules');
 

--- a/tests/Feature/ActionRulesTest.php
+++ b/tests/Feature/ActionRulesTest.php
@@ -122,5 +122,5 @@ it('add many \'setAttributes\' when dish-id == 11', function (string $component,
         ->set('search', 'Bife à Parmegiana')
         ->assertSee('class="text-center bg-custom-300"', false)
         ->assertSee('title="Title changed by setAttributes"', false)
-        ->assertSee('wire:click="test({&quot;dishId&quot;:11})', false);
-})->with('rules')->only();
+        ->assertSee('wire:click="test({&quot;param1&quot;:1,&quot;dishId&quot;:11})"', false);
+})->with('rules');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace PowerComponents\LivewirePowerGrid\Tests;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\File;
+use LaraDumps\LaraDumps\LaraDumpsServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use PowerComponents\LivewirePowerGrid\Providers\PowerGridServiceProvider;
@@ -68,6 +69,7 @@ class TestCase extends BaseTestCase
         return [
             LivewireServiceProvider::class,
             PowerGridServiceProvider::class,
+            LaraDumpsServiceProvider::class,
         ];
     }
 }


### PR DESCRIPTION
This change lets you add multiple `setAttribute` when using **Rule::buttons**

```php
 Rule::button('edit')
           ->when(fn ($dish) => $dish->id == 2)
           ->setAttribute('class', 'bg-green-200')
           ->setAttribute('wire:click', ['test' , ['param1' => 1, 'dishId' => 'id']]),
```

```blade
<button title="" 
        class="bg-indigo-500 cursor-pointer text-white px-3 py-2 m-1 rounded text-sm bg-green-200" 
        wire:click="test({"param1":1,"dishId":2})">
        Edit
</button>
```