### PR TITLE
refix toogle column weird bug change to columns property 

### DIFF
--- a/src/Concerns/Listeners.php
+++ b/src/Concerns/Listeners.php
@@ -26,17 +26,13 @@ trait Listeners
     #[On('pg:toggleColumn-{tableName}')]
     public function toggleColumn(string $field): void
     {
-        $this->visibleColumns = $this->visibleColumns->map(function (\stdClass | array $column) use ($field) {
-            if (is_object($column) && $column->field === $field) {
-                $column->hidden = !$column->hidden;
-            }
+        foreach ($this->columns as &$column) {
+            if (data_get($column, 'field') === $field) {
+                data_set($column, 'hidden', !data_get($column, 'hidden'));
 
-            if (is_array($column) && $column['field'] === $field) {
-                $column['hidden'] = !$column['hidden'];
+                break;
             }
-
-            return $column;
-        });
+        }
 
         $this->persistState('columns');
     }

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -20,7 +20,7 @@ use Throwable;
 /**
  * @property-read mixed $getCachedData
  * @property-read bool $hasColumnFilters
- * @property array|BaseCollection $visibleColumns
+ * @property-read array|BaseCollection $visibleColumns
  */
 class PowerGridComponent extends Component
 {


### PR DESCRIPTION
--- 
#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

i think there is still bug when using this fix #1431 


https://github.com/Power-Components/livewire-powergrid/assets/5910636/95e5d058-0792-4df1-bd6c-caefa0e81077

and i found that visibleColumns is computed property here
<img width="489" alt="image" src="https://github.com/Power-Components/livewire-powergrid/assets/5910636/be43ffd8-ff10-460d-932b-fcefddd121cc">

so its valid that it should be read only property

so i suggest this fix using your original solution with a little change to use columns property

sorry on the confusion on the last PR :)

#### Related Issue(s):  #1431

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
