### PR TITLE
[Feature] Restrict Filters in `makeInputText`

### DIFF
--- a/resources/views/components/frameworks/bootstrap5/filters/input-text.blade.php
+++ b/resources/views/components/frameworks/bootstrap5/filters/input-text.blade.php
@@ -8,7 +8,13 @@
 ])
 <div>
     @php
-        $field = data_get($inputText, 'dataField') ?? data_get($inputText, 'field');
+    $field = data_get($inputText, 'dataField') ?? data_get($inputText, 'field');
+
+    $AllowedFilters = data_get($inputText, 'filters') ?? [];
+
+    if (!empty($AllowedFilters)) {
+        $inputTextOptions = \Illuminate\Support\Arr::only($inputTextOptions, $AllowedFilters);
+    }
     @endphp
     @if(filled($inputText))
         <div class="{{ $theme->baseClass }}" style="{{ $theme->baseStyle }}">

--- a/resources/views/components/frameworks/tailwind/filters/input-text.blade.php
+++ b/resources/views/components/frameworks/tailwind/filters/input-text.blade.php
@@ -8,7 +8,13 @@
 ])
 <div>
     @php
-        $field = data_get($inputText, 'dataField') ?? data_get($inputText, 'field');
+    $field = data_get($inputText, 'dataField') ?? data_get($inputText, 'field');
+
+    $AllowedFilters = data_get($inputText, 'filters') ?? [];
+
+    if (!empty($AllowedFilters)) {
+        $inputTextOptions = \Illuminate\Support\Arr::only($inputTextOptions, $AllowedFilters);
+    }
     @endphp
     @if(filled($inputText))
         <div @class([

--- a/src/Column.php
+++ b/src/Column.php
@@ -427,10 +427,15 @@ final class Column
 
     /**
      * Add Input Text
+     *
+     * @param string $dataField
+     * @param array<mixed,mixed> $options
+     * @return Column
      */
-    public function makeInputText(string $dataField = ''): Column
+    public function makeInputText(string $dataField = '', array $options = []): Column
     {
         $this->inputs['input_text']['enabled'] = true;
+        $this->inputs['input_text']['filters'] = $options['filters'] ?? [];
         if (filled($dataField)) {
             $this->dataField = $dataField;
         }

--- a/tests/DishTableAllowedFilters.php
+++ b/tests/DishTableAllowedFilters.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests;
+
+use Illuminate\Database\Eloquent\Builder;
+use NumberFormatter;
+use PowerComponents\LivewirePowerGrid\Tests\Models\{Category, Dish};
+use PowerComponents\LivewirePowerGrid\Traits\ActionButton;
+use PowerComponents\LivewirePowerGrid\{Button,
+    Column,
+    Exportable,
+    Footer,
+    Header,
+    PowerGrid,
+    PowerGridComponent,
+    PowerGridEloquent};
+
+class DishTableAllowedFilters extends PowerGridComponent
+{
+    use ActionButton;
+
+    public array $eventId = [];
+
+    protected function getListeners()
+    {
+        return array_merge(
+            parent::getListeners(),
+            [
+                'deletedEvent',
+            ]
+        );
+    }
+
+    public function openModal(array $params)
+    {
+        $this->eventId = $params;
+    }
+
+    public function deletedEvent(array $params)
+    {
+        $this->eventId = $params;
+    }
+
+    public function setUp(): array
+    {
+        $this->showCheckBox();
+
+        return [
+            Exportable::make('export')
+                ->striped()
+                ->type(Exportable::TYPE_XLS, Exportable::TYPE_CSV),
+
+            Header::make()
+                ->showToggleColumns()
+                ->showSearchInput(),
+
+            Footer::make()
+                ->showPerPage()
+                ->showRecordCount(),
+        ];
+    }
+
+    public function datasource(): Builder
+    {
+        return Dish::with('category');
+    }
+
+    public function relationSearch(): array
+    {
+        return [
+            'category' => [
+                'name',
+            ],
+        ];
+    }
+
+    public function inputRangeConfig(): array
+    {
+        return [
+            'price' => ['thousands' => '.', 'decimal' => ','],
+        ];
+    }
+
+    public function addColumns(): PowerGridEloquent
+    {
+        $fmt = new NumberFormatter('ca_ES', NumberFormatter::CURRENCY);
+
+        return PowerGrid::eloquent()
+            ->addColumn('id')
+            ->addColumn('name');
+    }
+
+    public function columns(): array
+    {
+        $canEdit = true;
+
+        return [
+            Column::add()
+                ->title(__('ID'))
+                ->field('id')
+                ->searchable()
+                ->sortable(),
+
+            Column::add()
+                ->title(__('Stored at'))
+                ->field('storage_room')
+                ->sortable(),
+
+            Column::add()
+                ->title(__('Prato'))
+                ->field('name')
+                ->searchable()
+                ->editOnClick($canEdit)
+                ->clickToCopy(true)
+                ->makeInputText('name', options: ['filters' => ['contains_not', 'ends_with']])
+                ->placeholder('Prato placeholder')
+                ->sortable(),
+        ];
+    }
+
+    public function actions(): array
+    {
+        return [
+            Button::add('edit-stock')
+                ->caption('<div id="edit">Edit</div>')
+                ->class('text-center')
+                ->openModal('edit-stock', ['dishId' => 'id']),
+
+            Button::add('destroy')
+                ->caption(__('Delete'))
+                ->class('text-center')
+                ->emit('deletedEvent', ['dishId' => 'id'])
+                ->method('delete'),
+        ];
+    }
+
+    public function bootstrap()
+    {
+        config(['livewire-powergrid.theme' => 'bootstrap']);
+    }
+
+    public function tailwind()
+    {
+        config(['livewire-powergrid.theme' => 'tailwind']);
+    }
+}

--- a/tests/Feature/AllowedFiltersTest.php
+++ b/tests/Feature/AllowedFiltersTest.php
@@ -1,0 +1,22 @@
+<<?php
+
+use function Pest\Livewire\livewire;
+
+it('property displays the results and options', function (string $component, object $params) {
+    livewire($component)
+        ->call($params->theme)
+        ->assertSeeHtmlInOrder([
+            '<option value="contains_not">Does not contain</option>',
+            '<option value="ends_with">Ends with</option>',
+            '</select>',
+        ])
+        ->assertDontSeeHtml('<option value="is">Is</option>')
+        ->assertDontSeeHtml('<option value="is_not">Is not</option>')
+        ->assertDontSeeHtml('<option value="starts_with">Starts with</option>')
+        ->assertDontSeeHtml('<option value="is_empty">Is empty</option>')
+        ->assertDontSeeHtml('<option value="is_not_empty">Is not empty</option>')
+        ->assertDontSeeHtml('<option value="is_null">Is null</option>')
+        ->assertDontSeeHtml('<option value="is_not_null">Is not null</option>')
+        ->assertDontSeeHtml('<option value="is_blank">Is blank</option>')
+        ->assertDontSeeHtml('<option value="is_not_blank">Is not blank</option>');
+})->with('DishTableAllowedFilters');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -8,6 +8,7 @@ use PowerComponents\LivewirePowerGrid\Tests\TestCase;
 use PowerComponents\LivewirePowerGrid\{
     Column,
     PowerGridComponent,
+    Tests\DishTableAllowedFilters,
     Tests\DishesActionRulesTable,
     Tests\DishesArrayTable,
     Tests\DishesCalculationsTable,
@@ -127,6 +128,16 @@ dataset('themes', [
     'bootstrap -> id'        => [DishesTable::class, (object) ['theme' => 'bootstrap', 'field' => 'id']],
     'tailwind -> dishes.id'  => [DishesTableWithJoin::class, (object) ['theme' => 'tailwind', 'field' => 'dishes.id']],
     'bootstrap -> dishes.id' => [DishesTableWithJoin::class, (object) ['theme' => 'bootstrap', 'field' => 'dishes.id']],
+]);
+
+dataset('DishTableAllowedFilters', [
+    'tailwind -> id'  => [DishTableAllowedFilters::class, (object) ['theme' => 'tailwind', 'field' => 'id']],
+    'bootstrap -> id' => [DishTableAllowedFilters::class, (object) ['theme' => 'bootstrap', 'field' => 'id']],
+]);
+
+dataset('dishTableAllowedFilters', [
+    'tailwind -> id'  => [DishTableAllowedFilters::class, (object) ['theme' => 'tailwind', 'field' => 'id']],
+    'bootstrap -> id' => [DishTableAllowedFilters::class, (object) ['theme' => 'bootstrap', 'field' => 'id']],
 ]);
 
 dataset('rules', [


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

# ⚡ PowerGrid ⚡ Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.


💡 Please complete this template to submit a Pull Request, we cannot accept incomplete Pull Requests.

## Guidelines

`   🗒️ `  Please read the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`   ✍️ `  Give this PR a meaningful title.

`   📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

### Related Issue(s)

This PR is related to the Feature Request https://github.com/Power-Components/livewire-powergrid/issues/577.

### Description

I think PowerGrid must be the most adaptive and flexible as possible. In my understanding, the Feature Request suggestion would allow a "filter lock" and I can see scenarios where only some filters are acceptable. 

For instance, let's take a Passport column. It might be dangerous to allow the user to filter by `contains` when this filter must find an exact result. The usability would be far better with having only the filter `is` available.

I suggest a feature to allow the user to specify filters for each column by passing them in the key `filters` of the array `$options`.

```php
//...
            Column::add()
                ->title(__('Dish'))
                ->field('name')
                ->searchable()
                ->makeInputText('name', options: ['filters' => ['contains_not', 'ends_with']]),
```

Resulting in:

![pr](https://user-images.githubusercontent.com/79267265/188442168-8a2f90a1-93f6-426d-8d80-9c56d8420878.png)

### Open Points

- I am not happy with performing a check inside the view. I think we should not have any logic in there. There are rooms for improvements here.
- We might hide the select menu withh CSS if there is only one possible filter (`->makeInputText('name', options: ['filters' => ['is']]),`
 
### Contribution Guide

- [x] I have read and followed the steps listed in the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
