### PR TITLE
Using laravel cookie facade to ensure the cookie is set, encrypted, a…

### DIFF
--- a/resources/stubs/PowerGridDemoTable.stub
+++ b/resources/stubs/PowerGridDemoTable.stub
@@ -86,6 +86,8 @@ final class PowerGridDemoTable extends PowerGridComponent
     */
     public function setUp(): array
     {
+        $this->tableName = 'powergrid_demo_table';
+
         $this->showCheckBox();
 
         return [

--- a/src/Traits/PersistData.php
+++ b/src/Traits/PersistData.php
@@ -2,6 +2,8 @@
 
 namespace PowerComponents\LivewirePowerGrid\Traits;
 
+use Illuminate\Support\Facades\Cookie;
+
 use PowerComponents\LivewirePowerGrid\PowerGridComponent;
 
 trait PersistData
@@ -25,7 +27,7 @@ trait PersistData
         if (!empty($this->persist)) {
             $url  = parse_url(strval(filter_input(INPUT_SERVER, 'HTTP_REFERER')));
             $path = $url && array_key_exists('path', $url) ? $url['path'] : '/';
-            setcookie('pg:' . $this->tableName, strval(json_encode($state)), now()->addYear()->unix(), $path);
+            Cookie::queue('pg:'. $this->tableName, strval(json_encode($state)), now()->addYear(5)->unix());
         }
     }
 
@@ -35,7 +37,7 @@ trait PersistData
             return;
         }
 
-        $cookie = filter_input(INPUT_COOKIE, 'pg:' . $this->tableName);
+        $cookie = Cookie::get('pg:' . $this->tableName);
         if (is_null($cookie)) {
             return;
         }


### PR DESCRIPTION
On a live server running linux, cookies via header are not set because they are unsecure, this addresses that by using Laravels Cookie Facade to set cookies. These cookies are automatically encryted and decrypted by Laravel so they are more secure and cannot be accessed by other websites.

This change also recommends to set the tableName for every table you create that uses the persistData trait, so the cookie names dont conflict which can sometimes cause errors. You may see this recommendation in the Demo Table.

Notice the difference between pg:default cookie and the other cookies with names assigned.

![image](https://user-images.githubusercontent.com/4288353/191883352-0dfc5998-f4ce-4794-b67b-668abc5c766e.png)
