### PR TITLE
fix(filters): fix input text filter

### DIFF
--- a/resources/views/components/frameworks/bootstrap5/filters/input-text.blade.php
+++ b/resources/views/components/frameworks/bootstrap5/filters/input-text.blade.php
@@ -59,7 +59,7 @@
                     >
                         @foreach ($inputTextOptions as $key => $value)
                             <option
-                                wire:key="{{ uniqid() }}"
+                                wire:key="input-text-options-{{ $tableName }}-{{ $key . '-' . $value }}"
                                 value="{{ $value }}"
                             >{{ trans('livewire-powergrid::datatable.input_text_options.' . $value) }}</option>
                         @endforeach


### PR DESCRIPTION
Input text filter lose options text in bootstrap

key for livewire was unique for every request, it rerender and lose selected visual text option for filter
