### PR TITLE
Create PowerGrid Components in different directories following Livewire Class Namespace

### DIFF
--- a/resources/config/livewire-powergrid.php
+++ b/resources/config/livewire-powergrid.php
@@ -124,4 +124,19 @@ return [
             'csv'  => \PowerComponents\LivewirePowerGrid\Components\Exports\OpenSpout\v3\ExportToCsv::class,
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-Discover Models
+    |--------------------------------------------------------------------------
+    |
+    | PowerGrid will search for Models in the directories listed below.
+    | These Models be listed as options when you run the
+    | "artisan powergrid:create" command.
+    |
+    */
+
+    'auto_discover_models_paths' => [
+        app_path('Models'),
+    ],
 ];

--- a/src/Actions/AskModelName.php
+++ b/src/Actions/AskModelName.php
@@ -18,7 +18,7 @@ final class AskModelName
         {
             while (self::$model === '') {
                 self::setModel(suggest(
-                    label: 'Select a Model or enter its Name/FQN class.',
+                    label: 'Select a Model or enter its Fully qualified name.',
                     options: ListModels::handle(),
                     required: true,
                 ));

--- a/src/Actions/ParseFqnClassInCode.php
+++ b/src/Actions/ParseFqnClassInCode.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Actions;
+
+final class ParseFqnClassInCode
+{
+    /**
+     * Parse namespace from PHP source code
+     * Inspired by: https://gist.github.com/ludofleury/1886076
+     * @throws \Exception
+     */
+    public static function handle(string $sourceCode): string
+    {
+        if (preg_match('#^namespace\s+(.+?);.*class\s+(\w+).+;$#sm', $sourceCode, $matches)) {
+            return $matches[1] . '\\' . $matches[2];
+        }
+
+        throw new \Exception('could not find a FQN Class is source-code');
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -58,9 +58,9 @@ if (!function_exists('convertObjectsToArray')) {
 if (!function_exists('powergrid_components_path')) {
     function powergrid_components_path(string $filename = ''): string
     {
-        return app_path(
+        return base_path(
             str(strval(config('livewire.class_namespace')))
-                ->ltrim('App//')
+                 ->replace('App', 'app')
                 ->append(DIRECTORY_SEPARATOR . $filename)
                 ->replace('\\', '/')
                 ->replace('//', '/')

--- a/tests/Feature/Actions/ListModelsTest.php
+++ b/tests/Feature/Actions/ListModelsTest.php
@@ -1,20 +1,28 @@
-<?php
 
-use Illuminate\Support\Facades\File;
+<?php
 
 use PowerComponents\LivewirePowerGrid\Actions\ListModels;
 
-beforeEach(function () {
-    File::cleanDirectory(base_path('app/Models'));
+it('list all Eloquent Models in a directory', function () {
+    app()->config->set('livewire-powergrid.auto_discover_models_paths', [
+        'tests/Concerns/Models',
+    ]);
 
-    $this->artisan('make:model Demo');
-});
-
-test('list models', function () {
     expect(ListModels::handle())->toBe(
         [
-            'Demo',
-            'App\Models\Demo',
+            'PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Category',
+            'PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Chef',
+            'PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Dish',
+            'PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Restaurant',
         ]
     );
+});
+
+it('will not list non-Eloquent Models', function () {
+    app()->config->set('livewire-powergrid.auto_discover_models_paths', [
+        'tests/Concerns/Enums', //There are no models in this directory.
+
+    ]);
+
+    expect(ListModels::handle())->toBe([]);
 });

--- a/tests/Feature/Actions/ParseFqnClassInCodeTest.php
+++ b/tests/Feature/Actions/ParseFqnClassInCodeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use PowerComponents\LivewirePowerGrid\Actions\ParseFqnClassInCode;
+
+it('can find the namespace in a PHP file source code', function () {
+    $code = <<<EOD
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DemoModel extends Model
+{
+    use HasFactory;
+}
+EOD;
+
+    expect(ParseFqnClassInCode::handle($code))->toBe('App\Models\DemoModel');
+});
+
+it('throws an exception when namespace cannot be found', function () {
+    ParseFqnClassInCode::handle('foobar');
+})->throws('could not find a FQN Class is source-code');

--- a/tests/Feature/Support/PowerGridMakerTest.php
+++ b/tests/Feature/Support/PowerGridMakerTest.php
@@ -141,3 +141,23 @@ it('creates proper components with different name text cases ', function (array 
         ]],
     ],
 );
+
+test('Livewire class namespace is App\Livewire')
+  ->expect(fn () => config('livewire.class_namespace'))->toBe('App\Livewire');
+
+it('can create component in a custom Livewire namespace', function () {
+    app()->config->set('livewire.class_namespace', 'Domains');
+
+    $component = PowerGridComponentMaker::make('System/Office/Users/Admin/Active/ListTable');
+
+    expect($component)
+      ->name->toBe('ListTable')
+      ->namespace->toBe('Domains\System\Office\Users\Admin\Active')
+      ->folder->toBe('System\Office\Users\Admin\Active')
+      ->fqn->toBe('Domains\System\Office\Users\Admin\Active\ListTable')
+      ->htmlTag->toBe('<livewire:system.office.users.admin.active.list-table/>');
+
+    expect($component->createdPath())->toBe("Domains/System/Office/Users/Admin/Active/ListTable.php");
+
+    expect($component->savePath($component->filename))->toEndWith(str_replace('/', DIRECTORY_SEPARATOR, 'Domains/System/Office/Users/Admin/Active/ListTable.php'));
+});


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [X] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This pull request improves the compatibility with Livewire Class Namespace configuration, allowing to create PowerGrid tables outside the `app/Models` directory.

To illustrate a use case, let's see an example where the application is organized in a Domain-Driven Design. Here is the directory structure:

```text
|_app
|_bootstrap
|_config
|_database
|_Domain
   |____Client
   |_________Models
   |_________Tables
   |____User
```

By default, PowerGrid auto discovers Models living in the directory `app/Models/`. This PR, presents the new configuration key `livewire-powergrid.auto_discover_models_paths`, providing a simple way to register new directories to be scanned for Eloquent Models.

After publishing the configuration file by running `php artisan vendor:publish --tag=livewire-powergrid-config`, users can register directories as demonstrated below:

```php
//config/livewire-powergrid.php

    /*
    |--------------------------------------------------------------------------
    | Auto-Discover Models
    |--------------------------------------------------------------------------
    |
    | PowerGrid will search for Models in the directories listed below.
    | These Models be listed as options when you run the
    | "artisan powergrid:create" command.
    |
    */

    'auto_discover_models_paths' => [
        app_path('Models'),
        base_path('Domain'),
    ],
```

Now, when running `php artisan powergrid:create`, the user will be presented with a list of Models found in the specified directories:

```text
 Select a Model or enter its Fully qualified name
 › Domain\Client\Models\Client
   Domain\User\Models\User
```

To maintain consistency when saving files, PowerGrid will follow the Livewire Config Key `livewire.class_namespace`.

To adjust the configuration, run:  `php artisan livewire:publish --config`. 

In our example, Livewire Namespace can be adjusted as follows:

```php
//config/livewire.php

    /*
    |---------------------------------------------------------------------------
    | Class Namespace
    |---------------------------------------------------------------------------
    |
    | This value sets the root class namespace for Livewire component classes in
    | your application. This value will change where component auto-discovery
    | finds components. It's also referenced by the file creation commands.
    |
    */

    'class_namespace' => 'Domain',
```

When running `php artisan powergrid:create`, the user can enter the component name following the desired path. For example:

```text
Enter a name for your new PowerGrid Component:
Client\Tables\ClientList
```

This will result in:

```text
 ⚡ ClientList was successfully created at [Domain/Client/Tables/ClientList.php].

 💡 include the ClientList component using the tag: <livewire:client.tables.client-list/>

 👍 Please consider ⭐ starring ⭐ our repository. Visit: https://github.com/Power-Components/livewire-powergrid
 ```

As a reminder, the `Domain` directory must be added to autoload in `composer.json`:

```json
    "autoload": {
        "psr-4": {
            "App\\": "app/",
            "Database\\Factories\\": "database/factories/",
            "Database\\Seeders\\": "database/seeders/",
            "Domain\\": "Domain/"
        }
    },
```

#### Related Issue(s):  https://github.com/Power-Components/livewire-powergrid/issues/1499

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [X] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
