### PR TITLE
[FIX] Check Flatpick dependency only in package.json

### DIFF
--- a/src/Actions/CheckDependencyFlatPick.php
+++ b/src/Actions/CheckDependencyFlatPick.php
@@ -16,10 +16,9 @@ class CheckDependencyFlatPick
     {
         return self::checkIfFileContains(
             [
-                base_path('tailwind.config.js'),
-                base_path('resources/js/app.js'),
+                base_path('package.json'),
             ],
-            'flatpickr',
+            '"flatpickr"',
         );
     }
 


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [X] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request removes the verification for _flatpicker_ in `resources/js/app.js` and `tailwind.config.js`as projects might not even use Tailwind. From now on, it searches package.json for `"flatpicker"` (with quotes).

Alternatively, I've considered removing this check if it is too inconvenient for users.

#### Related Issue(s): https://github.com/Power-Components/livewire-powergrid/issues/1437

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.

