### PR TITLE
Added hide classes on the loader

### DIFF
--- a/resources/views/components/frameworks/bootstrap5/header/loading.blade.php
+++ b/resources/views/components/frameworks/bootstrap5/header/loading.blade.php
@@ -3,7 +3,7 @@
     style="padding-left: 10px;"
 >
     <div
-        wire:loading.class="spinner-border"
+        wire:loading.class="spinner-border d-none"
         role="status"
         style="color: #656363;"
     >

--- a/resources/views/components/frameworks/tailwind/header/loading.blade.php
+++ b/resources/views/components/frameworks/tailwind/header/loading.blade.php
@@ -1,7 +1,7 @@
 <div class="hidden lg:!block">
     <div
         wire:loading
-        class="mt-2"
+        class="mt-2 hidden"
     >
         <svg
             class="animate-spin h-5 w-5 text-pg-primary-300 dark:text-pg-primary-400"


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request adds the ability to hide the loader without using the ```withoutLoading()``` which hides the loader for ever.

The CSS classes added hide the loader by default, the ```wire:loading``` adds an inline style ``` style: inline-block`` which will force the loader to show up when the wire loading is triggered.

 I experienced this when I migrated from ```v3``` which had that loading behavior correctly working, but that was not the same in ```v5```.
![2023-10-16_23-14](https://github.com/Power-Components/livewire-powergrid/assets/41122179/6b306985-7843-4a05-8284-5fb23beac6ab)

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
