### PR TITLE
add content classes

### DIFF
--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -3,15 +3,17 @@
 @foreach ($columns as $column)
     @php
         $content = $row->{$column->field};
+        $contentClassField = $row->{$column->contentClassField};
         $content = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $content);
         $field = $column->dataField != '' ? $column->dataField : $column->field;
+        $contentClass = array_key_exists($content, $column->contentClasess) ? $column->contentClasses[$content] : '';
     @endphp
     <td
         class="{{ $theme->table->tdBodyClass . ' ' . $column->bodyClass ?? '' }}"
         style="{{ $column->hidden === true ? 'display:none' : '' }}; {{ $theme->table->tdBodyStyle . ' ' . $column->bodyStyle ?? '' }}"
     >
         @if (data_get($column->editable, 'hasPermission') && !str_contains($field, '.'))
-            <span class="{{ $theme->clickToCopy->spanClass }}">
+            <span class="{{ $bodyClassField ?? '' . ' ' . $contentClass }} {{ $theme->clickToCopy->spanClass }}">
                 @include($theme->editable->view, ['editable' => $column->editable])
                 @if ($column->clickToCopy)
                     <x-livewire-powergrid::click-to-copy
@@ -30,7 +32,7 @@
             @endphp
             @include($theme->toggleable->view, ['tableName' => $tableName])
         @else
-            <span class="@if ($column->clickToCopy) {{ $theme->clickToCopy->spanClass }} @endif">
+            <span class="{{ $contentClassField ?? '' . ' ' . $contentClass }} @if ($column->clickToCopy) {{ $theme->clickToCopy->spanClass }} @endif">
                 <div>{!! $column->index ? $rowIndex : $content !!}</div>
                 @if ($column->clickToCopy)
                     <x-livewire-powergrid::click-to-copy

--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -3,17 +3,17 @@
 @foreach ($columns as $column)
     @php
         $content = $row->{$column->field};
-        $contentClassField = $row->{$column->contentClassField};
+        $contentClassField = $column->contentClassField != '' ? $row->{$column->contentClassField} : '';
         $content = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $content);
         $field = $column->dataField != '' ? $column->dataField : $column->field;
-        $contentClass = array_key_exists($content, $column->contentClasess) ? $column->contentClasses[$content] : '';
+        $contentClass = array_key_exists($content, $column->contentClasses) ? $column->contentClasses[$content] : '';
     @endphp
     <td
         class="{{ $theme->table->tdBodyClass . ' ' . $column->bodyClass ?? '' }}"
         style="{{ $column->hidden === true ? 'display:none' : '' }}; {{ $theme->table->tdBodyStyle . ' ' . $column->bodyStyle ?? '' }}"
     >
         @if (data_get($column->editable, 'hasPermission') && !str_contains($field, '.'))
-            <span class="{{ $bodyClassField ?? '' . ' ' . $contentClass }} {{ $theme->clickToCopy->spanClass }}">
+            <span class="{{ $contentClassField . ' ' . $contentClass }} {{ $theme->clickToCopy->spanClass }}">
                 @include($theme->editable->view, ['editable' => $column->editable])
                 @if ($column->clickToCopy)
                     <x-livewire-powergrid::click-to-copy
@@ -32,7 +32,7 @@
             @endphp
             @include($theme->toggleable->view, ['tableName' => $tableName])
         @else
-            <span class="{{ $contentClassField ?? '' . ' ' . $contentClass }} @if ($column->clickToCopy) {{ $theme->clickToCopy->spanClass }} @endif">
+            <span class="{{ $contentClassField . ' ' . $contentClass }} @if ($column->clickToCopy) {{ $theme->clickToCopy->spanClass }} @endif">
                 <div>{!! $column->index ? $rowIndex : $content !!}</div>
                 @if ($column->clickToCopy)
                     <x-livewire-powergrid::click-to-copy

--- a/src/Column.php
+++ b/src/Column.php
@@ -16,6 +16,10 @@ final class Column
 
     public string $bodyClass = '';
 
+    public string $contentClassField = '';
+
+    public array $contentClasses = [];
+
     public string $bodyStyle = '';
 
     public string $dataField = '';
@@ -351,6 +355,20 @@ final class Column
             'enabled' => $hasPermission,
             'label'   => $label,
         ];
+
+        return $this;
+    }
+
+    public function contentClassField(string $dataField = ''): Column
+    {
+        $this->contentClassField = $dataField;
+
+        return $this;
+    }
+
+    public function contentClasses(array $array): Column
+    {
+        $this->contentClasses = $array;
 
         return $this;
     }


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

#### Motivation

- [ ] Bug fix
- [ ] Enhancement
- [X] New feature
- [ ] Breaking change

#### Description

This Pull Request adds the ability to set custom per column <span> class attributes using either 
- an array relating possible field values with class attributes
  e.g. `Column::make('Status', 'status')->contentClasses([ 'Incomplete' => 'text-red-600' ]),`
- a database column containing class attributes
  e.g. `'task_types.label_colour as task_type_colour',` in the datasource query,
         `Column::make('Task Type', 'task_type_name')->contentClassField('task_type_colour'),`

![Screenshot from 2023-05-31 20-47-52](https://github.com/Power-Components/livewire-powergrid/assets/47018451/8a56874d-083f-4a78-890f-fe4efda72518)

#### Related Issue(s):  null

#### Documentation


 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [X] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
