### PR TITLE
Apply timezone before cut times (3.x)

### DIFF
--- a/src/Traits/Filter.php
+++ b/src/Traits/Filter.php
@@ -172,8 +172,8 @@ trait Filter
 
         $filterTimezone = new DateTimeZone($data['timezone'] ?? 'UTC');
 
-        $startDate = Carbon::parse($startDate)->format('Y-m-d');
-        $endDate   = Carbon::parse($endDate)->format('Y-m-d');
+        $startDate = Carbon::parse($startDate)->setTimezone($filterTimezone)->format('Y-m-d');
+        $endDate   = Carbon::parse($endDate)->setTimezone($filterTimezone)->format('Y-m-d');
 
         $startDate = Carbon::createFromFormat('Y-m-d', $startDate, $filterTimezone);
         $endDate   = Carbon::createFromFormat('Y-m-d', $endDate, $filterTimezone);


### PR DESCRIPTION
It prevent to lose one day if timezone > 0 
e.g.
if timezone Europe/Moscow (+3)
select 12.07.2023 in input filter
we have 11.07.2023 21:00:00 and then it trim to 11.07.2023 and finaly we have sql query between 11.07.2023 00:00:00 instead of 12.07.2023 00:00:00


--- 
#### Motivation

- [X] Bug fix

