### PR TITLE
[FIX] Fixes issue with empty th appearing when no data in table. (#1428)

### DIFF
--- a/resources/views/components/table/th-empty.blade.php
+++ b/resources/views/components/table/th-empty.blade.php
@@ -1,14 +1,12 @@
-<th>
-    <tr
-        class="{{ data_get($theme, 'table.trBodyClass') }}"
-        style="{{ data_get($theme, 'table.trBodyStyle') }}"
+<tr
+    class="{{ data_get($theme, 'table.trBodyClass') }}"
+    style="{{ data_get($theme, 'table.trBodyStyle') }}"
+>
+    <th
+        class="{{ data_get($theme, 'table.tdBodyEmptyClass') }}"
+        style="{{ data_get($theme, 'table.tdBodyEmptyStyle') }}"
+        colspan="{{ ($checkbox ? 1 : 0) + count($columns) + (data_get($setUp, 'detail.showCollapseIcon') ? 1 : 0) }}"
     >
-        <td
-            class="{{ data_get($theme, 'table.tdBodyEmptyClass') }}"
-            style="{{ data_get($theme, 'table.tdBodyEmptyStyle') }}"
-            colspan="{{ ($checkbox ? 1 : 0) + count($columns) + (data_get($setUp, 'detail.showCollapseIcon') ? 1 : 0) }}"
-        >
-            <span>{{ trans('livewire-powergrid::datatable.labels.no_data') }}</span>
-        </td>
-    </tr>
-</th>
+        <span>{{ trans('livewire-powergrid::datatable.labels.no_data') }}</span>
+    </th>
+</tr>


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This pull request fixes the issue in which an empty `<th>` appears when there is no data present in a table.  In the `components/table/th-empty.blade.php` file, the container element was a `<th>` tag with a `<tr>` inside it.  A `<th>` tag is used for table cells rather than table rows.  Therefore, the container element should be the `<tr>` tag, and instead of a `<td>` tag for the table cell, we can use `<th>`.

#### Related Issue(s):  #1428 .

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
