### PR TITLE
Fix for issue #538 - removes duplicate queries for column checking

### DIFF
--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -261,7 +261,7 @@ class Model implements ModelFilterInterface
         if ($this->search != '') {
             $this->query = $this->query->where(function (Builder $query) {
                 $table   = $query->getModel()->getTable();
-                $columnList = Cache::remember('powergrid_columns_in_' . $table, 600, fn() => Schema::getColumnListing($table));
+                $columnList = Cache::remember('powergrid_columns_in_' . $table, 600, fn () => Schema::getColumnListing($table));
 
                 /** @var Column $column */
                 foreach ($this->columns as $column) {

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -4,8 +4,7 @@ namespace PowerComponents\LivewirePowerGrid\Helpers;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\{Cache,Schema};
 use Illuminate\Support\Str;
 use PowerComponents\LivewirePowerGrid\Column;
 use PowerComponents\LivewirePowerGrid\Services\Contracts\ModelFilterInterface;
@@ -261,7 +260,9 @@ class Model implements ModelFilterInterface
         if ($this->search != '') {
             $this->query = $this->query->where(function (Builder $query) {
                 $table   = $query->getModel()->getTable();
-                $columnList = Cache::remember('powergrid_columns_in_' . $table, 600, fn () => Schema::getColumnListing($table));
+                $columnList = Cache::remember('powergrid_columns_in_' . $table, 600, function () {
+                    return Schema::getColumnListing($table);
+                });
 
                 /** @var Column $column */
                 foreach ($this->columns as $column) {

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -260,7 +260,7 @@ class Model implements ModelFilterInterface
         if ($this->search != '') {
             $this->query = $this->query->where(function (Builder $query) {
                 $table   = $query->getModel()->getTable();
-                $columnList = Cache::remember('powergrid_columns_in_' . $table, 600, function () {
+                $columnList = Cache::remember('powergrid_columns_in_' . $table, 600, function () use ($table) {
                     return Schema::getColumnListing($table);
                 });
 

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -260,7 +260,7 @@ class Model implements ModelFilterInterface
         if ($this->search != '') {
             $this->query    = $this->query->where(function (Builder $query) {
                 $table      = $query->getModel()->getTable();
-                $columnList = Cache::remember('powergrid_columns_in_' . $table, 600, function () use ($table) {
+                $columnList = (array) Cache::remember('powergrid_columns_in_' . $table, 600, function () use ($table) {
                     return Schema::getColumnListing($table);
                 });
 

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -4,6 +4,7 @@ namespace PowerComponents\LivewirePowerGrid\Helpers;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use PowerComponents\LivewirePowerGrid\Column;
@@ -260,6 +261,7 @@ class Model implements ModelFilterInterface
         if ($this->search != '') {
             $this->query = $this->query->where(function (Builder $query) {
                 $table   = $query->getModel()->getTable();
+                $columnList = Cache::remember('columns_in_' . $table, 600, fn() => Schema::getColumnListing($table));
 
                 /** @var Column $column */
                 foreach ($this->columns as $column) {
@@ -275,7 +277,7 @@ class Model implements ModelFilterInterface
                             $field        = $explodeField->get(1);
                         }
 
-                        $hasColumn = Schema::hasColumn($table, $field);
+                        $hasColumn = in_array($field, $columnList, true);
 
                         if ($hasColumn) {
                             $query->orWhere($table . '.' . $field, SqlSupport::like(), '%' . $this->search . '%');

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -261,7 +261,7 @@ class Model implements ModelFilterInterface
         if ($this->search != '') {
             $this->query = $this->query->where(function (Builder $query) {
                 $table   = $query->getModel()->getTable();
-                $columnList = Cache::remember('columns_in_' . $table, 600, fn() => Schema::getColumnListing($table));
+                $columnList = Cache::remember('powergrid_columns_in_' . $table, 600, fn() => Schema::getColumnListing($table));
 
                 /** @var Column $column */
                 foreach ($this->columns as $column) {

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -258,8 +258,8 @@ class Model implements ModelFilterInterface
     public function filterContains(): Model
     {
         if ($this->search != '') {
-            $this->query = $this->query->where(function (Builder $query) {
-                $table   = $query->getModel()->getTable();
+            $this->query    = $this->query->where(function (Builder $query) {
+                $table      = $query->getModel()->getTable();
                 $columnList = Cache::remember('powergrid_columns_in_' . $table, 600, function () use ($table) {
                     return Schema::getColumnListing($table);
                 });


### PR DESCRIPTION
This PR removes duplicate SQL queries generated in the Model helper as described in issue #538 when checking for existence of columns.