### PR TITLE
[3.x] Add CSV Export Options: Separator & Delimiter 

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -4,10 +4,14 @@ namespace PowerComponents\LivewirePowerGrid;
 
 final class Exportable
 {
-    public const TYPE_XLS = 'excel';
-    public const TYPE_CSV = 'csv';
+    public const TYPE_XLS      = 'excel';
+    public const TYPE_CSV      = 'csv';
 
     public string $name = 'exportable';
+
+    public string $csvSeparator = ',';
+
+    public string $csvDelimiter = '"';
 
     public array $type = [];
 
@@ -31,6 +35,20 @@ final class Exportable
         foreach ($types as $type) {
             $this->type[] = $type;
         }
+
+        return $this;
+    }
+
+    public function csvSeparator(string $separator): self
+    {
+        $this->csvSeparator = $separator;
+
+        return $this;
+    }
+
+    public function csvDelimiter(string $delimiter): self
+    {
+        $this->csvDelimiter = $delimiter;
 
         return $this;
     }

--- a/src/Services/Contracts/ExportInterface.php
+++ b/src/Services/Contracts/ExportInterface.php
@@ -8,5 +8,5 @@ interface ExportInterface
 {
     public function download(array $exportOptions): BinaryFileResponse;
 
-    public function build(): void;
+    public function build(array $exportOptions): void;
 }

--- a/src/Services/Export.php
+++ b/src/Services/Export.php
@@ -5,7 +5,7 @@ namespace PowerComponents\LivewirePowerGrid\Services;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use PowerComponents\LivewirePowerGrid\Column;
-use PowerComponents\LivewirePowerGrid\Helpers\{ActionRules, Helpers};
+use PowerComponents\LivewirePowerGrid\Helpers\ActionRules;
 
 class Export
 {

--- a/src/Services/Spout/ExportToCsv.php
+++ b/src/Services/Spout/ExportToCsv.php
@@ -20,7 +20,7 @@ class ExportToCsv extends Export implements ExportInterface
     public function download(Exportable|array $exportOptions): BinaryFileResponse
     {
         $deleteFileAfterSend = boolval(data_get($exportOptions, 'deleteFileAfterSend'));
-        $this->build();
+        $this->build($exportOptions);
 
         return response()
             ->download(storage_path($this->fileName . '.csv'))
@@ -31,11 +31,18 @@ class ExportToCsv extends Export implements ExportInterface
      * @throws WriterNotOpenedException
      * @throws IOException
      */
-    public function build(): void
+    public function build(Exportable|array $exportOptions): void
     {
         $data = $this->prepare($this->data, $this->columns);
 
-        $writer = new Writer();
+        $csvSeparator     = strval(data_get($exportOptions, 'csvSeparator', ','));
+        $csvDelimiter     = strval(data_get($exportOptions, 'csvDelimiter', '"'));
+
+        $csvOptions                   = new \OpenSpout\Writer\CSV\Options();
+        $csvOptions->FIELD_DELIMITER  = $csvSeparator;
+        $csvOptions->FIELD_ENCLOSURE  = $csvDelimiter;
+
+        $writer = new Writer($csvOptions);
         $writer->openToFile(storage_path($this->fileName . '.csv'));
 
         $row = Row::fromValues($data['headers']);

--- a/src/Services/Spout/ExportToXLS.php
+++ b/src/Services/Spout/ExportToXLS.php
@@ -26,7 +26,7 @@ class ExportToXLS extends Export implements ExportInterface
         $columnWidth         = data_get($exportOptions, 'columnWidth', []);
         $this->columnWidth   = $columnWidth;
 
-        $this->build();
+        $this->build($exportOptions);
 
         return response()
             ->download(storage_path($this->fileName . '.xlsx'))
@@ -37,7 +37,7 @@ class ExportToXLS extends Export implements ExportInterface
      * @throws WriterNotOpenedException
      * @throws IOException
      */
-    public function build(): void
+    public function build(Exportable|array $exportOptions): void
     {
         $data = $this->prepare($this->data, $this->columns);
 

--- a/tests/ExportTable.php
+++ b/tests/ExportTable.php
@@ -2,7 +2,6 @@
 
 namespace PowerComponents\LivewirePowerGrid\Tests;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use NumberFormatter;
 use PowerComponents\LivewirePowerGrid\Tests\Models\{Category, Dish};
@@ -20,6 +19,10 @@ class ExportTable extends PowerGridComponent
 {
     use ActionButton;
 
+    public string $separator = ',';
+
+    public string $delimiter = '"';
+
     public function setUp(): array
     {
         $this->showCheckBox();
@@ -27,6 +30,8 @@ class ExportTable extends PowerGridComponent
         return [
             Exportable::make('export')
                 ->striped()
+                ->csvSeparator($this->separator)
+                ->csvDelimiter($this->delimiter)
                 ->type(Exportable::TYPE_XLS, Exportable::TYPE_CSV),
 
             Header::make()
@@ -56,41 +61,7 @@ class ExportTable extends PowerGridComponent
 
         return PowerGrid::eloquent()
             ->addColumn('id')
-            ->addColumn('name')
-            ->addColumn('storage_room')
-            ->addColumn('chef_name')
-            ->addColumn('serving_at')
-            ->addColumn('calories')
-            ->addColumn('calories', function (Dish $dish) {
-                return $dish->calories . ' kcal';
-            })
-            ->addColumn('category_id', function (Dish $dish) {
-                return $dish->category_id;
-            })
-            ->addColumn('category_name', function (Dish $dish) {
-                return $dish->category->name;
-            })
-            ->addColumn('price')
-            ->addColumn('price_EUR', function (Dish $dish) use ($fmt) {
-                return $fmt->formatCurrency($dish->price, 'EUR');
-            })
-            ->addColumn('price_BRL', function (Dish $dish) {
-                return 'R$ ' . number_format($dish->price, 2, ',', '.'); //R$ 1.000,00
-            })
-            ->addColumn('sales_price')
-            ->addColumn('sales_price_BRL', function (Dish $dish) {
-                $sales_price = $dish->price + ($dish->price * 0.15);
-
-                return 'R$ ' . number_format($sales_price, 2, ',', '.'); //R$ 1.000,00
-            })
-            ->addColumn('in_stock')
-            ->addColumn('in_stock_label', function (Dish $dish) {
-                return ($dish->in_stock ? 'sim' : 'não');
-            })
-            ->addColumn('produced_at')
-            ->addColumn('produced_at_formatted', function (Dish $dish) {
-                return Carbon::parse($dish->produced_at)->format('d/m/Y');
-            });
+            ->addColumn('name');
     }
 
     public function columns(): array
@@ -105,11 +76,6 @@ class ExportTable extends PowerGridComponent
                 ->sortable(),
 
             Column::add()
-                ->title(__('Stored at'))
-                ->field('storage_room')
-                ->sortable(),
-
-            Column::add()
                 ->title(__('Prato'))
                 ->field('name')
                 ->searchable()
@@ -117,61 +83,6 @@ class ExportTable extends PowerGridComponent
                 ->clickToCopy(true)
                 ->makeInputText('name')
                 ->placeholder('Prato placeholder')
-                ->sortable(),
-
-            Column::add()
-                ->title('Serving at')
-                ->field('serving_at')
-                ->sortable()
-                ->makeInputSelect(Dish::servedAt(), 'serving_at', 'serving_at', ['live-search' => true]),
-
-            Column::add()
-                ->title(__('Chef'))
-                ->field('chef_name')
-                ->searchable()
-                ->editOnClick($canEdit)
-                ->clickToCopy(true)
-                ->makeInputText('chef_name')
-                ->placeholder('Chef placeholder')
-                ->sortable(),
-
-            Column::add()
-                ->title(__('Categoria'))
-                ->field('category_name')
-                ->placeholder('Categoria placeholder')
-                ->makeInputSelect(Category::all(), 'name', 'category_id'),
-
-            Column::add()
-                ->title(__('Preço'))
-                ->field('price_BRL')
-                ->editOnClick($canEdit, 'price')
-                ->makeInputRange('price'),
-
-            Column::add()
-                ->title(__('Preço de Venda'))
-                ->field('sales_price_BRL'),
-
-            Column::add()
-                ->title(__('Calorias'))
-                ->field('calories')
-                ->makeInputRange('calories')
-                ->sortable(),
-
-            Column::add()
-                ->title(__('Em Estoque'))
-                ->toggleable(true, 'sim', 'não')
-                ->makeBooleanFilter('in_stock', 'sim', 'não')
-                ->field('in_stock'),
-
-            Column::add()
-                ->title(__('Data de produção'))
-                ->field('produced_at_formatted')
-                ->makeInputDatePicker('produced_at'),
-
-            Column::add()
-                ->title(__('Data'))
-                ->field('produced_at')
-                ->makeInputDatePicker('produced_at')
                 ->sortable(),
         ];
     }

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -28,23 +28,24 @@ it('properly does not export xls data without selected data', function () {
 });
 
 it('properly export csv data with selected data', function () {
-    livewire(ExportTable::class)
-        ->set('checkboxValues', [
-            0 => '1',
-            1 => '2',
-        ])
-        ->call('exportToCsv', true)
-        ->assertFileDownloaded('export.csv');
+    $downloadedFile =  livewire(ExportTable::class)
+         ->set('checkboxValues', [
+             0 => '1',
+             1 => '2',
+         ])
+         ->call('exportToCsv', true);
+
+    expect($downloadedFile)->toBeCsvWithContent('export.csv', 'ID,Prato1,"Pastel de Nata"2,"Peixada da chef Nábia"');
 });
 
 it('properly sets CSV separator and delimiter', function () {
-    $component = livewire(ExportTable::class, ['separator' => '|', 'delimiter' => '@'])
+    $downloadedFile = livewire(ExportTable::class, ['separator' => '|', 'delimiter' => '@'])
        ->set('checkboxValues', [
            0 => '1',
        ])
        ->call('exportToCsv', true);
 
-    expect($component)->toBeCsvWithContent('export.csv', 'ID|Prato1|@Pastel de Nata@');
+    expect($downloadedFile)->toBeCsvWithContent('export.csv', 'ID|Prato1|@Pastel de Nata@');
 });
 
 it('properly export csv - all data', function () {
@@ -81,8 +82,10 @@ expect()->extend('toBeCsvWithContent', function (string $filename, $content) {
         data_get($downloadEffect, 'name')
     );
 
+    $regex = '/[^A-Za-z0-9.!?|@,á" ]/';
+
     test()->assertEquals(
-        preg_replace('/[^A-Za-z0-9.!?|@]/', '', $content),
-        preg_replace('/[^A-Za-z0-9.!?|@]/', '', base64_decode(data_get($downloadEffect, 'content'))),
+        preg_replace($regex, '', $content),
+        preg_replace($regex, '', base64_decode(data_get($downloadEffect, 'content'))),
     );
 });

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -37,6 +37,16 @@ it('properly export csv data with selected data', function () {
         ->assertFileDownloaded('export.csv');
 });
 
+it('properly sets CSV separator and delimiter', function () {
+    $component = livewire(ExportTable::class, ['separator' => '|', 'delimiter' => '@'])
+       ->set('checkboxValues', [
+           0 => '1',
+       ])
+       ->call('exportToCsv', true);
+
+    expect($component)->toBeCsvWithContent('export.csv', 'ID|Prato1|@Pastel de Nata@');
+});
+
 it('properly export csv - all data', function () {
     livewire(ExportTable::class)
         ->call('exportToCsv', false)
@@ -48,4 +58,31 @@ it('properly does not export csv data without selected data', function () {
         ->call('exportToCsv', true);
 
     expect(null)->notToBeFileDownloaded($component);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Expectations for this test
+|--------------------------------------------------------------------------
+|
+*/
+
+expect()->extend('notToBeFileDownloaded', function ($component) {
+    $downloadEffect = data_get($component->lastResponse, 'original.effects.download');
+
+    expect($downloadEffect)->toBeNull();
+});
+
+expect()->extend('toBeCsvWithContent', function (string $filename, $content) {
+    $downloadEffect = data_get($this->value->lastResponse, 'original.effects.download');
+
+    test()->assertEquals(
+        $filename,
+        data_get($downloadEffect, 'name')
+    );
+
+    test()->assertEquals(
+        preg_replace('/[^A-Za-z0-9.!?|@]/', '', $content),
+        preg_replace('/[^A-Za-z0-9.!?|@]/', '', base64_decode(data_get($downloadEffect, 'content'))),
+    );
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -213,9 +213,3 @@ function requiresPostgreSQL()
 
     return test();
 }
-
-expect()->extend('notToBeFileDownloaded', function ($component) {
-    $downloadEffect = data_get($component->lastResponse, 'original.effects.download');
-
-    expect($downloadEffect)->toBeNull();
-});


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

# ⚡ PowerGrid ⚡ Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.


💡 Please complete this template to submit a Pull Request, we cannot accept incomplete Pull Requests.

## Guidelines

`   🗒️ `  Please read the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`   ✍️ `  Give this PR a meaningful title.

`   📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

### Related Issue(s)

This PR Fixes the Issue https://github.com/Power-Components/livewire-powergrid/issues/623.

### Description

This Pull Request adds the possibility to set the separator and field delimiter when exporting to CSV.

```php
    public function setUp(): array
    {
        $this->showCheckBox();

        return [
            Exportable::make('export')
                ->csvSeparator('|')
                ->csvDelimiter('@')
                ->type(Exportable::TYPE_CSV),
        ];
    }
```

Resulting in:

```plain
ID|Prato
1|@Pastel de Nata@
```

Instead of the default:

```plain
ID,Prato
1,"Pastel de Nata"
```

This can be useful if the CSV exported by PowerGrid will be imported in some other software with different requirements.


### Contribution Guide

- [X] I have read and followed the steps listed in the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [ ] No
- [X] I have already submitted a Documentation pull request.
