### PR TITLE
Add e() to stubs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5914,16 +5914,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.10.0",
+            "version": "v3.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "76d7da666e66d83a1dc27a9d1c625c80cc4ac1fe"
+                "reference": "7dcdea3f2f5f473464e835be9be55283ff8cfdc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/76d7da666e66d83a1dc27a9d1c625c80cc4ac1fe",
-                "reference": "76d7da666e66d83a1dc27a9d1c625c80cc4ac1fe",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/7dcdea3f2f5f473464e835be9be55283ff8cfdc3",
+                "reference": "7dcdea3f2f5f473464e835be9be55283ff8cfdc3",
                 "shasum": ""
             },
             "require": {
@@ -5991,7 +5991,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.10.0"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.11.0"
             },
             "funding": [
                 {
@@ -5999,7 +5999,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-17T22:13:10+00:00"
+            "time": "2022-09-01T18:24:51+00:00"
         },
         {
             "name": "guzzlehttp/psr7",

--- a/resources/stubs/PowerGridDemoTable.stub
+++ b/resources/stubs/PowerGridDemoTable.stub
@@ -142,6 +142,9 @@ final class PowerGridDemoTable extends PowerGridComponent
     | Make Datasource fields available to be used as columns.
     | You can pass a closure to transform/modify the data.
     |
+    | ❗ IMPORTANT: When using closures, you must escape any value coming from
+    |    the database using the `e()` Laravel Helper function.
+    |
     */
     public function addColumns(): PowerGridEloquent
     {
@@ -149,6 +152,11 @@ final class PowerGridDemoTable extends PowerGridComponent
             ->addColumn('id')
             ->addColumn('name')
             ->addColumn('email')
+
+            // Create a custom column with name in lower case.
+            ->addColumn('name_lower', function (User $model) {
+                return strtolower(e($model->name));
+            })
 
             // Create a custom column "laracon" based on "has_laracon_ticket" boolean field
             ->addColumn('laracon', function (User $model) {

--- a/resources/stubs/table.fillable.stub
+++ b/resources/stubs/table.fillable.stub
@@ -78,6 +78,9 @@ final class {{ componentName }} extends PowerGridComponent
     | Make Datasource fields available to be used as columns.
     | You can pass a closure to transform/modify the data.
     |
+    | ❗ IMPORTANT: When using closures, you must escape any value coming from
+    |    the database using the `e()` Laravel Helper function.
+    |
     */
     public function addColumns(): PowerGridEloquent
     {

--- a/resources/stubs/table.model.stub
+++ b/resources/stubs/table.model.stub
@@ -79,12 +79,16 @@ final class {{ componentName }} extends PowerGridComponent
     | Make Datasource fields available to be used as columns.
     | You can pass a closure to transform/modify the data.
     |
+    | ❗ IMPORTANT: When using closures, you must escape any value coming from
+    |    the database using the `e()` Laravel Helper function.
+    |
     */
     public function addColumns(): PowerGridEloquent
     {
         return PowerGrid::eloquent()
             ->addColumn('id')
             ->addColumn('name')
+            ->addColumn('name_lower', fn ({{ modelLastName }} $model) => strtolower(e($model->name)));
             ->addColumn('created_at')
             ->addColumn('created_at_formatted', fn ({{ modelLastName }} $model) => Carbon::parse($model->created_at)->format('d/m/Y H:i:s'));
     }

--- a/src/Helpers/Collection.php
+++ b/src/Helpers/Collection.php
@@ -117,7 +117,7 @@ class Collection implements CollectionFilterInterface
         }
 
         foreach ($this->filters as $key => $type) {
-            foreach ($type as $field    => $value) {
+            foreach ($type as $field => $value) {
                 switch ($key) {
                     case 'date_picker':
                         $this->filterDatePicker($field, $value);

--- a/src/PowerGrid.php
+++ b/src/PowerGrid.php
@@ -3,13 +3,9 @@
 namespace PowerComponents\LivewirePowerGrid;
 
 use Illuminate\Support\Facades\Facade;
-use PowerComponents\LivewirePowerGrid\Themes\ThemeBase;
 
 /**
- * @method static PowerGridEloquent eloquent()
- * @method static ThemeBase theme(string $class)
- *
- * @see \PowerComponents\LivewirePowerGrid\PowerGridManager
+ * @mixin \PowerComponents\LivewirePowerGrid\PowerGridManager
  */
 class PowerGrid extends Facade
 {

--- a/src/Themes/Theme.php
+++ b/src/Themes/Theme.php
@@ -20,22 +20,7 @@ use PowerComponents\LivewirePowerGrid\Themes\Components\{Actions,
     Toggleable};
 
 /**
- * @method static Table table(string $attrClass, string $attrStyle='')
- * @method static Footer footer()
- * @method static Toggleable toggleable()
- * @method static Layout layout()
- * @method static Cols cols()
- * @method static Actions actions()
- * @method static Checkbox checkbox()
- * @method static Editable editable()
- * @method static ClickToCopy clickToCopy()
- * @method static FilterBoolean filterBoolean()
- * @method static FilterDatePicker filterDatePicker()
- * @method static FilterMultiSelect filterMultiSelect()
- * @method static FilterNumber filterNumber()
- * @method static FilterSelect filterSelect()
- * @method static FilterInputText filterInputText()
- * @see \PowerComponents\LivewirePowerGrid\Themes\ThemeManager
+ * @mixin \PowerComponents\LivewirePowerGrid\Themes\ThemeManager
  */
 class Theme extends Facade
 {


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

# ⚡ PowerGrid ⚡ Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.


💡 Please complete this template to submit a Pull Request, we cannot accept incomplete Pull Requests.

## Guidelines

`   🗒️ `  Please read the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`   ✍️ `  Give this PR a meaningful title.

`   📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvements

### Related Issue(s)



### Description

This PR adds the recommendation to use `e()` helper when dealing with closures in `addColumns` and usage examples.

![carbon](https://user-images.githubusercontent.com/79267265/188285300-ac957ce6-33b9-4519-9083-a8494aeb13fe.png)

### Contribution Guide

- [x] I have read and followed the steps listed in the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
