### PR TITLE
Added details count to colspan calculation

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -54,6 +54,7 @@
                     <td class="{{ $theme->table->tdBodyClass }}" style="{{ $theme->table->tdBodyStyle }}" colspan="{{ (($checkbox) ? 1:0)
                                     + ((isset($actions)) ? 1: 0)
                                     + (count($columns))
+                                    + (data_get($setUp, 'detail.showCollapseIcon') ? 1: 0)
                                     }}">
                         <span>{{ trans('livewire-powergrid::datatable.labels.no_data') }}</span>
                     </td>


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

The calculations for the 'colspan' attribute did not match, resulting in styling issues, particularly when the table had no data.

Example: https://prnt.sc/j2lVNd-nkWgX 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
