### PR TITLE
Toggle columns output html for Column Title

### DIFF
--- a/resources/views/components/frameworks/bootstrap5/header/toggle-columns.blade.php
+++ b/resources/views/components/frameworks/bootstrap5/header/toggle-columns.blade.php
@@ -19,7 +19,7 @@
                             @else
                                 <x-livewire-powergrid::icons.eye-off width="20"/>
                             @endif
-                            {{ $column->title }}
+                            {!! $column->title !!}
                         </a>
                     </li>
                 @endif

--- a/resources/views/components/frameworks/tailwind/header/toggle-columns.blade.php
+++ b/resources/views/components/frameworks/tailwind/header/toggle-columns.blade.php
@@ -32,7 +32,7 @@
                         <x-livewire-powergrid::icons.eye-off class="text-slate-500 dark:text-slate-300"/>
                     @endif
                     <div class="ml-2">
-                        {{ $column->title }}
+                        {!! $column->title !!}
                     </div>
                 </div>
                 @endif


### PR DESCRIPTION
This PR fixes a side effect of PR #517. PR #517 allowed html output of column title. However, the column title field was still escaped in the toggle-columns. This PR allows unescaped characters for both Bootstrap and Tailwind in the `toggle-columns.blade.php` files.