### PR TITLE
fix(filters): fix date filter

### DIFF
--- a/src/Traits/HasFilter.php
+++ b/src/Traits/HasFilter.php
@@ -201,7 +201,7 @@ trait HasFilter
         if (!isset($selectedDates[1])) {
             return;
         }
-        
+
         $this->resetPage();
 
         $input = explode('.', $wireModel);

--- a/src/Traits/HasFilter.php
+++ b/src/Traits/HasFilter.php
@@ -198,6 +198,10 @@ trait HasFilter
         string $type,
         string $timezone = 'UTC',
     ): void {
+        if (!isset($selectedDates[1])) {
+            return;
+        }
+        
         $this->resetPage();
 
         $input = explode('.', $wireModel);


### PR DESCRIPTION
fix "Undefined array key 1" when user did not select second date in date filter

in this patch check and exit from event listener if second date not select.

The alternative solution is put first date to second date. I don't know which is better for general usage

