### PR TITLE
[BUG] Search query and filters produce wrong results

### DIFF
--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -248,8 +248,13 @@ class PowerGridComponent extends Component
                     ->setColumns($this->columns)
                     ->setSearch($this->search)
                     ->setRelationSearch($this->relationSearch)
+                    ->filterContains();
+            })
+            ->where(function (Eloquent\Builder $query) {
+                Model::query($query)
+                    ->setInputRangeConfig($this->inputRangeConfig)
+                    ->setColumns($this->columns)
                     ->setFilters($this->filters)
-                    ->filterContains()
                     ->filter();
             });
 


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request tackles an issue outlined below. Suppose we have a generated query as follows:

```sql
select * from `products` where ((`products`.`reference` LIKE '%700%' or `products`.`ean13` LIKE '%700%') or (exists (select * from `product_translations` where `products`.`id` = `product_translations`.`product_id` and `name` LIKE '%700%')) and (`active` = 1)) and `products`.`deleted_at` is null order by `id` asc limit 10 offset 0
```

Based on the applied filters, the query is intended to search for products using the query string and then apply filtering, such as `active = 1`. However it was observed that the query returns products matching the search query, but the filtering is entirely ignored.

This Pull Request resolves this issue by segregating the search and filtering into different WHERE statements. The modified query now appears as follows:

```sql
select * from `products` where ((`products`.`reference` LIKE '%700%' or `products`.`ean13` LIKE '%700%') or (exists (select * from `product_translations` where `products`.`id` = `product_translations`.`product_id` and `name` LIKE '%700%'))) and ((`active` = 1)) and `products`.`deleted_at` is null order by `id` asc limit 10 offset 0
```

#### Related Issue(s):  None.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
