### PR TITLE
Fix action buttons to appear inline

### DIFF
--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -56,9 +56,9 @@
             @if (filled(data_get($row, 'actions')) && $column->isAction)
                 @foreach (data_get($row, 'actions') as $key => $action)
                     @if(filled($action))
-                        <div wire:key="action-{{ data_get($row, $primaryKey) }}-{{ $key }}">
+                        <span wire:key="action-{{ data_get($row, $primaryKey) }}-{{ $key }}">
                             {!! $action !!}
-                        </div>
+                        </span>
                     @endif
                 @endforeach
             @endif


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

--- 
#### Motivation

- [ ] Bug fix
- [X] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Earlier versions of PowerGrid would allow all action buttons to be inline within a row, like:

![image](https://github.com/Power-Components/livewire-powergrid/assets/42812604/4a3b3eaa-b402-45f9-b942-582a1c4aac5e)


Since 5.x this has changed as it is contained in individual `div` elements, making it appear more cluttered like:

![image](https://github.com/Power-Components/livewire-powergrid/assets/42812604/7cf749b5-d227-46b2-9bd0-fb453e8a330e)


This PR proposes to change it to `span` elements to fix this and get the same UI as previous versions. 

**Please Note** - I have checked this only with Bootstrap and not with the Tailwind stack, so I am not sure if this breaks something with the Tailwind UI. 

#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
