### PR TITLE
fix clear filter duplicate 

### DIFF
--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -300,7 +300,7 @@ trait Filter
 
                     data_set($column, 'filters', (array) $filter);
 
-                    if (isset($this->filters[data_get($filter, 'key')])
+                    if (isset($this->filters[data_get($filter, 'field')])
                         && in_array(data_get($filter, 'field'), array_keys($this->filters[data_get($filter, 'key')]))
                         && array_values($this->filters[data_get($filter, 'key')])) {
                         $this->enabledFilters[] = [


### PR DESCRIPTION
--- 
#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

fix clear filter duplicate when using multiple filter with the same type, example
```php
            Filter::inputText('key')->operators(['contains']),
            Filter::inputText('type')->operators(['contains']),
```

<img width="1164" alt="image" src="https://github.com/Power-Components/livewire-powergrid/assets/5910636/fa631243-76c5-4f10-92f0-eea19e8a8c9b">

#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
