### PR TITLE
fixed a bug if the filter contains the name of the datatable ('tabl…

### DIFF
--- a/src/Helpers/Builder.php
+++ b/src/Helpers/Builder.php
@@ -66,11 +66,21 @@ class Builder
                     is_string(key($column[key($column)])) &&
                     count($column[key($column)]) === 1
                 ) {
-                    $field = key(Arr::dot($column));
+                    if (count($column) > 1) {
+                        foreach ($column as $tableName => $columnValue) {
+                            $field = key(Arr::dot($columnValue));
 
-                    $value = Arr::dot($column)[$field];
+                            $value = Arr::dot($columnValue)[$field];
 
-                    $filter($query, $filters, $filterType, $field, $value);
+                            $filter($query, $filters, $filterType, $tableName . '.' . $field, $value);
+                        }
+                    } else {
+                        $field = key(Arr::dot($column));
+
+                        $value = Arr::dot($column)[$field];
+
+                        $filter($query, $filters, $filterType, $field, $value);
+                    }
                 } else {
                     foreach ($column as $field => $value) {
                         if (is_array($value) && $filterType === 'input_text') {

--- a/src/Helpers/Builder.php
+++ b/src/Helpers/Builder.php
@@ -73,7 +73,13 @@ class Builder
                     $filter($query, $filters, $filterType, $field, $value);
                 } else {
                     foreach ($column as $field => $value) {
-                        $filter($query, $filters, $filterType, $field, $value);
+                        if (is_array($value) && $filterType === 'input_text') {
+                            foreach ($value as $arrayField => $arrayValue) {
+                                $filter($query, $filters, $filterType, $arrayField, $arrayValue);
+                            }
+                        } else {
+                            $filter($query, $filters, $filterType, $field, $value);
+                        }
                     }
                 }
             });


### PR DESCRIPTION
…ename.attribut' instead of 'attribut')

<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [X] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

this pull request fixed a bug - fixed a bug if the filter contains the name of the datatable ('tablename.attribut' instead of 'attribut')

you can reproduce it if you set the "field" in the Filter::inputText()-method with the tablename:

```
public function filters(): array
{
    return [
        Filter::inputText('name', 'tablename.name'),
        Filter::inputText('second_field', 'tablename.second_field')
    ];
}
```

If you remove it, the filter works:
```
public function filters(): array
{
    return [
        Filter::inputText('name'),
        Filter::inputText('second_field')
    ];
}
```

#### Related Issue(s):  #971.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.

