### PR TITLE
[4.x] Add Bool for Action to Display Left Side Of Table

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -32,6 +32,27 @@
                 />
             @endif
 
+            @if($displayActionsFirst)
+
+                @if (isset($actions) && count($actions))
+                    @php
+                        $responsiveActionsColumnName = PowerComponents\LivewirePowerGrid\Responsive::ACTIONS_COLUMN_NAME;
+
+                        $isActionFixedOnResponsive = isset($this->setUp['responsive']) && in_array($responsiveActionsColumnName, data_get($this->setUp, 'responsive.fixedColumns')) ? true : false;
+                    @endphp
+
+                    <th
+                            @if($isActionFixedOnResponsive) fixed @endif
+                    class="{{ $theme->table->thClass . ' ' . $theme->table->thActionClass }}"
+
+                            style="{{ $theme->table->thStyle . ' ' . $theme->table->thActionStyle }} width: max-content;  cursor:pointer;"
+                            wire:key="{{ md5('actions') }}"
+                    >
+                        {{ trans('livewire-powergrid::datatable.labels.action') }}
+                    </th>
+                @endif
+            @endif
+
             @foreach ($columns as $column)
                 <x-livewire-powergrid::cols
                     :column="$column"
@@ -175,6 +196,16 @@
                     @include('livewire-powergrid::components.checkbox-row', [
                         'attribute' => $row->{$checkboxAttribute},
                     ])
+                @endif
+
+                @if($displayActionsFirst)
+                    <x-livewire-powergrid::actions
+                            :primary-key="$primaryKey"
+                            :tableName="$tableName"
+                            :theme="$theme"
+                            :row="$row"
+                            :actions="$actions"
+                    />
                 @endif
 
                 @include('livewire-powergrid::components.row', ['rowIndex' => $loop->index + 1])

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -83,6 +83,8 @@ class PowerGridComponent extends Component
 
     public bool $showFilters = false;
 
+    public bool $displayActionsFirst = false;
+
     protected ?ProcessDataSource $processDataSourceInstance = null;
 
     public function mount(): void
@@ -123,6 +125,12 @@ class PowerGridComponent extends Component
         $this->checkbox          = true;
         $this->checkboxAttribute = $attribute;
 
+        return $this;
+    }
+
+    public function showActionsFirst(string $attribute = 'id'): PowerGridComponent
+    {
+        $this->displayActionsFirst = true;
         return $this;
     }
 


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Adds the ability to show Row Actions on Left Side of table. Helpful for product tables especially on mobile devices.

Usage:
`public function setUp(): array
    {
        $this->showActionsFirst();
}`
#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x ] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
