### PR TITLE
add property $showFilters

### DIFF
--- a/resources/views/components/cols.blade.php
+++ b/resources/views/components/cols.blade.php
@@ -18,7 +18,7 @@
     x-data x-multisort-shift-click="{{ $this->id }}"
     @endif
     style="{{ $column->hidden === true ? 'display:none': '' }}; width: max-content; @if($column->sortable) cursor:pointer; @endif {{ $theme->table->thStyle.' '. $column->headerStyle }}">
-    <div class="text-md flex gap-2 {{ $theme->cols->divClass }}"
+    <div class="{{ $theme->cols->divClass }}"
         @if($column->sortable) wire:click="sortBy('{{ $field }}')" @endif>
         @if($column->sortable)
             <span>

--- a/resources/views/components/frameworks/tailwind/filter.blade.php
+++ b/resources/views/components/frameworks/tailwind/filter.blade.php
@@ -4,7 +4,9 @@
     'tableName' => null,
     'filtersFromColumns' => null,
 ])
-<div x-data={open:false} x-on:toggle-filters-{{ $tableName }}.window="open = !open" class="mt-2 md:mt-0">
+<div x-data="{ open:@entangle('showFilters') }"
+     x-on:toggle-filters-{{ $tableName }}.window="open = !open"
+     class="mt-2 md:mt-0">
     <div x-show="open"
          x-cloak
          x-transition:enter="transform duration-100"

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -78,9 +78,11 @@ class PowerGridComponent extends Component
 
     public bool $deferLoading = false;
 
-    public bool $readyToLoad;
+    public bool $readyToLoad = false;
 
     public string $loadingComponent = '';
+
+    public bool $showFilters = false;
 
     public function mount(): void
     {


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This PR adds a `showFilters` property to allow defining the default state of the filters component. By default it will not be displayed.

If you need to display, set true
```php
public bool $showFilters = true;
```

#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
