### PR TITLE
[Feature] Unescape column titles to allow custom html to be shown

### DIFF
--- a/resources/views/components/cols.blade.php
+++ b/resources/views/components/cols.blade.php
@@ -43,6 +43,6 @@
         @else
             <span style="width: 6px"></span>
         @endif
-        <span>{{ $column->title }}</span>
+        <span>{!! $column->title !!}</span>
     </div>
 </th>


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [X] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request unescapes the column title field to allow html to be input in that. This is particularly useful if you do not want the column title to have a string but rather have an icon. Since the column title is expected to be coded in by the developer, I do not think this would be a security issue (i.e. XSS vulnerability)

For example:
If only text is allowed (i.e. currently escapes the title) you would need to label a column for "Visibility" making the size of the column broad like:
![image](https://github.com/Power-Components/livewire-powergrid/assets/42812604/db233c01-7392-47c2-ae62-484cc7892091)

However, with the above PR, you could replace the column title with some html (e.g. fontawesome icon) like:
![image](https://github.com/Power-Components/livewire-powergrid/assets/42812604/268e4555-0493-4328-abca-9f2c913b9220)

Moreover, you could even put icons before your text like: 
![image](https://github.com/Power-Components/livewire-powergrid/assets/42812604/69a79815-d4b7-4fba-995c-10d8f9939929)


Not sure if this would require an update in the documentation - but happy to provide a PR there if needed.

#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
