### PR TITLE
Macro addition in Button class

### DIFF
--- a/src/Button.php
+++ b/src/Button.php
@@ -2,8 +2,12 @@
 
 namespace PowerComponents\LivewirePowerGrid;
 
+use Illuminate\Support\Traits\Macroable;
+
 final class Button
 {
+    use Macroable;
+
     public string $caption = '';
 
     public string $route = '';
@@ -35,6 +39,8 @@ final class Button
     public array $params = [];
 
     public ?string $id = null;
+
+    public array $dynamicProperties = [];
 
     /**
      * Button constructor.

--- a/src/Helpers/Actions.php
+++ b/src/Helpers/Actions.php
@@ -319,4 +319,9 @@ class Actions
             ]);
         }
     }
+
+    public function getDynamicProperty(string $key): mixed
+    {
+        return data_get($this->action->dynamicProperties, $key);
+    }
 }

--- a/tests/Feature/DynamicButtonPropertyTest.php
+++ b/tests/Feature/DynamicButtonPropertyTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use PowerComponents\LivewirePowerGrid\Button;
+use PowerComponents\LivewirePowerGrid\Helpers\Actions;
+use PowerComponents\LivewirePowerGrid\Themes\{Bootstrap5, Tailwind};
+
+beforeEach(function () {
+    Button::macro('icon', function (string $name) {
+        $this->dynamicProperties['icon'] = $name;
+
+        return $this;
+    });
+});
+
+it('properly handles macroable button method', function (string $theme) {
+    $button = Button::add('edit')
+        ->class('text-center')
+        ->icon('fa-user');
+
+    $actionClass = new Actions(
+        $button,
+        new stdClass(),
+        'id',
+        new $theme(),
+    );
+
+    expect($actionClass->getDynamicProperty('icon'))
+        ->toBe('fa-user');
+})->with('dynamic-action')->group('dynamic-action');
+
+dataset('dynamic-action', [
+    'tailwind'  => [Tailwind::class],
+    'bootstrap' => [Bootstrap5::class],
+]);


### PR DESCRIPTION
## Pull Request Information

### Motivation

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

### Related Issue(s)

This PR Fixes the Issue #715.

### Description

This Pull Request adds an ability to dynamically extend Button class with [macros](https://laravel.com/api/9.x/Illuminate/Support/Traits/Macroable.html).

### Contribution Guide

- [x] I have read and followed the steps listed in the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
