### PR TITLE
bugfix - keep the model table as the default when processing filters

### DIFF
--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -260,7 +260,7 @@ class Model implements ModelFilterInterface
         if ($this->search != '') {
             $this->query    = $this->query->where(function (Builder $query) {
                 $modelTable = $query->getModel()->getTable();
-                $columnList = (array) Cache::remember('powergrid_columns_in_' . $table, 600, function () use ($modelTable) {
+                $columnList = (array) Cache::remember('powergrid_columns_in_' . $modelTable, 600, function () use ($modelTable) {
                     return Schema::getColumnListing($modelTable);
                 });
 

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -259,14 +259,15 @@ class Model implements ModelFilterInterface
     {
         if ($this->search != '') {
             $this->query    = $this->query->where(function (Builder $query) {
-                $table      = $query->getModel()->getTable();
-                $columnList = (array) Cache::remember('powergrid_columns_in_' . $table, 600, function () use ($table) {
-                    return Schema::getColumnListing($table);
+                $modelTable = $query->getModel()->getTable();
+                $columnList = (array) Cache::remember('powergrid_columns_in_' . $table, 600, function () use ($modelTable) {
+                    return Schema::getColumnListing($modelTable);
                 });
 
                 /** @var Column $column */
                 foreach ($this->columns as $column) {
                     $searchable = strval(data_get($column, 'searchable'));
+                    $table      = $modelTable;
                     $field      = strval(data_get($column, 'dataField')) ?: strval(data_get($column, 'field'));
 
                     if ($searchable && $field) {


### PR DESCRIPTION
When iterating through filters, the code set the table at the beginning, but if any tables were referenced with dot notation by the filters, it overwrote the original table, causing errors (including silent and potentially subtle errors if the field existed in both tables) if subsequent filters did not use dot notation to specify the field's origin table.