### PR TITLE
[Feature] ActionRules Show/Hide Toggleable

### DIFF
--- a/resources/views/components/frameworks/bootstrap5/toggleable.blade.php
+++ b/resources/views/components/frameworks/bootstrap5/toggleable.blade.php
@@ -1,12 +1,13 @@
 <div x-data="pgToggleable({
             id: '{{ $row->{$primaryKey} }}',
+            isHidden: {{ !$showToggleable ? 'true' : 'false' }},
             tableName: '{{ $tableName }}',
             field: '{{ $column->field }}',
             toggle: {{ (int) $row->{$column->field} }},
             trueValue: '{{ $column->toggleable['default'][0] }}',
             falseValue:  '{{ $column->toggleable['default'][1] }}'
          })">
-    @if($column->toggleable['enabled'])
+    @if($column->toggleable['enabled'] && $showToggleable === true)
         <div class="form-check form-switch">
             <label>
                 <input x-on:click="save()"

--- a/resources/views/components/frameworks/tailwind/toggleable.blade.php
+++ b/resources/views/components/frameworks/tailwind/toggleable.blade.php
@@ -6,13 +6,14 @@
 @endphp
 <div x-data="pgToggleable({
             id: '{{ $row->{$primaryKey} }}',
+            isHidden: {{ !$showToggleable ? 'true' : 'false' }},
             tableName: '{{ $tableName }}',
             field: '{{ $column->field }}',
             toggle: {{ (int)$row->{$column->field} }},
             trueValue: '{{ $column->toggleable['default'][0] }}',
             falseValue:  '{{ $column->toggleable['default'][1] }}',
          })">
-    @if($column->toggleable['enabled'] && !$showDefaultToggle)
+    @if($column->toggleable['enabled'] && !$showDefaultToggle && $showToggleable === true)
         <div class="flex justify-center">
             <div class="relative rounded-full w-12 h-6 transition duration-200 ease-linear"
                  :class="[toggle === 1 ? 'bg-blue-400 dark:bg-blue-500' : 'bg-slate-400']">

--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -21,6 +21,11 @@
                 @endif
             </span>
         @elseif(count($column->toggleable) > 0)
+            @php
+                $rules = $actionRulesClass->recoverFromAction('pg:rows', $row);
+                $toggleableRules =  collect(data_get($rules, 'showHideToggleable', []));
+                $showToggleable = ($toggleableRules->isEmpty() || $toggleableRules->last() == 'show');
+            @endphp
             @include($theme->toggleable->view, ['tableName' => $tableName])
         @else
             <span class="@if($column->clickToCopy) {{ $theme->clickToCopy->spanClass }} @endif">

--- a/src/Helpers/ActionRules.php
+++ b/src/Helpers/ActionRules.php
@@ -19,6 +19,7 @@ class ActionRules
         'pg:column',
         'detailView',
         'bladeComponent',
+        'showHideToggleable',
     ];
 
     public function resolveRules(array $rules, object|array $row): Collection

--- a/src/Rules/RuleRows.php
+++ b/src/Rules/RuleRows.php
@@ -47,4 +47,24 @@ class RuleRows
 
         return $this;
     }
+
+    /**
+     * Show the toggleable in current row.
+     */
+    public function showToggleable(): RuleRows
+    {
+        $this->rule['showHideToggleable'] = 'show';
+
+        return $this;
+    }
+
+    /**
+     * Hide the toggleable in current row.
+     */
+    public function hideToggleable(): RuleRows
+    {
+        $this->rule['showHideToggleable'] = 'hide';
+
+        return $this;
+    }
 }

--- a/tests/Feature/ActionRules/ShowHideToggleable.php
+++ b/tests/Feature/ActionRules/ShowHideToggleable.php
@@ -1,0 +1,66 @@
+<?php
+
+use function Pest\Livewire\livewire;
+
+use PowerComponents\LivewirePowerGrid\Rules\Rule;
+use PowerComponents\LivewirePowerGrid\Tests\Models\Dish;
+use PowerComponents\LivewirePowerGrid\Tests\RulesShowHideToggleable;
+
+it('hides all Toggleables except for id #2', function (string $component, object $params) {
+    livewire($component, ['join' => $params->join])
+        ->call($params->theme)
+        ->set('testActionRules', [
+            Rule::rows()
+                ->when(fn (Dish $dish) => $dish->id < 50)
+                ->hideToggleable(),
+
+            Rule::rows()
+                ->when(fn (Dish $dish) => $dish->id == 2)
+                ->showToggleable(),
+        ])
+        ->assertSeeHtmlInOrder([
+            "id: '1',",
+            'isHidden: true,',
+        ])
+        ->assertSeeHtmlInOrder([
+            "id: '2',",
+            'isHidden: false,',
+        ])
+        ->assertSeeHtmlInOrder([
+            "id: '3',",
+            'isHidden: true,',
+        ]);
+})->with('ShowHideToggleable')->group('actionRules');
+
+it('hides only toggleables on id #2', function (string $component, object $params) {
+    livewire($component, ['join' => $params->join])
+        ->call($params->theme)
+        ->set('testActionRules', [
+            Rule::rows()
+                ->when(fn (Dish $dish) => $dish->id < 50)
+                ->showToggleable(),
+
+            Rule::rows()
+                ->when(fn (Dish $dish) => $dish->id == 2)
+                ->hideToggleable(),
+        ])
+        ->assertSeeHtmlInOrder([
+            "id: '1',",
+            'isHidden: false,',
+        ])
+        ->assertSeeHtmlInOrder([
+            "id: '2',",
+            'isHidden: true,',
+        ])
+        ->assertSeeHtmlInOrder([
+            "id: '3',",
+            'isHidden: false,',
+        ]);
+})->with('ShowHideToggleable')->group('actionRules');
+
+dataset('ShowHideToggleable', [
+    'tailwind'       => [RulesShowHideToggleable::class, (object) ['theme' => 'tailwind', 'join' => false]],
+    'bootstrap'      => [RulesShowHideToggleable::class, (object) ['theme' => 'bootstrap', 'join' => false]],
+    'tailwind join'  => [RulesShowHideToggleable::class, (object) ['theme' => 'tailwind', 'join' => true]],
+    'bootstrap join' => [RulesShowHideToggleable::class, (object) ['theme' => 'bootstrap', 'join' => true]],
+]);

--- a/tests/RulesShowHideToggleable.php
+++ b/tests/RulesShowHideToggleable.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests;
+
+use PowerComponents\LivewirePowerGrid\Tests\Models\Dish;
+use PowerComponents\LivewirePowerGrid\{
+    Column,
+    Footer,
+    Header,
+    PowerGrid,
+    PowerGridEloquent};
+
+class RulesShowHideToggleable extends DishesTable
+{
+    public array $testActionRules = [];
+
+    public function setUp(): array
+    {
+        return [
+            Header::make()
+                ->showToggleColumns()
+                ->showSearchInput(),
+
+            Footer::make()
+                ->showPerPage()
+                ->showRecordCount(),
+
+        ];
+    }
+
+    public function addColumns(): PowerGridEloquent
+    {
+        return PowerGrid::eloquent()
+                  ->addColumn('id')
+                  ->addColumn('in_stock')
+                  ->addColumn('in_stock_label', function (Dish $dish) {
+                      return ($dish->in_stock ? 'sim' : 'não');
+                  });
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::add()
+                ->title(__('ID'))
+                ->field('id'),
+
+            Column::add()
+                ->title(__('Em Estoque'))
+                ->toggleable(true, 'sim', 'não')
+                ->makeBooleanFilter('in_stock', 'sim', 'não')
+                ->field('in_stock'),
+        ];
+    }
+
+    public function actionRules(): array
+    {
+        return $this->testActionRules;
+    }
+}


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

# ⚡ PowerGrid ⚡ Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.


💡 Please complete this template to submit a Pull Request, we cannot accept incomplete Pull Requests.

## Guidelines

`   🗒️ `  Please read the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`   ✍️ `  Give this PR a meaningful title.

`   📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

### Description

This Pull Request adds the possibility to use Row ActionRules to show/hide Toggleables.

An example of Use Case is soft deleted models should not be toggled, as briefly discussed in the [Add or Update Button while using Action Rule #617 ](https://github.com/Power-Components/livewire-powergrid/discussions/617). If hidden, the column will show the boolean label.

```php

public function actionRules(): array
    {
        return [
            Rule::rows()
              ->when(fn ($dish) => $dish->trashed() == true)
              ->setAttribute('class', 'bg-red-100 hover:bg-red-200')
              ->hideToggleable(),
        ];
    }
```

Resulting in:

![pr](https://user-images.githubusercontent.com/79267265/189240068-b8fa88b3-d105-436a-9cc5-70ffecf2d075.png)

### Contribution Guide

- [X] I have read and followed the steps listed in the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [X] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
