### PR TITLE
Using simplePaginate to avoid SELECT COUNT(*) #475

### DIFF
--- a/resources/views/components/frameworks/bootstrap5/pagination.blade.php
+++ b/resources/views/components/frameworks/bootstrap5/pagination.blade.php
@@ -1,73 +1,145 @@
 <div class="d-flex flex-column flex-lg-row align-items-sm-center justify-content-between">
-@if($recordCount === 'full')
-    <small class="text-muted d-block mb-2 my-md-2 me-1">
-        {{ trans('livewire-powergrid::datatable.pagination.showing') }}
-        <span class="font-semibold">{{ $paginator->firstItem() }}</span>
-        {{ trans('livewire-powergrid::datatable.pagination.to') }}
-        <span class="font-semibold">{{ $paginator->lastItem() }}</span>
-        {{ trans('livewire-powergrid::datatable.pagination.of') }}
-        <span class="font-semibold">{{ $paginator->total() }}</span>
-        {{ trans('livewire-powergrid::datatable.pagination.results') }}
-    </small>
-@elseif($recordCount === 'short')
-    <small class="text-muted d-block mb-2 my-md-2 me-1">
-        <span class="font-semibold"> {{ $paginator->firstItem() }}</span>
-        -
-        <span class="font-semibold"> {{ $paginator->lastItem() }}</span>
-        |
-        <span class="font-semibold"> {{ $paginator->total() }}</span>
-    </small>
-@elseif($recordCount === 'min')
-    <small class="text-muted d-block mb-2 my-md-2 me-1">
-        <span class="font-semibold"> {{ $paginator->firstItem() }}</span>
-        -
-        <span class="font-semibold"> {{ $paginator->lastItem() }}</span>
-    </small>
-@endif
-@if ($paginator->hasPages())
-    <nav>
-        <ul class="pagination mb-0 ms-0 ms-sm-1">
-            {{-- Previous Page Link --}}
-            @if ($paginator->onFirstPage())
-                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
-                    <span class="page-link" aria-hidden="true">&lsaquo;</span>
-                </li>
-            @else
-                <li class="page-item">
-                    <button type="button" dusk="previousPage" class="page-link" wire:click="previousPage" wire:loading.attr="disabled" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</button>
-                </li>
-            @endif
+    @if($recordCount === 'full')
+        <small class="text-muted d-block mb-2 my-md-2 me-1">
+            {{ trans('livewire-powergrid::datatable.pagination.showing') }}
+            <span class="font-semibold">{{ $paginator->firstItem() }}</span>
+            {{ trans('livewire-powergrid::datatable.pagination.to') }}
+            <span class="font-semibold">{{ $paginator->lastItem() }}</span>
+            {{ trans('livewire-powergrid::datatable.pagination.of') }}
+            <span class="font-semibold">{{ $paginator->total() }}</span>
+            {{ trans('livewire-powergrid::datatable.pagination.results') }}
+        </small>
+    @elseif($recordCount === 'short')
+        <small class="text-muted d-block mb-2 my-md-2 me-1">
+            <span class="font-semibold"> {{ $paginator->firstItem() }}</span>
+            -
+            <span class="font-semibold"> {{ $paginator->lastItem() }}</span>
+            |
+            <span class="font-semibold"> {{ $paginator->total() }}</span>
+        </small>
+    @elseif($recordCount === 'min')
+        <small class="text-muted d-block mb-2 my-md-2 me-1">
+            <span class="font-semibold"> {{ $paginator->firstItem() }}</span>
+            -
+            <span class="font-semibold"> {{ $paginator->lastItem() }}</span>
+        </small>
+    @endif
 
-            {{-- Pagination Elements --}}
-            @foreach ($elements as $element)
-                {{-- "Three Dots" Separator --}}
-                @if (is_string($element))
-                    <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+    @if ($paginator->hasPages() && $recordCount != 'min')
+        <nav>
+            <ul class="pagination mb-0 ms-0 ms-sm-1">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                    <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                        <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                    </li>
+                @else
+                    <li class="page-item">
+                        <button type="button" class="page-link" wire:click="previousPage"
+                                wire:loading.attr="disabled" rel="prev" aria-label="@lang('pagination.previous')">
+                            &lsaquo;
+                        </button>
+                    </li>
                 @endif
 
-                {{-- Array Of Links --}}
-                @if (is_array($element))
-                    @foreach ($element as $page => $url)
-                        @if ($page == $paginator->currentPage())
-                            <li class="page-item active" wire:key="paginator-page-{{ $page }}" aria-current="page"><span class="page-link">{{ $page }}</span></li>
-                        @else
-                            <li class="page-item" wire:key="paginator-page-{{ $page }}"><button type="button" class="page-link" wire:click="gotoPage({{ $page }})">{{ $page }}</button></li>
-                        @endif
-                    @endforeach
-                @endif
-            @endforeach
+                {{-- Pagination Elements --}}
+                @foreach ($elements as $element)
+                    {{-- "Three Dots" Separator --}}
+                    @if (is_string($element))
+                        <li class="page-item disabled" aria-disabled="true"><span
+                                class="page-link">{{ $element }}</span></li>
+                    @endif
 
-            {{-- Next Page Link --}}
-            @if ($paginator->hasMorePages())
-                <li class="page-item">
-                    <button type="button" dusk="nextPage" class="page-link" wire:click="nextPage" wire:loading.attr="disabled" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</button>
-                </li>
-            @else
-                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
-                    <span class="page-link" aria-hidden="true">&rsaquo;</span>
-                </li>
-            @endif
-        </ul>
-    </nav>
-@endif
+                    {{-- Array Of Links --}}
+                    @if (is_array($element))
+                        @foreach ($element as $page => $url)
+                            @if ($page == $paginator->currentPage())
+                                <li class="page-item active" wire:key="paginator-page-{{ $page }}" aria-current="page">
+                                    <span class="page-link">{{ $page }}</span></li>
+                            @else
+                                <li class="page-item" wire:key="paginator-page-{{ $page }}">
+                                    <button type="button" class="page-link"
+                                            wire:click="gotoPage({{ $page }})">{{ $page }}</button>
+                                </li>
+                            @endif
+                        @endforeach
+                    @endif
+                @endforeach
+
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                    <li class="page-item">
+                        <button type="button" class="page-link" wire:click="nextPage"
+                                wire:loading.attr="disabled" rel="next" aria-label="@lang('pagination.next')">&rsaquo;
+                        </button>
+                    </li>
+                @else
+                    <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                        <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                    </li>
+                @endif
+            </ul>
+        </nav>
+    @endif
+
+    @if ($paginator->hasPages() && $recordCount == 'min')
+        <nav>
+            <ul class="pagination mb-0 ms-0 ms-sm-1">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                    <li class="page-item disabled">
+                        <button type="button" class="page-link"
+                                rel="prev" aria-label="@lang('pagination.previous')">
+                            &lsaquo;
+                        </button>
+                    </li>
+                @else
+                    @if(method_exists($paginator,'getCursorName'))
+                        <li class="page-item">
+                            <button type="button" class="page-link"
+                                    wire:click="setPage('{{$paginator->previousCursor()->encode()}}','{{ $paginator->getCursorName() }}')"
+                                    wire:loading.attr="disabled"
+                                    rel="prev" aria-label="@lang('pagination.previous')">
+                                &lsaquo;
+                            </button>
+                        </li>
+                    @else
+                        <li class="page-item">
+                            <button type="button" class="page-link"
+                                    wire:click="previousPage('{{ $paginator->getPageName() }}')"
+                                    wire:loading.attr="disabled"
+                                    rel="prev" aria-label="@lang('pagination.previous')">
+                                &lsaquo;
+                            </button>
+                        </li>
+                    @endif
+                @endif
+
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                    @if(method_exists($paginator,'getCursorName'))
+                        <li class="page-item">
+                            <button type="button" class="page-link"
+                                    wire:click="setPage('{{$paginator->nextCursor()->encode()}}','{{ $paginator->getCursorName() }}')"
+                                    wire:loading.attr="disabled" rel="next" aria-label="@lang('pagination.next')">&rsaquo;
+                            </button>
+                        </li>
+                    @else
+                        <li class="page-item">
+                            <button type="button" class="page-link"
+                                    wire:click="nextPage('{{ $paginator->getPageName() }}')"
+                                    wire:loading.attr="disabled" rel="next" aria-label="@lang('pagination.next')">&rsaquo;
+                            </button>
+                        </li>
+                    @endif
+                @else
+                    <li class="page-item disabled">
+                        <button type="button" class="page-link"
+                                rel="next" aria-label="@lang('pagination.next')">&rsaquo;
+                        </button>
+                    </li>
+                @endif
+            </ul>
+        </nav>
+    @endif
 </div>

--- a/resources/views/components/frameworks/tailwind/pagination.blade.php
+++ b/resources/views/components/frameworks/tailwind/pagination.blade.php
@@ -33,27 +33,25 @@
             </div>
         @endif
 
-        @if ($paginator->hasPages())
+        @if ($paginator->hasPages() && $recordCount != 'min')
             <nav role="navigation" aria-label="Pagination Navigation" class="items-center justify-between sm:flex">
                 <div class="flex justify-center mt-2 md:flex-none md:justify-end sm:mt-0">
 
                     @if(!$paginator->onFirstPage())
-
                         <a
                             class="px-2 py-1 pt-2 m-1 text-center text-white bg-slate-500 border-slate-400 rounded cursor-pointer border-1 hover:bg-slate-600 hover:border-slate-800 dark:text-slate-300"
                             wire:click="gotoPage(1)"
                         >
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-double-left" viewBox="0 0 16 16">
-                                <path fill-rule="evenodd" d="M8.354 1.646a.5.5 0 0 1 0 .708L2.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
-                                <path fill-rule="evenodd" d="M12.354 1.646a.5.5 0 0 1 0 .708L6.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
-                            </svg>
+                            <x-livewire-powergrid::icons.chevron-double-left/>
                         </a>
 
                         <a class="px-2 py-1 pt-2 m-1 text-center text-white bg-slate-500 border-slate-400 rounded cursor-pointer border-1 hover:bg-slate-600 hover:border-slate-800 dark:text-slate-300"
                            wire:click="previousPage"
                            rel="next">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-compact-left" viewBox="0 0 16 16">
-                                <path fill-rule="evenodd" d="M9.224 1.553a.5.5 0 0 1 .223.67L6.56 8l2.888 5.776a.5.5 0 1 1-.894.448l-3-6a.5.5 0 0 1 0-.448l3-6a.5.5 0 0 1 .67-.223z"/>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                                 class="bi bi-chevron-compact-left" viewBox="0 0 16 16">
+                                <path fill-rule="evenodd"
+                                      d="M9.224 1.553a.5.5 0 0 1 .223.67L6.56 8l2.888 5.776a.5.5 0 1 1-.894.448l-3-6a.5.5 0 0 1 0-.448l3-6a.5.5 0 0 1 .67-.223z"/>
                             </svg>
                         </a>
 
@@ -97,22 +95,79 @@
                             <a class="px-2 py-1 pt-2 m-1 text-center text-white bg-slate-500 border-slate-400 rounded cursor-pointer border-1 hover:bg-slate-600 hover:border-slate-800 dark:text-slate-300"
                                wire:click="nextPage"
                                rel="next">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-compact-right" viewBox="0 0 16 16">
-                                    <path fill-rule="evenodd" d="M6.776 1.553a.5.5 0 0 1 .671.223l3 6a.5.5 0 0 1 0 .448l-3 6a.5.5 0 1 1-.894-.448L9.44 8 6.553 2.224a.5.5 0 0 1 .223-.671z"/>
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                                     class="bi bi-chevron-compact-right" viewBox="0 0 16 16">
+                                    <path fill-rule="evenodd"
+                                          d="M6.776 1.553a.5.5 0 0 1 .671.223l3 6a.5.5 0 0 1 0 .448l-3 6a.5.5 0 1 1-.894-.448L9.44 8 6.553 2.224a.5.5 0 0 1 .223-.671z"/>
                                 </svg>
                             </a>
                         @endif
                         <a class="px-2 py-1 pt-2 m-1 text-center text-white bg-slate-500 border-slate-400 rounded cursor-pointer border-1 hover:bg-slate-600 hover:border-slate-800 dark:text-slate-300"
-                            wire:click="gotoPage({{ $paginator->lastPage() }})"
+                           wire:click="gotoPage({{ $paginator->lastPage() }})"
                         >
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-double-right" viewBox="0 0 16 16">
-                                <path fill-rule="evenodd" d="M3.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L9.293 8 3.646 2.354a.5.5 0 0 1 0-.708z"/>
-                                <path fill-rule="evenodd" d="M7.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L13.293 8 7.646 2.354a.5.5 0 0 1 0-.708z"/>
-                            </svg>
+                            <x-livewire-powergrid::icons.chevron-double-right/>
                         </a>
                     @endif
                 </div>
             </nav>
         @endif
+
+        <div>
+            @if ($paginator->hasPages() && $recordCount == 'min')
+                <nav role="navigation" aria-label="Pagination Navigation" class="items-center justify-between sm:flex">
+                    <div class="flex justify-center mt-2 md:flex-none md:justify-end sm:mt-0">
+                    <span>
+                        {{-- Previous Page Link Disabled --}}
+                        @if ($paginator->onFirstPage())
+                            <button disabled
+                                    class="p-2 m-1 text-center text-slate-400 bg-slate-200 border-slate-400 rounded border-1 dark:text-slate-300">
+                                <x-livewire-powergrid::icons.chevron-double-left/>
+                            </button>
+                        @else
+                            @if(method_exists($paginator,'getCursorName'))
+                                <button
+                                    wire:click="setPage('{{$paginator->previousCursor()->encode()}}','{{ $paginator->getCursorName() }}')"
+                                    wire:loading.attr="disabled"
+                                    class="p-2 m-1 text-center text-white bg-slate-500 border-slate-400 rounded cursor-pointer border-1 hover:bg-slate-600 hover:border-slate-800 dark:text-slate-300">
+                                        <x-livewire-powergrid::icons.chevron-double-left/>
+                                </button>
+                            @else
+                                <button wire:click="previousPage('{{ $paginator->getPageName() }}')"
+                                        wire:loading.attr="disabled"
+                                        class="p-2 m-1 text-center text-white bg-slate-500 border-slate-400 rounded cursor-pointer border-1 hover:bg-slate-600 hover:border-slate-800 dark:text-slate-300">
+                                        <x-livewire-powergrid::icons.chevron-double-left/>
+                                </button>
+                            @endif
+                        @endif
+                    </span>
+
+                        <span>
+                        {{-- Next Page Link --}}
+                            @if ($paginator->hasMorePages())
+                                @if(method_exists($paginator,'getCursorName'))
+                                    <button
+                                        wire:click="setPage('{{$paginator->nextCursor()->encode()}}','{{ $paginator->getCursorName() }}')"
+                                        wire:loading.attr="disabled"
+                                        class="p-2 m-1 text-center text-white bg-slate-500 border-slate-400 rounded cursor-pointer border-1 hover:bg-slate-600 hover:border-slate-800 dark:text-slate-300">
+                                        <x-livewire-powergrid::icons.chevron-double-right/>
+                                </button>
+                                @else
+                                    <button wire:click="nextPage('{{ $paginator->getPageName() }}')"
+                                            wire:loading.attr="disabled"
+                                            class="p-2 m-1 text-center text-white bg-slate-500 border-slate-400 rounded cursor-pointer border-1 hover:bg-slate-600 hover:border-slate-800 dark:text-slate-300">
+                                        <x-livewire-powergrid::icons.chevron-double-right/>
+                                </button>
+                                @endif
+                            @else
+                                <button disabled
+                                        class="p-2 m-1 text-center text-slate-400 bg-slate-200 border-slate-400 rounded border-1 dark:text-slate-300">
+                                 <x-livewire-powergrid::icons.chevron-double-right/>
+                             </button>
+                            @endif
+                    </span>
+                    </div>
+                </nav>
+            @endif
+        </div>
     </div>
 </div>

--- a/resources/views/components/icons/chevron-double-left.blade.php
+++ b/resources/views/components/icons/chevron-double-left.blade.php
@@ -1,0 +1,7 @@
+<svg width="16" height="16" fill="currentColor"
+     class="bi bi-chevron-double-left" viewBox="0 0 16 16">
+    <path fill-rule="evenodd"
+          d="M8.354 1.646a.5.5 0 0 1 0 .708L2.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
+    <path fill-rule="evenodd"
+          d="M12.354 1.646a.5.5 0 0 1 0 .708L6.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
+</svg>

--- a/resources/views/components/icons/chevron-double-right.blade.php
+++ b/resources/views/components/icons/chevron-double-right.blade.php
@@ -1,0 +1,7 @@
+<svg width="16" height="16" fill="currentColor"
+     class="bi bi-chevron-double-right" viewBox="0 0 16 16">
+    <path fill-rule="evenodd"
+          d="M3.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L9.293 8 3.646 2.354a.5.5 0 0 1 0-.708z"/>
+    <path fill-rule="evenodd"
+          d="M7.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L13.293 8 7.646 2.354a.5.5 0 0 1 0-.708z"/>
+</svg>


### PR DESCRIPTION
This Pr changes the pagination display type to simplePaginate when we use recourdCount 'min'.

discussed in: https://github.com/Power-Components/livewire-powergrid/discussions/475

```php
Footer::make()
        ->showPerPage()
        ->showRecordCount('min'),
```

![image](https://user-images.githubusercontent.com/33601626/182041850-36398f66-b460-4deb-9550-5ab3262acf42.png)


