### PR TITLE
Fix test output

### DIFF
--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -199,7 +199,7 @@ it('publishes config file', function () {
     File::delete($configFilePath);
 
     $this->artisan('vendor:publish --tag=livewire-powergrid-config')
-        ->expectsOutput('Publishing complete.');
+        ->assertExitCode(0);
 
     $this->assertFileExists($configFilePath);
 
@@ -212,7 +212,7 @@ it('publishes views file', function () {
     File::delete($dirPath);
 
     $this->artisan('vendor:publish --tag=livewire-powergrid-views')
-        ->expectsOutput('Publishing complete.');
+        ->assertExitCode(0);
 
     $this->assertDirectoryExists($dirPath);
 
@@ -225,7 +225,7 @@ it('publishes the language file in the lang path', function () {
     File::delete($dirPath);
 
     $this->artisan('vendor:publish --tag=livewire-powergrid-lang')
-        ->expectsOutput('Publishing complete.');
+        ->assertExitCode(0);
 
     $this->assertDirectoryExists($dirPath);
 


### PR DESCRIPTION
Hi Luan,

The Fresh Look Artisan change in [Laravel v9.21.0](https://github.com/laravel/framewrk/releases/tag/v9.21.0) no longers output `Publishing complete.`

Since the file is deleted before the test, I believe it is enough to test that the command ran successfully, and the file exists.

```php
    $this->artisan('vendor:publish --tag=livewire-powergrid-views')
        ->assertExitCode(0);

    $this->assertDirectoryExists($dirPath);
```

Thanks
