### PR TITLE
Add e() example to Fillable table

### DIFF
--- a/src/Helpers/Collection.php
+++ b/src/Helpers/Collection.php
@@ -117,7 +117,7 @@ class Collection implements CollectionFilterInterface
         }
 
         foreach ($this->filters as $key => $type) {
-            foreach ($type as $field    => $value) {
+            foreach ($type as $field => $value) {
                 switch ($key) {
                     case 'date_picker':
                         $this->filterDatePicker($field, $value);

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -20,7 +20,8 @@ it('creates a PowerGrid Model Table', function () {
         ->expectsQuestion($this->model_path_question, 'PowerComponents\LivewirePowerGrid\Tests\Models\Dish')
         ->expectsQuestion($this->use_fillable_question, 'yes')
         ->expectsOutput("\n⚡ DemoTable.php was successfully created at [App/Http/Livewire/].")
-        ->expectsOutput("\n⚡ Your PowerGrid table can be now included with the tag: <livewire:demo-table/>");
+        ->expectsOutput("\n⚡ Your PowerGrid table can be now included with the tag: <livewire:demo-table/>")
+        ->assertSuccessful();
 
     $this->assertFileExists($this->tableModelFilePath);
 
@@ -34,7 +35,8 @@ it('creates a PowerGrid Collection Table', function () {
         ->expectsQuestion($this->model_name_question, 'CollectionTable')
         ->expectsQuestion($this->datasource_question, 'C')
         ->expectsOutput("\n⚡ CollectionTable.php was successfully created at [App/Http/Livewire/].")
-        ->expectsOutput("\n⚡ Your PowerGrid table can be now included with the tag: <livewire:collection-table/>");
+        ->expectsOutput("\n⚡ Your PowerGrid table can be now included with the tag: <livewire:collection-table/>")
+        ->assertSuccessful();
 
     $this->assertFileExists($this->tableCollectionFilePath);
 
@@ -58,7 +60,8 @@ it('notifies about tailwind forms', function () {
         ->expectsQuestion($this->use_fillable_question, 'yes')
         ->expectsOutput("\n💡 It seems you are using the plugin Tailwindcss/form.\n   Please check: https://livewire-powergrid.com/#/get-started/configure?id=_43-tailwind-forms for more information.")
         ->expectsOutput("\n⚡ DemoTable.php was successfully created at [App/Http/Livewire/].")
-        ->expectsOutput("\n⚡ Your PowerGrid table can be now included with the tag: <livewire:demo-table/>");
+        ->expectsOutput("\n⚡ Your PowerGrid table can be now included with the tag: <livewire:demo-table/>")
+        ->assertSuccessful();
 
     File::delete($this->tableModelFilePath);
     File::delete($tailwindConfigFile);
@@ -77,7 +80,8 @@ it('publishes the Demo Table', function () {
         ->expectsOutput("\n1. You must include Route::view('/powergrid', 'powergrid-demo'); in your routes/web.php file.")
         ->expectsOutput("\n2. Serve your project. For example, run php artisan serve.")
         ->expectsOutput("\n3. Visit http://localhost/powergrid to view the Demo Table.")
-        ->expectsOutput("\n\n⭐ Thanks! Please consider starring our repository at https://github.com/Power-Components/livewire-powergrid ⭐\n");
+        ->expectsOutput("\n\n⭐ Thanks! Please consider starring our repository at https://github.com/Power-Components/livewire-powergrid ⭐\n")
+        ->assertSuccessful();
 
     $this->assertFileExists($tableFile);
     $this->assertFileExists($viewsFile);
@@ -92,7 +96,7 @@ it('does not accept an empty table name', function () {
     $this->artisan('powergrid:create')
         ->expectsQuestion($this->model_name_question, '')
         ->expectsOutput('You must provide a name for your ⚡ PowerGrid Table!')
-        ->assertExitCode(1);
+        ->assertFailed();
 
     $this->assertFileDoesNotExist($this->tableModelFilePath);
 });
@@ -104,7 +108,7 @@ it('accepts only [M]odel or [C]ollection', function () {
         ->expectsQuestion($this->model_name_question, 'DemoTable')
         ->expectsQuestion($this->datasource_question, 'Z')
         ->expectsOutput('Invalid option. Please enter [M] for model or [C] for Collection.')
-        ->assertExitCode(1);
+        ->assertFailed();
 
     $this->assertFileDoesNotExist($this->tableModelFilePath);
 });
@@ -117,7 +121,7 @@ it('does not create a table with empty model', function () {
         ->expectsQuestion($this->datasource_question, 'M')
         ->expectsQuestion($this->model_path_question, '')
         ->expectsOutput('Error: You must inform the Model name or file path.')
-        ->assertExitCode(1);
+        ->assertFailed();
 
     $this->assertFileDoesNotExist($this->tableModelFilePath);
 
@@ -132,7 +136,7 @@ it('does not create a table with invalid model path', function () {
         ->expectsQuestion($this->datasource_question, 'M')
         ->expectsQuestion($this->model_path_question, 'xyz-model')
         ->expectsOutput('Error: Could not find "xyz-model" class.')
-        ->assertExitCode(1);
+        ->assertFailed();
 
     $this->assertFileDoesNotExist($this->tableModelFilePath);
 
@@ -146,7 +150,8 @@ it('does overwrite the existing table file w/ YES', function () {
         ->expectsQuestion($this->model_name_question, 'DemoTable')
         ->expectsQuestion($this->datasource_question, 'M')
         ->expectsQuestion($this->model_path_question, '\PowerComponents\LivewirePowerGrid\Tests\Models\Dish')
-        ->expectsQuestion($this->use_fillable_question, 'yes');
+        ->expectsQuestion($this->use_fillable_question, 'yes')
+        ->assertSuccessful();
 
     $this->assertFileExists($this->tableModelFilePath);
 
@@ -159,7 +164,8 @@ it('does overwrite the existing table file w/ YES', function () {
         ->expectsQuestion($this->datasource_question, 'M')
         ->expectsQuestion($this->model_path_question, '\PowerComponents\LivewirePowerGrid\Tests\Models\Dish')
         ->expectsQuestion($this->use_fillable_question, 'yes')
-        ->expectsQuestion('It seems that <comment>DemoTable</comment> already exists. Would you like to overwrite it?', 'yes');
+        ->expectsQuestion('It seems that <comment>DemoTable</comment> already exists. Would you like to overwrite it?', 'yes')
+        ->assertSuccessful();
 
     expect(file_get_contents($this->tableModelFilePath))->not->toContain('x0007');
 
@@ -173,7 +179,8 @@ it('does NOT overwride the existing table file', function () {
         ->expectsQuestion($this->model_name_question, 'DemoTable')
         ->expectsQuestion($this->datasource_question, 'M')
         ->expectsQuestion($this->model_path_question, '\PowerComponents\LivewirePowerGrid\Tests\Models\Dish')
-        ->expectsQuestion($this->use_fillable_question, 'yes');
+        ->expectsQuestion($this->use_fillable_question, 'yes')
+        ->assertSuccessful();
 
     $this->assertFileExists($this->tableModelFilePath);
 
@@ -186,7 +193,8 @@ it('does NOT overwride the existing table file', function () {
         ->expectsQuestion($this->datasource_question, 'M')
         ->expectsQuestion($this->model_path_question, '\PowerComponents\LivewirePowerGrid\Tests\Models\Dish')
         ->expectsQuestion($this->use_fillable_question, 'yes')
-        ->expectsQuestion('It seems that <comment>DemoTable</comment> already exists. Would you like to overwrite it?', '');
+        ->expectsQuestion('It seems that <comment>DemoTable</comment> already exists. Would you like to overwrite it?', '')
+        ->assertSuccessful();
 
     expect(file_get_contents($this->tableModelFilePath))->toContain('x0007');
 
@@ -199,7 +207,7 @@ it('publishes config file', function () {
     File::delete($configFilePath);
 
     $this->artisan('vendor:publish --tag=livewire-powergrid-config')
-        ->assertExitCode(0);
+        ->assertSuccessful();
 
     $this->assertFileExists($configFilePath);
 
@@ -212,7 +220,7 @@ it('publishes views file', function () {
     File::delete($dirPath);
 
     $this->artisan('vendor:publish --tag=livewire-powergrid-views')
-        ->assertExitCode(0);
+        ->assertSuccessful();
 
     $this->assertDirectoryExists($dirPath);
 
@@ -225,7 +233,7 @@ it('publishes the language file in the lang path', function () {
     File::delete($dirPath);
 
     $this->artisan('vendor:publish --tag=livewire-powergrid-lang')
-        ->assertExitCode(0);
+        ->assertSuccessful();
 
     $this->assertDirectoryExists($dirPath);
 


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

# ⚡ PowerGrid ⚡ Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.


💡 Please complete this template to submit a Pull Request, we cannot accept incomplete Pull Requests.

## Guidelines

`   🗒️ `  Please read the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`   ✍️ `  Give this PR a meaningful title.

`   📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

### Related Issue(s)

### Description

This Pull Request adds an auto-generated example for `e()` usage in closure columns when creating a table from a Model's `fillable`. The example will use the first found `string` column.

`❗` Depends on PR https://github.com/Power-Components/livewire-powergrid/pull/605 with fixes for Static Analysis.

![carbon(2)](https://user-images.githubusercontent.com/79267265/188287137-0272ac83-4978-4f79-9e87-2ac5691e5861.png)

### Contribution Guide

- [x] I have read and followed the steps listed in the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
