### PR TITLE
In case value is 0, avoid empty check

### DIFF
--- a/resources/views/components/editable.blade.php
+++ b/resources/views/components/editable.blade.php
@@ -12,7 +12,9 @@
 
 @php
     $fallback = html_entity_decode(strval(data_get($editable, 'fallback')), ENT_QUOTES, 'utf-8');
-    $content  = html_entity_decode(strval($helperClass->resolveContent($currentTable, $field, $row)), ENT_QUOTES, 'utf-8') ?: $fallback;
+    $value  = html_entity_decode(strval($helperClass->resolveContent($currentTable, $field, $row)), ENT_QUOTES, 'utf-8');
+
+    $content = !empty($value) || $value == '0' ? $value : $fallback;
 
     $params = [
         'theme' => $theme->name,


### PR DESCRIPTION
## Pull Request Information

### Motivation

- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change

### Related Issue(s)

This PR Fixes the Issue #_____.

### Description

When the value of the field is "0", empty() functions interpretates it string. Therefore, the fields with values of 0 are not displayed.

Current results: https://prnt.sc/wvCoQwKZh11Q

Desired results: https://prnt.sc/pHY-pn8sad1J

### Contribution Guide

- [ x] I have read and followed the steps listed in the [Contributing Guide](https://github.com/Power-Components/livewire-powergrid/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [ x] No
- [ ] I have already submitted a Documentation pull request.
