### PR TITLE
Fix detailRow corrupt hydrate + add collapseOthers feature

### DIFF
--- a/src/Detail.php
+++ b/src/Detail.php
@@ -16,6 +16,8 @@ final class Detail
 
     public string $viewIcon = '';
 
+    public bool $collapseOthers = false;
+
     public static function make(): self
     {
         return new Detail();
@@ -28,9 +30,17 @@ final class Detail
         return $this;
     }
 
+    /** @deprecated - use params instead of options, it will deprecate in version 4 */
     public function options(array $options = []): Detail
     {
         $this->options   = $options;
+
+        return $this;
+    }
+
+    public function params(array $params = []): Detail
+    {
+        $this->options   = $params;
 
         return $this;
     }
@@ -39,6 +49,13 @@ final class Detail
     {
         $this->showCollapseIcon = true;
         $this->viewIcon         = $viewIcon;
+
+        return $this;
+    }
+
+    public function collapseOthers(): Detail
+    {
+        $this->collapseOthers   = true;
 
         return $this;
     }

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -320,8 +320,12 @@ class PowerGridComponent extends Component
         }
 
         $collection->each(function ($model) {
-            $id    = intval($model->{$this->primaryKey});
+            $id    = strval($model->{$this->primaryKey});
+
+            data_set($this->setUp, 'detail', (array) $this->setUp['detail']);
+
             $state = data_get($this->setUp, 'detail.state.' . $id, false);
+
             data_set($this->setUp, 'detail.state.' . $id, $state);
         });
     }
@@ -441,6 +445,19 @@ class PowerGridComponent extends Component
 
     public function toggleDetail(string $id): void
     {
+        $detailStates = (array) data_get($this->setUp, 'detail.state');
+
+        if (boolval(data_get($this->setUp, 'detail.collapseOthers'))) {
+            /** @var Support\Enumerable<(int|string), (int|string)> $except */
+            $except = $id;
+            collect($detailStates)->except($except)
+                ->filter(fn ($state) => $state)->keys()
+                ->each(
+                    fn ($key) => data_set($this->setUp, "detail.state.$key", false)
+                );
+        }
+
+        ds(data_get($this->setUp, "detail.state.$id"));
         data_set($this->setUp, "detail.state.$id", !boolval(data_get($this->setUp, "detail.state.$id")));
     }
 

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -457,7 +457,6 @@ class PowerGridComponent extends Component
                 );
         }
 
-        ds(data_get($this->setUp, "detail.state.$id"));
         data_set($this->setUp, "detail.state.$id", !boolval(data_get($this->setUp, "detail.state.$id")));
     }
 

--- a/tests/Feature/ActionRules/DetailRowTest.php
+++ b/tests/Feature/ActionRules/DetailRowTest.php
@@ -2,13 +2,26 @@
 
 use function Pest\Livewire\livewire;
 
-use PowerComponents\LivewirePowerGrid\Button;
 use PowerComponents\LivewirePowerGrid\Rules\Rule;
+
 use PowerComponents\LivewirePowerGrid\Tests\Models\Dish;
 use PowerComponents\LivewirePowerGrid\Tests\RulesToggleDetailTable;
+use PowerComponents\LivewirePowerGrid\{Button, Detail, Footer};
 
 it('change \'detailRow\' component when dish-id == 1', function (string $component, object $params) {
-    livewire($component, ['join' => $params->join])
+    livewire($component, [
+        'join'      => $params->join,
+        'setUpTest' => [
+            Footer::make()
+                ->showPerPage(5),
+
+            Detail::make()
+                ->view('livewire-powergrid::tests.detail')
+                ->params([
+                    'name' => 'Luan',
+                ])
+                ->showCollapseIcon(),
+        ], ])
         ->call($params->theme)
         ->set('testActions', [
             Button::make('toggleDetail', 'Toggle Detail')

--- a/tests/Feature/ActionRules/ToggleDetailTest.php
+++ b/tests/Feature/ActionRules/ToggleDetailTest.php
@@ -2,13 +2,26 @@
 
 use function Pest\Livewire\livewire;
 
-use PowerComponents\LivewirePowerGrid\Button;
 use PowerComponents\LivewirePowerGrid\Rules\Rule;
+
 use PowerComponents\LivewirePowerGrid\Tests\Models\Dish;
 use PowerComponents\LivewirePowerGrid\Tests\RulesToggleDetailTable;
+use PowerComponents\LivewirePowerGrid\{Button, Detail, Footer};
 
 it('add rule \'toggleDetail\' when dishId == 3', function () {
-    livewire(RulesToggleDetailTable::class)
+    livewire(RulesToggleDetailTable::class, [
+        'setUpTest' => [
+            Footer::make()
+                ->showPerPage(5),
+
+            Detail::make()
+                ->view('livewire-powergrid::tests.detail')
+                ->params([
+                    'name' => 'Luan',
+                ])
+                ->showCollapseIcon(),
+        ],
+    ])
         ->set('testActions', [
             Button::make('toggleDetail', 'Toggle Detail')
                 ->class('text-center')

--- a/tests/Feature/DetailRowTest.php
+++ b/tests/Feature/DetailRowTest.php
@@ -4,8 +4,22 @@ use function Pest\Livewire\livewire;
 
 use PowerComponents\LivewirePowerGrid\Tests\RulesToggleDetailTable;
 
+use PowerComponents\LivewirePowerGrid\{Detail, Footer};
+
 it('collapse detail row', function () {
-    livewire(RulesToggleDetailTable::class)
+    livewire(RulesToggleDetailTable::class, [
+        'setUpTest' => [
+            Footer::make()
+                ->showPerPage(5),
+
+            Detail::make()
+                ->view('livewire-powergrid::tests.detail')
+                ->params([
+                    'name' => 'Luan',
+                ])
+                ->showCollapseIcon(),
+        ],
+    ])
         ->assertSee('Pastel de Nata')
         ->assertDontSeeHtml([
             '<div>Id 1</div>',
@@ -76,7 +90,16 @@ it('collapse detail row', function () {
 });
 
 it('render x-data correctly for detail row state', function () {
-    $component = livewire(RulesToggleDetailTable::class);
+    $component = livewire(RulesToggleDetailTable::class, [
+        'setUpTest' => [
+            Footer::make()
+                ->showPerPage(5),
+
+            Detail::make()
+                ->view('livewire-powergrid::tests.detail')
+                ->collapseOthers(),
+        ],
+    ]);
 
     $perPage = data_get($component, 'payload.serverMemo.data.setUp.footer.perPage');
     $xData   = [];
@@ -85,4 +108,78 @@ it('render x-data correctly for detail row state', function () {
     }
 
     $component->assertSeeHtmlInOrder($xData);
+});
+
+it('collapse detail row with collapseOthers', function () {
+    livewire(RulesToggleDetailTable::class, [
+        'setUpTest' => [
+            Footer::make()
+                ->showPerPage(5),
+
+            Detail::make()
+                ->view('livewire-powergrid::tests.detail')
+                ->collapseOthers(),
+        ],
+    ])
+        ->assertSee('Pastel de Nata')
+        ->assertDontSeeHtml([
+            '<div>Id 1</div>',
+        ])
+        ->assertSet('setUp.detail.state', [
+            1 => false,
+            2 => false,
+            3 => false,
+            4 => false,
+            5 => false,
+        ])
+        // show detail row #1
+        ->call('toggleDetail', 1)
+        ->assertSeeHtmlInOrder([
+            '<div>Id 1</div>',
+        ])
+        ->assertSet('setUp.detail.state', [
+            1 => true,
+            2 => false,
+            3 => false,
+            4 => false,
+            5 => false,
+        ])
+        // show detail row #2
+        ->call('toggleDetail', 2)
+        ->assertSet('setUp.detail.state', [
+            1 => false,
+            2 => true,
+            3 => false,
+            4 => false,
+            5 => false,
+        ])
+        // see two details
+        ->assertDontSeeHtml([
+            '<div>Id 1</div>',
+        ])
+        ->assertSeeHtmlInOrder([
+            '<div>Id 2</div>',
+        ])
+        // collapse detail row #2
+        ->call('toggleDetail', 2)
+        ->assertSet('setUp.detail.state', [
+            1 => false,
+            2 => false,
+            3 => false,
+            4 => false,
+            5 => false,
+        ])
+        ->assertDontSeeHtml([
+            '<div>Id 1</div>',
+            '<div>Id 2</div>',
+        ])
+        // collapse detail row #1
+        ->call('toggleDetail', 1)
+        ->assertSet('setUp.detail.state', [
+            1 => true,
+            2 => false,
+            3 => false,
+            4 => false,
+            5 => false,
+        ]);
 });

--- a/tests/RulesToggleDetailTable.php
+++ b/tests/RulesToggleDetailTable.php
@@ -2,31 +2,14 @@
 
 namespace PowerComponents\LivewirePowerGrid\Tests;
 
-use PowerComponents\LivewirePowerGrid\{
-    Detail,
-    Footer,
-    Header};
-
 class RulesToggleDetailTable extends DishTableBase
 {
+    public array $setUpTest = [];
+
     public function setUp(): array
     {
         $this->showCheckBox();
 
-        return [
-            Header::make()
-                ->showSearchInput(),
-
-            Footer::make()
-                ->showPerPage(5)
-                ->showRecordCount(),
-
-            Detail::make()
-                ->view('livewire-powergrid::tests.detail')
-                ->options([
-                    'name' => 'Luan',
-                ])
-                ->showCollapseIcon(),
-        ];
+        return $this->setUpTest;
     }
 }


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

# ⚡ PowerGrid ⚡ Pull Request


## Guidelines

`   🗒️ `  Please read the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`   ✍️ `  Give this PR a meaningful title.

`   📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [x] Bug fix
- [x] New feature
- [ ] Breaking change

### Related Issue(s)

This PR Fixes the Issue #712,.

### Description

This PR fixes the `detailRow` corrupt hydrate (Livewire\CorruptComponentPayloadException) issue when using `$sortDirection.`
Adds the possibility to close other details with `collapseOthers`



### Contribution Guide

- [ ] I have read and followed the steps listed in the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
