### PR TITLE
[FIX] Allow different text cases on component create

### DIFF
--- a/src/Actions/SanitizeComponentName.php
+++ b/src/Actions/SanitizeComponentName.php
@@ -10,7 +10,7 @@ class SanitizeComponentName
             ->rtrim('.php')
             // Remove possible prefix
             ->ltrim('//')
-            //Remove anything but alphanumeric, dot and all slashes
+            //Remove anything but alphanumeric, dot and slashes
             ->replaceMatches('#[^A-Za-z0-9 .//\\\\]#', '')
             //Convert multiple spaces into forward slashes
             ->replaceMatches('/\s+/', '//')
@@ -20,7 +20,6 @@ class SanitizeComponentName
             ->replaceMatches('/\/{2,}/', "\\")
             //Multile dots
             ->replaceMatches('/\.{2,}/', ".")
-            //Left over dots into forward slashes
             ->replace('.', '\\')
             //Left over backslahes into forward slashes
             ->replace('/', '\\')

--- a/src/Support/PowerGridComponentMaker.php
+++ b/src/Support/PowerGridComponentMaker.php
@@ -91,9 +91,15 @@ final class PowerGridComponentMaker
         return $this->isProcessed;
     }
 
-    public function savePath(): string
+    public function savePath(string $filename = ''): string
     {
-        return powergrid_components_path($this->folder . DIRECTORY_SEPARATOR . $this->filename);
+        $path = $this->folder;
+
+        if ($filename !== '') {
+            $path .= $this->folder = DIRECTORY_SEPARATOR . $filename;
+        }
+
+        return powergrid_components_path($path);
     }
 
     public function setModelWithFqn(string $model, string $modelFqn): self
@@ -159,9 +165,9 @@ final class PowerGridComponentMaker
 
     public function saveToDisk(): self
     {
-        File::ensureDirectoryExists(powergrid_components_path());
+        File::ensureDirectoryExists($this->savePath());
 
-        File::put($this->savePath(), $this->saveToString());
+        File::put($this->savePath($this->filename), $this->saveToString());
 
         return $this;
     }
@@ -215,7 +221,6 @@ final class PowerGridComponentMaker
         }
 
         return Str::of($name)->beforeLast('\\')
-            ->title()
             ->toString();
     }
 

--- a/tests/Feature/Actions/SanitizeComponentNameTest.php
+++ b/tests/Feature/Actions/SanitizeComponentNameTest.php
@@ -22,5 +22,12 @@ it('can properly sanitize a component name', function (string $componentName, st
     ['User.Admin.ListTable', 'User\Admin\ListTable'],
     ['List_Table.php', 'ListTable'],
     ['User.Foo', 'User\Foo'],
-
+    ['User\UserTables\ListTable', 'User\UserTables\ListTable'],
+    ['User\user-tables\ListTable', 'User\usertables\ListTable'],
+    ['User\user-tables\ListTable', 'User\usertables\ListTable'],
+    ['User//UserTables//ListTable', 'User\UserTables\ListTable'],
+    ['User//user-tables//ListTable', 'User\usertables\ListTable'],
+    ['User//user-tables//ListTable', 'User\usertables\ListTable'],
+    ['User\tables\ListTable', 'User\tables\ListTable'],
+    ['user\tables\ListTable', 'user\tables\ListTable'],
 ]);

--- a/tests/Feature/Support/PowerGridMakerTest.php
+++ b/tests/Feature/Support/PowerGridMakerTest.php
@@ -27,7 +27,7 @@ it('can make an eloquent component', function () {
 
     expect($component->createdPath())->toBe('app/Livewire/UserTable.php');
 
-    expect($component->savePath())->toEndWith(str_replace('/', DIRECTORY_SEPARATOR, 'app/Livewire/UserTable.php'));
+    expect($component->savePath($component->filename))->toEndWith(str_replace('/', DIRECTORY_SEPARATOR, 'app/Livewire/UserTable.php'));
 });
 
 it('can make an query builder component', function () {
@@ -54,7 +54,7 @@ it('can make an query builder component', function () {
 
     expect($component->createdPath())->toBe('app/Livewire/UserTable.php');
 
-    expect($component->savePath())->toEndWith(str_replace('/', DIRECTORY_SEPARATOR, 'app/Livewire/UserTable.php'));
+    expect($component->savePath($component->filename))->toEndWith(str_replace('/', DIRECTORY_SEPARATOR, 'app/Livewire/UserTable.php'));
 });
 
 it('acceptes different subfolder notations', function (string $name) {
@@ -69,13 +69,14 @@ it('acceptes different subfolder notations', function (string $name) {
 
     expect($component->createdPath())->toBe('app/Livewire/Users/Admins/ListTable.php');
 
-    expect($component->savePath())->toEndWith(str_replace('/', DIRECTORY_SEPARATOR, 'app/Livewire/Users/Admins/ListTable.php'));
+    expect($component->savePath($component->filename))->toEndWith(str_replace('/', DIRECTORY_SEPARATOR, 'app/Livewire/Users/Admins/ListTable.php'));
 })
 ->with(
     ['Users.Admins.ListTable'],
     ['Users\Admins\ListTable'],
     ['Users/Admins/ListTable'],
-    ['Users.Admins/ListTable']
+    ['Users.Admins/ListTable'],
+    ['Users.Admins/ListTable'],
 );
 
 it('can create component with 5 subfolder level', function () {
@@ -90,5 +91,53 @@ it('can create component with 5 subfolder level', function () {
 
     expect($component->createdPath())->toBe("app/Livewire/System/Office/Users/Admin/Active/ListTable.php");
 
-    expect($component->savePath())->toEndWith(str_replace('/', DIRECTORY_SEPARATOR, 'app/Livewire/System/Office/Users/Admin/Active/ListTable.php'));
+    expect($component->savePath($component->filename))->toEndWith(str_replace('/', DIRECTORY_SEPARATOR, 'app/Livewire/System/Office/Users/Admin/Active/ListTable.php'));
 });
+
+it('creates proper components with different name text cases ', function (array $expected) {
+    expect(PowerGridComponentMaker::make($expected['name']))
+      ->namespace->toBe($expected['namespace'])
+      ->fqn->toBe($expected['fqn'])
+      ->htmlTag->toBe($expected['html_tag'])
+    ->createdPath()->toBe($expected['created_path'])
+     ->not->toBeNull();
+})
+->with(
+    [
+        'SysAdmins' => [[
+            'name'         => 'Users\SysAdmins\UserIndexTable',
+            'fqn'          => 'App\Livewire\Users\SysAdmins\UserIndexTable',
+            'namespace'    => 'App\Livewire\Users\SysAdmins',
+            'html_tag'     => '<livewire:users.sysadmins.user-index-table/>',
+            'created_path' => 'app/Livewire/Users/SysAdmins/UserIndexTable.php',
+        ]],
+        'SYSADMINS' => [[
+            'name'         => 'Users\SYSADMINS\UserIndexTable',
+            'fqn'          => 'App\Livewire\Users\SYSADMINS\UserIndexTable',
+            'namespace'    => 'App\Livewire\Users\SYSADMINS',
+            'html_tag'     => '<livewire:users.sysadmins.user-index-table/>',
+            'created_path' => 'app/Livewire/Users/SYSADMINS/UserIndexTable.php',
+        ]],
+        'sys_admins' => [[
+            'name'         => 'Users\sysadmins\UserIndexTable',
+            'fqn'          => 'App\Livewire\Users\sysadmins\UserIndexTable',
+            'namespace'    => 'App\Livewire\Users\sysadmins',
+            'html_tag'     => '<livewire:users.sysadmins.user-index-table/>',
+            'created_path' => 'app/Livewire/Users/sysadmins/UserIndexTable.php',
+        ]],
+        'sys-admins' => [[
+            'name'         => 'Users\sys-admins\UserIndexTable',
+            'fqn'          => 'App\Livewire\Users\sysadmins\UserIndexTable',
+            'namespace'    => 'App\Livewire\Users\sysadmins',
+            'html_tag'     => '<livewire:users.sysadmins.user-index-table/>',
+            'created_path' => 'app/Livewire/Users/sysadmins/UserIndexTable.php',
+        ]],
+        'sysadmins' => [[
+            'name'         => 'Users\sysadmins\UserIndexTable',
+            'fqn'          => 'App\Livewire\Users\sysadmins\UserIndexTable',
+            'namespace'    => 'App\Livewire\Users\sysadmins',
+            'html_tag'     => '<livewire:users.sysadmins.user-index-table/>',
+            'created_path' => 'app/Livewire/Users/sysadmins/UserIndexTable.php',
+        ]],
+    ],
+);


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [X] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request changes the `powergrid:create` command, keeping the text case informed by the user unaltered, while still trying to normalize and prevent mistakes. Before, we tried to fix/standardize the component paths, thus preventing user errors. 

With this PR, we also disable the possibility to create components with dashes or underscores in the name. While PSR-4 cna can resolve underscores in namespaces, this is not very "Laravel like" and users are welcome to rename their folders and namespaces as they want, after the component is created.

```plain
   Enter a name for your new PowerGrid Component:

    Dispatch\ServiceCalls\ServiceCallIndexTable

    Dispatch.ServiceCalls.ServiceCallIndexTable
```

```shell
 ⚡ ServiceCallIndexTable was successfully created at [app/Livewire/Dispatch/ServiceCalls/ServiceCallIndexTable.php].

 💡 include the ServiceCallIndexTable component using the tag: <livewire:dispatch.servicecalls.service-call-index-table/>

 👍 Please consider ⭐ starring ⭐ our repository. Visit: https://github.com/Power-Components/livewire-powergrid
```

When using special characters:

```plain
   Enter a name for your new PowerGrid Component:

     tables/my-tables/UserTable

     tables/my_tables/UserTable

     tables/my-tables/@!$#UserTable

```

Will result in:

```
 ⚡ UserTable was successfully created at [app/Livewire/tables/mytables/UserTable.php].

 💡 include the UserTable component using the tag: <livewire:tables.mytables.user-table/>

 👍 Please consider ⭐ starring ⭐ our repository. Visit: https://github.com/Power-Components/livewire-powergrid
```

#### Related Issue(s):  https://github.com/Power-Components/livewire-powergrid/issues/1450.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
