### PR TITLE
[BUG] Search filters with AND

### DIFF
--- a/src/Helpers/Model.php
+++ b/src/Helpers/Model.php
@@ -317,7 +317,7 @@ class Model implements ModelFilterInterface
 
     private function filterRelation(): void
     {
-        $this->query = $this->query->where(function (Builder $query) {
+        $this->query = $this->query->orWhere(function (Builder $query) {
             foreach ($this->relationSearch as $table => $relation) {
                 if (!is_array($relation)) {
                     return;


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

My earlier PR #948 fixed bug related to relation filter query being out of scope. However, this fix unintentionally caused some undesirable side effects. Hence, this new PR aims to address those side effects.

Let's consider a table that has searchable columns `first_name` and `last_name` and relation search is also enabled for column `name`. Currently, the query is generated as follows:

```sql
select 
  * 
from 
  `table` 
where 
  (
    (
      `table`.`first_name` LIKE '%test%' 
      or `table`.`last_name` LIKE '%test%'
    ) 
    and (
      exists (
        select 
          * 
        from 
          `table2` 
        where 
          `table`.`column` = `table`.`column` 
          and `name` LIKE '%test%' 
          and `table`.`deleted_at` is null
      )
    )
  ) 
order by 
  `id` asc 
limit 
  10 offset 0
```

As you can see the two search queries are joined by `AND` which is not the desired outcome. This PR would generate slightly different query, such as:

```sql
select 
  * 
from 
  `table` 
where 
  (
    (
      `table`.`first_name` LIKE '%test%' 
      or `table`.`last_name` LIKE '%test%'
    ) 
    or (
      exists (
        select 
          * 
        from 
          `table2` 
        where 
          `table`.`column` = `table`.`column` 
          and `name` LIKE '%test%' 
          and `table`.`deleted_at` is null
      )
    )
  ) 
order by 
  `id` asc 
limit 
  10 offset 0
```

#### Related Issue(s):  #947.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
