### PR TITLE
[BUG] Fixed datepicker date formatting

### DIFF
--- a/resources/js/components/pg-flatpickr.js
+++ b/resources/js/components/pg-flatpickr.js
@@ -51,6 +51,8 @@ export default (params) => ({
         }
 
         options.onClose = (selectedDates, dateStr, instance) => {
+            selectedDates = selectedDates.map((date) => this.element.formatDate(date, 'Y-m-d H:i:S'));
+
             const key = `${this.tableName}::${this.dataField}::${selectedDates}`
             const encrypted = Buffer.from(key).toString('base64')
 


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

The date that is passed from _flatpickr_ to _Livewire_ is in the **ISO8601** format, such as `2023-04-30T21:00:00.000Z`. However, when [carbon tries to parse](https://github.com/Power-Components/livewire-powergrid/blob/3.x/src/Traits/Filter.php#L175) this format, it returns the date as `2023-04-30`, even though the actual date should be `2023-05-01`.

See it in action:

https://github.com/Power-Components/livewire-powergrid/assets/10911957/f6e06086-aaa6-4d1e-a846-90217e064893

The PR adds additional date formatting in the frontend that converts _flatpickr_ dates into `Y-m-d H:i:s` format. With this formatting, the filtering feature works as expected, as demonstrated in the following example.

https://github.com/Power-Components/livewire-powergrid/assets/10911957/f7e3d760-4914-4d1e-bef4-1a0950c9eb3d

#### Related Issue(s): #951.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
