### PR TITLE
Improve larastan.sh

### DIFF
--- a/larastan.sh
+++ b/larastan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-LARAVEL_VERSION=$(composer show 'laravel/framework' | grep 'versions' | grep -o -E '\*\ .+' | cut -d' ' -f2 | cut -d',' -f1)
+LARAVEL_VERSION="$(composer show 'laravel/framework' --format=json | jq -r '."versions"[0] | sub("v";"")')"
 
-if [[ $LARAVEL_VERSION =~ .*v9.* ]]; then
+if { echo "9.0.0"; echo "${LARAVEL_VERSION}"; } | sort --version-sort --check 2>/dev/null; then
   ./vendor/bin/phpstan analyse --ansi --memory-limit=-1
 fi


### PR DESCRIPTION
## Pull Request Information

### Motivation

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change

### Related Issue(s)

-

### Description

`| grep 'versions' | grep -o -E '\*\ .+' | cut -d' ' -f2 | cut -d',' -f1` seems to be unreadable.

The condition in "if" is true if the current version comes after 9.0.0
Adding more constraint can be done by appending `echo "10.0.0";`

### Contribution Guide

- [ ] I have read and followed the steps listed in the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
