### PR TITLE
[FEATURE] Add noDataLabel to customize "no records found" message

### DIFF
--- a/resources/views/components/table/no-data-label.blade.php
+++ b/resources/views/components/table/no-data-label.blade.php
@@ -1,0 +1,1 @@
+<span>{!! $noDataLabel !!}</span>

--- a/resources/views/components/table/th-empty.blade.php
+++ b/resources/views/components/table/th-empty.blade.php
@@ -7,6 +7,6 @@
         style="{{ data_get($theme, 'table.tdBodyEmptyStyle') }}"
         colspan="{{ ($checkbox ? 1 : 0) + count($columns) + (data_get($setUp, 'detail.showCollapseIcon') ? 1 : 0) }}"
     >
-        <span>{{ trans('livewire-powergrid::datatable.labels.no_data') }}</span>
+            {!! $this->processNoDataLabel() !!}
     </th>
 </tr>

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -276,6 +276,29 @@ class PowerGridComponent extends Component
         return $this->processDataSourceInstance->get();
     }
 
+    public function processNoDataLabel(): string
+    {
+        $noDataLabel = $this->noDataLabel();
+
+        if ($noDataLabel instanceof View) {
+            return $noDataLabel->with(
+                [
+                    'noDataLabel' => trans('livewire-powergrid::datatable.labels.no_data'),
+                    'theme'       => $this->getTheme(),
+                    'table'       => 'livewire-powergrid::components.table',
+                    'data'        => [],
+                ]
+            )->render();
+        }
+
+        return "<span>{$noDataLabel}</span>";
+    }
+
+    public function noDataLabel(): string|View
+    {
+        return view('livewire-powergrid::components.table.no-data-label');
+    }
+
     private function renderView(mixed $data): Application|Factory|View
     {
         $theme = $this->getTheme();

--- a/tests/Concerns/Components/NoDataCollectionTable.php
+++ b/tests/Concerns/Components/NoDataCollectionTable.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests\Concerns\Components;
+
+use Illuminate\Support\Collection;
+use PowerComponents\LivewirePowerGrid\{
+    Column,
+    PowerGrid,
+    PowerGridComponent,
+    PowerGridFields
+};
+
+class NoDataCollectionTable extends PowerGridComponent
+{
+    public function datasource(): Collection
+    {
+        return collect([]);
+    }
+
+    public function fields(): PowerGridFields
+    {
+        return PowerGrid::fields()
+            ->add('id')
+            ->add('name');
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::add()
+                ->title(__('ID'))
+                ->field('id')
+                ->searchable()
+                ->sortable(),
+
+            Column::add()
+                ->title(__('Name'))
+                ->field('name')
+                ->searchable()
+                ->sortable(),
+
+            Column::action('Action'),
+        ];
+    }
+
+    public function actions($row): array
+    {
+        return [];
+    }
+
+    public function filters(): array
+    {
+        return [];
+    }
+
+    public function bootstrap()
+    {
+        config(['livewire-powergrid.theme' => 'bootstrap']);
+    }
+
+    public function tailwind()
+    {
+        config(['livewire-powergrid.theme' => 'tailwind']);
+    }
+}

--- a/tests/Concerns/Fixtures/views/no-data.blade.php
+++ b/tests/Concerns/Fixtures/views/no-data.blade.php
@@ -1,0 +1,1 @@
+<div><span class="custom">No Data Here!!!</span></div>

--- a/tests/Feature/NoDataTest.php
+++ b/tests/Feature/NoDataTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\View\View;
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Components\NoDataCollectionTable;
+
+use function PowerComponents\LivewirePowerGrid\Tests\Plugins\livewire;
+
+$componentCustomMessage = new class () extends NoDataCollectionTable {
+    public function noDataLabel(): string|View
+    {
+        return 'foo bar 1234';
+    }
+};
+
+$componentCustomView = new class () extends NoDataCollectionTable {
+    public function noDataLabel(): string|View
+    {
+        return view('no-data');
+    }
+};
+
+it('shows the Powergrid default "no data" message', function (string $theme) {
+    livewire(NoDataCollectionTable::class)
+        ->call($theme)
+        ->assertSeeHtml('<span>No records found</span>');
+})->with(['bootstrap', 'tailwind']);
+
+it('shows a custom string message', function ($component, $theme) {
+    livewire($component)
+           ->call($theme)
+           ->assertSeeHtml('<span>foo bar 1234</span>');
+})->with(['string' => [$componentCustomMessage::class]])
+->with(['bootstrap', 'tailwind']);
+
+it('show a view', function ($component, $theme) {
+    $this->app['view']->addLocation(fixturePath('views'));
+
+    livewire($component)
+           ->call($theme)
+           ->assertSeeHtml('<div><span class="custom">No Data Here!!!</span></div>');
+})->with(['view' => [$componentCustomView::class]])
+->with(['bootstrap', 'tailwind']);

--- a/tests/Feature/Support/PowerGridStubTest.php
+++ b/tests/Feature/Support/PowerGridStubTest.php
@@ -25,7 +25,7 @@ it('can set and unset stub vars', function () {
 });
 
 it('can list all variables in stub file', function () {
-    expect(PowerGridStub::make(_fixtureStubPath('demo.stub')))
+    expect(PowerGridStub::make(fixturePath('Stubs/demo.stub')))
       ->listStubVars()
       ->toArray()
       ->toBe([
@@ -37,7 +37,7 @@ it('can list all variables in stub file', function () {
 });
 
 it('properly replaces legacy variables', function () {
-    $stub = PowerGridStub::make(_fixtureStubPath('legacy.stub'))
+    $stub = PowerGridStub::make(fixturePath('Stubs/legacy.stub'))
       ->setVar('namespace', 'App\Livewire')
       ->setVar('model', 'User')
       ->setVar('modelFqn', 'App\Models\User')
@@ -52,11 +52,6 @@ it('properly replaces legacy variables', function () {
     ->toContain("return PowerGrid::fields()->add('created_at');")
     ->toContain("return DB::table('users');");
 });
-
-function _fixtureStubPath(string $filename): string
-{
-    return str_replace('/', DIRECTORY_SEPARATOR, __DIR__ . '/../../Concerns/Fixtures/Stubs/' . $filename);
-}
 
 it('throws FileNotFoundException if template does not exist', function (string $invalidTemplate) {
     PowerGridStub::make($invalidTemplate);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -76,3 +76,8 @@ function requiresOpenSpout()
 
     return test();
 }
+
+function fixturePath(string $filepath): string
+{
+    return str_replace('/', DIRECTORY_SEPARATOR, __DIR__ . '/Concerns/Fixtures/' . ltrim($filepath, '/'));
+}


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request, or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [ ] Enhancement
- [X] New feature
- [ ] Breaking change

#### Description

This Pull Request adds the possibility to customize the no-data message ("No records found") individually in each component.

Individualized messages can be useful when having multiple PowerGrid components on the same page, and they also to provide more contextualized messages to users. 

Usage:

The user may override the method `noDataLabel()` returning his own message.

```php
use Illuminate\View\View;

class DishTable extends PowerGridComponent
{
    //...

    public function noDataLabel(): string|View
    {
        return 'We could not find any dish matching your search.';
    }
}
```

For the user's convenience, the method may also return a `View`.


```php
use Illuminate\View\View;

class DishTable extends PowerGridComponent
{
    //...
    public function noDataLabel(): string|View
    {
        return view('dishes.no-data');
    }
}
```

I will provide a PR in PowerGrid's documentation once the implementation is approved.

#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [X] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
