### PR TITLE
Improve search - Add beforeSearch / beforeSearch{Field}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ vendor
 pnpm-lock.yaml
 tmp/
 dist/powergrid.js.LICENSE.txt
+.env

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "test": "@test:sqlite",
         "test:pint": "./vendor/bin/pint --test",
         "test:sqlite": [
-            "./vendor/bin/pest --compact --min=80"
+            "./vendor/bin/pest --compact"
         ],
         "test:mysql":  [
             "./vendor/bin/pest --compact --configuration phpunit.mysql.xml"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "pestphp/pest-plugin-livewire": "^2.0",
         "laravel/pint": "^1.8",
         "nunomaduro/larastan": "^2.5.1",
-        "laradumps/laradumps": "^1.11.0",
+        "laradumps/laradumps": "2.x-dev",
         "spaze/phpstan-disallowed-calls": "^2.12.1"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "pestphp/pest-plugin-livewire": "^2.0",
         "laravel/pint": "^1.9",
         "nunomaduro/larastan": "^2.6.0",
-        "laradumps/laradumps": "2.x-dev",
+        "laradumps/laradumps": "^1.11",
         "spaze/phpstan-disallowed-calls": "^2.13.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
         "composer/composer": "^2.5.5",
         "pestphp/pest-plugin-faker": "^2.0",
         "pestphp/pest-plugin-livewire": "^2.0",
-        "laravel/pint": "^1.8",
-        "nunomaduro/larastan": "^2.5.1",
+        "laravel/pint": "^1.9",
+        "nunomaduro/larastan": "^2.6.0",
         "laradumps/laradumps": "2.x-dev",
-        "spaze/phpstan-disallowed-calls": "^2.12.1"
+        "spaze/phpstan-disallowed-calls": "^2.13.0"
     },
     "suggest": {
         "openspout/openspout": "Required to export XLS and CSV"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4257f9c2bbdcbe6adb72f5ccfe9b5553",
+    "content-hash": "4f76e6e98a519a82acacbd00b5a96078",
     "packages": [
         {
             "name": "brick/math",
@@ -6290,31 +6290,31 @@
         },
         {
             "name": "laradumps/laradumps",
-            "version": "2.x-dev",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laradumps/laradumps.git",
-                "reference": "b13273d49b35d6aa320b8368ea7783f559364252"
+                "reference": "5cde804d47a7567b2a4c75b2491ca7ef36ddbc49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laradumps/laradumps/zipball/b13273d49b35d6aa320b8368ea7783f559364252",
-                "reference": "b13273d49b35d6aa320b8368ea7783f559364252",
+                "url": "https://api.github.com/repos/laradumps/laradumps/zipball/5cde804d47a7567b2a4c75b2491ca7ef36ddbc49",
+                "reference": "5cde804d47a7567b2a4c75b2491ca7ef36ddbc49",
                 "shasum": ""
             },
             "require": {
-                "illuminate/mail": "^9.0|^10.0",
-                "illuminate/support": "^9.0|^10.0",
-                "laradumps/laradumps-core": "dev-main",
-                "nunomaduro/termwind": "^1.15.1",
+                "nunomaduro/termwind": "^1.12",
                 "php": "^8.0"
             },
             "require-dev": {
-                "laravel/pint": "^1.7",
-                "nunomaduro/larastan": "^2.4",
-                "orchestra/testbench": "^7.22 | ^8.0",
-                "pestphp/pest": "^2.2",
-                "symfony/var-dumper": "^5.4 | ^6.2.5"
+                "friendsofphp/php-cs-fixer": "^3.8",
+                "illuminate/console": "^8.18 | ^9.0",
+                "illuminate/mail": "^8.18 | ^9.0",
+                "illuminate/support": "^8.18 | ^9.0",
+                "nunomaduro/larastan": "^1.0 | ^2.1",
+                "orchestra/testbench": "^6.17 | ^7.0",
+                "pestphp/pest": "^1.21",
+                "symfony/var-dumper": "^5.4 | ^6.0"
             },
             "type": "library",
             "extra": {
@@ -6347,7 +6347,7 @@
             "homepage": "https://github.com/laradumps/laradumps",
             "support": {
                 "issues": "https://github.com/laradumps/laradumps/issues",
-                "source": "https://github.com/laradumps/laradumps/tree/2.x"
+                "source": "https://github.com/laradumps/laradumps/tree/v.1.11.0"
             },
             "funding": [
                 {
@@ -6355,70 +6355,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-21T17:50:37+00:00"
-        },
-        {
-            "name": "laradumps/laradumps-core",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laradumps/laradumps-core.git",
-                "reference": "1e704bb505322c2f5990057de2753c6d78106511"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laradumps/laradumps-core/zipball/1e704bb505322c2f5990057de2753c6d78106511",
-                "reference": "1e704bb505322c2f5990057de2753c6d78106511",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "nesbot/carbon": "^2.66",
-                "php": "^8.0",
-                "ramsey/uuid": "^3.9|^4.7.3",
-                "symfony/console": "^6.2.7",
-                "symfony/var-dumper": "^6.2.7",
-                "vlucas/phpdotenv": "^5.5"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.7",
-                "pestphp/pest": "^2.3",
-                "phpstan/phpstan": "^1.10.8"
-            },
-            "default-branch": true,
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "LaraDumps\\LaraDumpsCore\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Luan Freitas",
-                    "email": "luanfreitas10@protonmail.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A dump component for php code.",
-            "homepage": "https://github.com/laradumps/laradumps-core",
-            "support": {
-                "issues": "https://github.com/laradumps/laradumps-core/issues",
-                "source": "https://github.com/laradumps/laradumps-core/tree/main"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/luanfreitasdev",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-04-21T17:25:49+00:00"
+            "time": "2023-04-12T21:15:11+00:00"
         },
         {
             "name": "laravel/pint",
@@ -10789,9 +10726,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "laradumps/laradumps": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bffeec0678f4e239bff224a04b5f3c5a",
+    "content-hash": "4257f9c2bbdcbe6adb72f5ccfe9b5553",
     "packages": [
         {
             "name": "brick/math",
@@ -6422,16 +6422,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "4b8f2ef22bfcddd1d163cfd282e3f42ee1a5cce2"
+                "reference": "eac5ec3d6b5c96543c682e309a10fdddc9f61d80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/4b8f2ef22bfcddd1d163cfd282e3f42ee1a5cce2",
-                "reference": "4b8f2ef22bfcddd1d163cfd282e3f42ee1a5cce2",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/eac5ec3d6b5c96543c682e309a10fdddc9f61d80",
+                "reference": "eac5ec3d6b5c96543c682e309a10fdddc9f61d80",
                 "shasum": ""
             },
             "require": {
@@ -6484,7 +6484,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2023-04-04T13:08:09+00:00"
+            "time": "2023-04-18T14:50:44+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -6834,16 +6834,16 @@
         },
         {
             "name": "nunomaduro/larastan",
-            "version": "2.5.1",
+            "version": "v2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/larastan.git",
-                "reference": "072e2c9566ae000bf66c92384fc933b81885244b"
+                "reference": "ccac5b25949576807862cf32ba1fce1769c06c42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/072e2c9566ae000bf66c92384fc933b81885244b",
-                "reference": "072e2c9566ae000bf66c92384fc933b81885244b",
+                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/ccac5b25949576807862cf32ba1fce1769c06c42",
+                "reference": "ccac5b25949576807862cf32ba1fce1769c06c42",
                 "shasum": ""
             },
             "require": {
@@ -6857,7 +6857,7 @@
                 "illuminate/support": "^9.47.0 || ^10.0.0",
                 "php": "^8.0.2",
                 "phpmyadmin/sql-parser": "^5.6.0",
-                "phpstan/phpstan": "~1.10.3"
+                "phpstan/phpstan": "~1.10.6"
             },
             "require-dev": {
                 "nikic/php-parser": "^4.15.2",
@@ -6906,7 +6906,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/larastan/issues",
-                "source": "https://github.com/nunomaduro/larastan/tree/2.5.1"
+                "source": "https://github.com/nunomaduro/larastan/tree/v2.6.0"
             },
             "funding": [
                 {
@@ -6926,7 +6926,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-03-04T23:46:40+00:00"
+            "time": "2023-04-20T12:40:01+00:00"
         },
         {
             "name": "orchestra/testbench",
@@ -9965,16 +9965,16 @@
         },
         {
             "name": "spaze/phpstan-disallowed-calls",
-            "version": "v2.12.1",
+            "version": "v2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spaze/phpstan-disallowed-calls.git",
-                "reference": "d598c896bcc05f77e8b270f5a249910680686e65"
+                "reference": "ad3a6d043463c441e73f1d190c1a4a19890abf83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spaze/phpstan-disallowed-calls/zipball/d598c896bcc05f77e8b270f5a249910680686e65",
-                "reference": "d598c896bcc05f77e8b270f5a249910680686e65",
+                "url": "https://api.github.com/repos/spaze/phpstan-disallowed-calls/zipball/ad3a6d043463c441e73f1d190c1a4a19890abf83",
+                "reference": "ad3a6d043463c441e73f1d190c1a4a19890abf83",
                 "shasum": ""
             },
             "require": {
@@ -9986,8 +9986,8 @@
                 "nikic/php-parser": "^4.13",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpunit/phpunit": "^7.0 || ^9.4.2",
-                "spaze/coding-standard": "^1.3"
+                "phpunit/phpunit": "^8.5 || ^10.1",
+                "spaze/coding-standard": "^1.6"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -10019,9 +10019,15 @@
             ],
             "support": {
                 "issues": "https://github.com/spaze/phpstan-disallowed-calls/issues",
-                "source": "https://github.com/spaze/phpstan-disallowed-calls/tree/v2.12.1"
+                "source": "https://github.com/spaze/phpstan-disallowed-calls/tree/v2.13.0"
             },
-            "time": "2023-03-20T20:29:04+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/spaze",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-04-24T00:48:17+00:00"
         },
         {
             "name": "symfony/filesystem",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96a0a7fe6212e2a2997b8b3ed1ca9846",
+    "content-hash": "bffeec0678f4e239bff224a04b5f3c5a",
     "packages": [
         {
             "name": "brick/math",
@@ -2509,16 +2509,16 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.x-dev",
+            "version": "4.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "8e955307d32dc9b6992440ff81321d3cb09db75a"
+                "reference": "60a4c63ab724854332900504274f6150ff26d286"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8e955307d32dc9b6992440ff81321d3cb09db75a",
-                "reference": "8e955307d32dc9b6992440ff81321d3cb09db75a",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/60a4c63ab724854332900504274f6150ff26d286",
+                "reference": "60a4c63ab724854332900504274f6150ff26d286",
                 "shasum": ""
             },
             "require": {
@@ -2559,7 +2559,6 @@
                 "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
                 "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "captainhook": {
@@ -2586,7 +2585,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.x"
+                "source": "https://github.com/ramsey/uuid/tree/4.7.4"
             },
             "funding": [
                 {
@@ -2598,7 +2597,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-27T22:05:11+00:00"
+            "time": "2023-04-15T23:01:58+00:00"
         },
         {
             "name": "symfony/console",
@@ -6291,31 +6290,31 @@
         },
         {
             "name": "laradumps/laradumps",
-            "version": "v1.11.0",
+            "version": "2.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laradumps/laradumps.git",
-                "reference": "5cde804d47a7567b2a4c75b2491ca7ef36ddbc49"
+                "reference": "b13273d49b35d6aa320b8368ea7783f559364252"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laradumps/laradumps/zipball/5cde804d47a7567b2a4c75b2491ca7ef36ddbc49",
-                "reference": "5cde804d47a7567b2a4c75b2491ca7ef36ddbc49",
+                "url": "https://api.github.com/repos/laradumps/laradumps/zipball/b13273d49b35d6aa320b8368ea7783f559364252",
+                "reference": "b13273d49b35d6aa320b8368ea7783f559364252",
                 "shasum": ""
             },
             "require": {
-                "nunomaduro/termwind": "^1.12",
+                "illuminate/mail": "^9.0|^10.0",
+                "illuminate/support": "^9.0|^10.0",
+                "laradumps/laradumps-core": "dev-main",
+                "nunomaduro/termwind": "^1.15.1",
                 "php": "^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.8",
-                "illuminate/console": "^8.18 | ^9.0",
-                "illuminate/mail": "^8.18 | ^9.0",
-                "illuminate/support": "^8.18 | ^9.0",
-                "nunomaduro/larastan": "^1.0 | ^2.1",
-                "orchestra/testbench": "^6.17 | ^7.0",
-                "pestphp/pest": "^1.21",
-                "symfony/var-dumper": "^5.4 | ^6.0"
+                "laravel/pint": "^1.7",
+                "nunomaduro/larastan": "^2.4",
+                "orchestra/testbench": "^7.22 | ^8.0",
+                "pestphp/pest": "^2.2",
+                "symfony/var-dumper": "^5.4 | ^6.2.5"
             },
             "type": "library",
             "extra": {
@@ -6348,7 +6347,7 @@
             "homepage": "https://github.com/laradumps/laradumps",
             "support": {
                 "issues": "https://github.com/laradumps/laradumps/issues",
-                "source": "https://github.com/laradumps/laradumps/tree/v.1.11.0"
+                "source": "https://github.com/laradumps/laradumps/tree/2.x"
             },
             "funding": [
                 {
@@ -6356,7 +6355,70 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-12T21:15:11+00:00"
+            "time": "2023-04-21T17:50:37+00:00"
+        },
+        {
+            "name": "laradumps/laradumps-core",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laradumps/laradumps-core.git",
+                "reference": "1e704bb505322c2f5990057de2753c6d78106511"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laradumps/laradumps-core/zipball/1e704bb505322c2f5990057de2753c6d78106511",
+                "reference": "1e704bb505322c2f5990057de2753c6d78106511",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "nesbot/carbon": "^2.66",
+                "php": "^8.0",
+                "ramsey/uuid": "^3.9|^4.7.3",
+                "symfony/console": "^6.2.7",
+                "symfony/var-dumper": "^6.2.7",
+                "vlucas/phpdotenv": "^5.5"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.7",
+                "pestphp/pest": "^2.3",
+                "phpstan/phpstan": "^1.10.8"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LaraDumps\\LaraDumpsCore\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luan Freitas",
+                    "email": "luanfreitas10@protonmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A dump component for php code.",
+            "homepage": "https://github.com/laradumps/laradumps-core",
+            "support": {
+                "issues": "https://github.com/laradumps/laradumps-core/issues",
+                "source": "https://github.com/laradumps/laradumps-core/tree/main"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/luanfreitasdev",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-04-21T17:25:49+00:00"
         },
         {
             "name": "laravel/pint",
@@ -7739,16 +7801,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.18.1",
+            "version": "1.20.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "22dcdfd725ddf99583bfe398fc624ad6c5004a0f"
+                "reference": "90490bd8fd8530a272043c4950c180b6d0cf5f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/22dcdfd725ddf99583bfe398fc624ad6c5004a0f",
-                "reference": "22dcdfd725ddf99583bfe398fc624ad6c5004a0f",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/90490bd8fd8530a272043c4950c180b6d0cf5f81",
+                "reference": "90490bd8fd8530a272043c4950c180b6d0cf5f81",
                 "shasum": ""
             },
             "require": {
@@ -7778,9 +7840,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.18.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.2"
             },
-            "time": "2023-04-07T11:51:11+00:00"
+            "time": "2023-04-22T12:59:35+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -10721,7 +10783,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "laradumps/laradumps": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/phpunit.mysql.xml
+++ b/phpunit.mysql.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix="Test.php">./tests/Feature</directory>
@@ -7,11 +7,7 @@
             <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+    <coverage/>
     <php>
         <server name="APP_ENV" value="testing"/>
         <server name="DB_DRIVER" value="mysql"/>
@@ -21,4 +17,9 @@
         <server name="DB_PASSWORD" value="password"/>
         <server name="DB_DATABASE" value="powergridtest"/>
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/phpunit.pgsql.xml
+++ b/phpunit.pgsql.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix="Test.php">./tests/Feature</directory>
+            <exclude>./tests/Feature/FilterInputOptionsCollectionTest.php</exclude>
             <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+    <coverage/>
     <php>
         <server name="APP_ENV" value="testing"/>
         <server name="DB_DRIVER" value="pgsql"/>
@@ -20,4 +17,9 @@
         <server name="DB_PASSWORD" value="password"/>
         <server name="DB_DATABASE" value="powergridtest"/>
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Test Suite">
       <directory suffix="Test.php">./tests/Feature</directory>
       <directory suffix="Test.php">./tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <coverage>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
+  <coverage/>
   <php>
     <server name="APP_ENV" value="testing"/>
     <server name="DB_DRIVER" value="sqlite"/>
@@ -20,4 +16,9 @@
     <server name="DB_PASSWORD" value=""/>
     <server name="DB_DATABASE" value=":memory:"/>
   </php>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Column.php
+++ b/src/Column.php
@@ -147,8 +147,6 @@ final class Column
     */
     public function searchableRaw(string $sql): Column
     {
-        $this->searchable();
-
         $this->searchableRaw = $sql;
 
         return $this;

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -129,7 +129,7 @@ class Model
                 return $query;
             });
 
-            if (count($this->powerGridComponent->relationSearch)) {
+            if (count($this->powerGridComponent->relationSearch) && $search) {
                 $this->filterRelation($search);
             }
         }
@@ -187,7 +187,7 @@ class Model
         return strval(data_get($column, 'dataField')) ?: strval(data_get($column, 'field'));
     }
 
-    private function getBeforeSearchMethod(string $field, string $search): ?string
+    private function getBeforeSearchMethod(string $field, ?string $search): ?string
     {
         $method = 'beforeSearch' . str($field)->headline()->replace(' ', '');
 

--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -86,6 +86,7 @@ class Model
         if ($this->powerGridComponent->search != '') {
             $search = $this->powerGridComponent->search;
             $search = htmlspecialchars($search, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $search = strtolower($search);
 
             if (method_exists($this->powerGridComponent, 'beforeSearchContains')) {
                 $search = $this->powerGridComponent->beforeSearchContains($search);
@@ -117,7 +118,7 @@ class Model
                                 $driverName = $query->getModel()->getConnection()->getDriverName();
 
                                 if ($columnType === 'json' && strtolower($driverName) !== 'pgsql') {
-                                    $query->orWhereRaw("LOWER(`{$table}`.`{$field}`)" . SqlSupport::like($query) . ":search", ['search' => "%{$search}%"]);
+                                    $query->orWhereRaw("LOWER(`{$table}`.`{$field}`)" . SqlSupport::like($query) . "?", '%' . $search . '%');
                                 } else {
                                     $query->orWhere("{$table}.{$field}", SqlSupport::like($query), "%{$search}%");
                                 }

--- a/tests/DishesBeforeSearchTable.php
+++ b/tests/DishesBeforeSearchTable.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests;
+
+use Illuminate\Database\Eloquent\Builder;
+use PowerComponents\LivewirePowerGrid\Tests\Models\Dish;
+use PowerComponents\LivewirePowerGrid\Traits\ActionButton;
+use PowerComponents\LivewirePowerGrid\{Column,
+    Footer,
+    Header,
+    PowerGrid,
+    PowerGridComponent,
+    PowerGridEloquent};
+
+class DishesBeforeSearchTable extends PowerGridComponent
+{
+    use ActionButton;
+
+    public function setUp(): array
+    {
+        return [
+            Header::make()
+                ->showSearchInput(),
+
+            Footer::make()
+                ->showPerPage()
+                ->showRecordCount(),
+        ];
+    }
+
+    public function beforeSearchName(string $search): string
+    {
+        return 'Peixada';
+    }
+
+    public function datasource(): Builder
+    {
+        return Dish::query();
+    }
+
+    public function addColumns(): PowerGridEloquent
+    {
+        return PowerGrid::eloquent()
+            ->addColumn('id')
+            ->addColumn('name');
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::make('Id', 'id')
+                ->searchable()
+                ->sortable(),
+
+            Column::make('Dish', 'name', 'dishes.name')
+                ->searchable()
+                ->sortable(),
+        ];
+    }
+
+    public function bootstrap(): void
+    {
+        config(['livewire-powergrid.theme' => 'bootstrap']);
+    }
+
+    public function tailwind(): void
+    {
+        config(['livewire-powergrid.theme' => 'tailwind']);
+    }
+}

--- a/tests/DishesSearchableRawTable.php
+++ b/tests/DishesSearchableRawTable.php
@@ -78,7 +78,7 @@ class DishesSearchableRawTable extends PowerGridComponent
                 ->placeholder('Prato placeholder')
                 ->sortable(),
 
-            Column::make('Produced At Formatted', 'produced_at_formatted')
+            Column::make('Produced At Formatted', 'produced_at_formatted', 'produced_Ats')
                 ->searchableRaw($searchableRaw)
                 ->sortable(),
         ];

--- a/tests/DishesSearchableRawTable.php
+++ b/tests/DishesSearchableRawTable.php
@@ -78,7 +78,7 @@ class DishesSearchableRawTable extends PowerGridComponent
                 ->placeholder('Prato placeholder')
                 ->sortable(),
 
-            Column::make('Produced At Formatted', 'produced_at_formatted', 'produced_Ats')
+            Column::make('Produced At Formatted', 'produced_at_formatted', 'produced_at')
                 ->searchableRaw($searchableRaw)
                 ->sortable(),
         ];

--- a/tests/Feature/BeforeSearchTest.php
+++ b/tests/Feature/BeforeSearchTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use function Pest\Livewire\livewire;
+
+use PowerComponents\LivewirePowerGrid\Tests\DishesBeforeSearchTable;
+
+it('searches data using beforeSearch', function (string $component, object $params) {
+    livewire($component)
+        ->call($params->theme)
+        ->set('search', 'Pastel')
+        ->assertSee('Peixada')
+        ->set('search', 'Francesinha')
+        ->assertSee('Peixada')
+        ->set('search', '')
+        ->assertSee('Peixada');
+})->with('before_search_themes');
+
+dataset('before_search_themes', [
+    'tailwind'  => [DishesBeforeSearchTable::class, (object) ['theme' => 'tailwind']],
+    'bootstrap' => [DishesBeforeSearchTable::class, (object) ['theme' => 'bootstrap']],
+]);


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This PR allows you to briefly change the behavior of the 'search' property before performing the search within PowerGrid.

This is useful when we have to handle the query before querying the database. 

For example, we have a phone field without a mask in the database, but the user types the search with a mask. 

With this PR you can do a treatment before removing the characters that do not need to be sent in the query

```php

    public function columns()
    {
        return [
            Column::make('Phone', 'clickable_phone_icon', 'phone')
                  ->visibleInExport(false)
                  ->headerAttribute('w-[160px]')
                  ->bodyAttribute('pl-5 text-start'),
        ];
    }

    public function beforeSearchPhone($search): string
    {
        return str($search)->replaceMatches('/[^0-9]+/', '')->toString();
    }

    public function beforeSearch(string $field = null, string $search = null)
    {
        if ($field === 'phone') {
            return str($search)->replaceMatches('/[^0-9]+/', '')->toString();
        }

        return $search;
    }

``` 

#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
