### PR TITLE
get db information from the query

### DIFF
--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -174,19 +174,19 @@ class Model implements ModelFilterInterface
 
                 break;
             case 'starts_with':
-                $query->where($field, SqlSupport::like(), $value . '%');
+                $query->where($field, SqlSupport::like($query), $value . '%');
 
                 break;
             case 'ends_with':
-                $query->where($field, SqlSupport::like(), '%' . $value);
+                $query->where($field, SqlSupport::like($query), '%' . $value);
 
                 break;
             case 'contains':
-                $query->where($field, SqlSupport::like(), '%' . $value . '%');
+                $query->where($field, SqlSupport::like($query), '%' . $value . '%');
 
                 break;
             case 'contains_not':
-                $query->where($field, 'NOT ' . SqlSupport::like(), '%' . $value . '%');
+                $query->where($field, 'NOT ' . SqlSupport::like($query), '%' . $value . '%');
 
                 break;
             case 'is_empty':
@@ -281,11 +281,11 @@ class Model implements ModelFilterInterface
                         $hasColumn = in_array($field, $columnList, true);
 
                         if ($hasColumn) {
-                            $query->orWhere($table . '.' . $field, SqlSupport::like(), '%' . $this->search . '%');
+                            $query->orWhere($table . '.' . $field, SqlSupport::like($query), '%' . $this->search . '%');
                         }
 
                         if ($sqlRaw = strval(data_get($column, 'searchableRaw'))) {
-                            $query->orWhereRaw($sqlRaw . ' ' . SqlSupport::like() . ' \'%' . $this->search . '%\'');
+                            $query->orWhereRaw($sqlRaw . ' ' . SqlSupport::like($query) . ' \'%' . $this->search . '%\'');
                         }
                     }
                 }
@@ -316,13 +316,13 @@ class Model implements ModelFilterInterface
                     if ($query->getRelation($nestedTable) != '') {
                         foreach ($column as $nestedColumn) {
                             $this->query = $this->query->orWhereHas($table . '.' . $nestedTable, function (Builder $query) use ($nestedColumn) {
-                                $query->where($nestedColumn, SqlSupport::like(), '%' . $this->search . '%');
+                                $query->where($nestedColumn, SqlSupport::like($query), '%' . $this->search . '%');
                             });
                         }
                     }
                 } else {
                     $this->query = $this->query->orWhereHas($table, function (Builder $query) use ($column) {
-                        $query->where($column, SqlSupport::like(), '%' . $this->search . '%');
+                        $query->where($column, SqlSupport::like($query), '%' . $this->search . '%');
                     });
                 }
             }

--- a/src/Helpers/SqlSupport.php
+++ b/src/Helpers/SqlSupport.php
@@ -12,9 +12,15 @@ class SqlSupport
      */
     private static array $sortStringNumberTypes = ['string', 'varchar', 'char'];
 
-    public static function like(): string
+    public static function like($query=null): string
     {
-        $driverName = self::getDatabaseDriverName();
+
+        if ($query) {
+            $driverName = $query->getModel()?->getConnection()?->getDriverName();
+        }
+
+        if (!isset($driverName) or !is_string($driverName))
+            $driverName = self::getDatabaseDriverName();
 
         /*
         |--------------------------------------------------------------------------

--- a/src/Helpers/SqlSupport.php
+++ b/src/Helpers/SqlSupport.php
@@ -3,6 +3,7 @@
 namespace PowerComponents\LivewirePowerGrid\Helpers;
 
 use Exception;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\{DB, Schema};
 
 class SqlSupport
@@ -12,15 +13,15 @@ class SqlSupport
      */
     private static array $sortStringNumberTypes = ['string', 'varchar', 'char'];
 
-    public static function like($query=null): string
+    public static function like(Builder $query = null): string
     {
-
         if ($query) {
-            $driverName = $query->getModel()?->getConnection()?->getDriverName();
+            $driverName = $query->getModel()->getConnection()->getDriverName();
         }
 
-        if (!isset($driverName) or !is_string($driverName))
+        if (!isset($driverName) or !is_string($driverName)) {
             $driverName = self::getDatabaseDriverName();
+        }
 
         /*
         |--------------------------------------------------------------------------


### PR DESCRIPTION
The current code assumes that your data source model/query is on the default connection, rather than pulling the database driver name from the query/model of the data source.  In my case, this caused it to try to use ILIKE on a database that did not support it because my default database was Postgres and my powergrid data source is from a DB that didn't support it.