### PR TITLE
fix: apply select style locally

### DIFF
--- a/resources/css/tailwind.css
+++ b/resources/css/tailwind.css
@@ -47,6 +47,6 @@
     @apply outline-none inline-flex justify-center items-center rounded gap-x-1 text-xs font-semibold px-2.5 py-0.5 text-pg-primary-600 dark:text-pg-primary-200 bg-pg-primary-100 dark:bg-pg-primary-600
 }
 
-select {
+#power-grid-table-container select {
     background-image:  unset !important;
 }


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request adds a local scope to the styling of the select tag. 
Why? Because currently when doing ```import "./../../vendor/power-components/livewire-powergrid/dist/tailwind.css"``` the custom select style is applied throughout the entire website/application, i.e. unintentionally restyling outside the powergrid component.
This PR adds a scope to the selector preventing this.

#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
