### PR TITLE
Removed semicolon causing error in stub

### DIFF
--- a/resources/stubs/table.model.stub
+++ b/resources/stubs/table.model.stub
@@ -88,7 +88,7 @@ final class {{ componentName }} extends PowerGridComponent
         return PowerGrid::eloquent()
             ->addColumn('id')
             ->addColumn('name')
-            ->addColumn('name_lower', fn ({{ modelLastName }} $model) => strtolower(e($model->name)));
+            ->addColumn('name_lower', fn ({{ modelLastName }} $model) => strtolower(e($model->name)))
             ->addColumn('created_at')
             ->addColumn('created_at_formatted', fn ({{ modelLastName }} $model) => Carbon::parse($model->created_at)->format('d/m/Y H:i:s'));
     }

--- a/tests/Feature/SearchableRawTest.php
+++ b/tests/Feature/SearchableRawTest.php
@@ -9,8 +9,8 @@ it('searches data using whereRaw on sqlite', function (string $component, object
         ->assertSee('Polpetone Filé Mignon')
         ->assertDontSee('Barco-Sushi Simples')
         ->assertDontSee('No records found')
-        # 09/09/2022
-        ->set('search', '09/09/2022')
+        # 09/09/2046
+        ->set('search', '09/09/2046') //No dishes in this date
         ->assertSee('No records found')
         # 06/2026
         ->set('search', '06/2026')
@@ -26,8 +26,8 @@ it('searches data using whereRaw on mysql', function (string $component, object 
         ->assertSee('Polpetone Filé Mignon')
         ->assertDontSee('Barco-Sushi Simples')
         ->assertDontSee('No records found')
-        # 09/09/2022
-        ->set('search', '09/09/2022')
+        # 09/09/2046
+        ->set('search', '09/09/2046') //No dishes in this date
         ->assertSee('No records found')
         # 06/2026
         ->set('search', '06/2026')
@@ -42,8 +42,8 @@ it('searches data using whereRaw on pgsql', function (string $component, object 
         ->assertSee('Polpetone Filé Mignon')
         ->assertDontSee('Barco-Sushi Simples')
         ->assertDontSee('No records found')
-        # 09/09/2022
-        ->set('search', '09/09/2022')
+        # 09/09/2046
+        ->set('search', '09/09/2046') //No dishes in this date
         ->assertSee('No records found')
         # 06/2026
         ->set('search', '06/2026')


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

# ⚡ PowerGrid ⚡ Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.


💡 Please complete this template to submit a Pull Request, we cannot accept incomplete Pull Requests.

## Guidelines

`   🗒️ `  Please read the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`   ✍️ `  Give this PR a meaningful title.

`   📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

### Related Issue(s)

None

### Description

The last update to stubs had a semicolon which was causing an error when producing a new table. Just removed it.

### Contribution Guide

- [x] I have read and followed the steps listed in the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
