### PR TITLE
forget the cache entry when updating collection with fillData()

### DIFF
--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -194,6 +194,7 @@ class PowerGridComponent extends Component
         $this->isCollection = is_a((object) $datasource, Support\Collection::class);
 
         if ($this->isCollection) {
+            cache()->forget($this->id);
             $filters = Collection::query($this->resolveCollection($datasource))
                 ->setColumns($this->columns)
                 ->setSearch($this->search)


### PR DESCRIPTION
fillData() is the method that is called to update data when a change is made.  For collections, the cache is not purged when fillData() is called, so the function call has no effect (unless you disable caching, which may not be desirable for performance reasons).