### PR TITLE
Allow html input for column titles

### DIFF
--- a/resources/views/components/cols.blade.php
+++ b/resources/views/components/cols.blade.php
@@ -30,6 +30,6 @@
                 @endif
 					</span>
         @endif
-        <span>{{ $column->title }}</span>
+        <span>{!! $column->title !!}</span>
     </div>
 </th>


### PR DESCRIPTION
This PR provides an enhancement of allowing column titles to be html. As discussed in the discussion #516, this will allow column titles to be icons as well. Since the column titles are set by developers, allowing unescaped characters should not be a security risk.