### PR TITLE
Fix: cast value to a decimal

### DIFF
--- a/src/PowerGridFields.php
+++ b/src/PowerGridFields.php
@@ -18,8 +18,17 @@ final class PowerGridFields
      */
     public function add(string $fieldName, Closure $closure = null): PowerGridFields
     {
-        $this->fields[$fieldName] = $closure ?? fn ($model) => data_get($model, $fieldName);
+        $this->fields[$fieldName] = $closure ?? fn ($model) => $this->valueIsString(data_get($model, $fieldName));
 
         return $this;
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    private function valueIsString(mixed $value): mixed
+    {
+        return is_string($value) ? e($value) : $value;
     }
 }

--- a/src/PowerGridFields.php
+++ b/src/PowerGridFields.php
@@ -18,7 +18,7 @@ final class PowerGridFields
      */
     public function add(string $fieldName, Closure $closure = null): PowerGridFields
     {
-        $this->fields[$fieldName] = $closure ?? fn ($model) => e(strval(data_get($model, $fieldName)));
+        $this->fields[$fieldName] = $closure ?? fn ($model) => data_get($model, $fieldName);
 
         return $this;
     }

--- a/tests/Concerns/Models/Dish.php
+++ b/tests/Concerns/Models/Dish.php
@@ -29,6 +29,13 @@ class Dish extends Model
 
     protected $table = 'dishes';
 
+    protected $casts = [
+        'in_stock'    => 'boolean',
+        'active'      => 'boolean',
+        'price'       => 'float',
+        'produced_at' => 'datetime',
+    ];
+
     public static function servedAt()
     {
         return  self::select('serving_at')->distinct('serving_at')->get();

--- a/tests/Concerns/Models/Order.php
+++ b/tests/Concerns/Models/Order.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests\Concerns\Models;
+
+use Illuminate\Database\Eloquent\{Model, SoftDeletes};
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property float $price
+ * @property float $tax
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Carbon $produced_at
+ */
+class Order extends Model
+{
+    use SoftDeletes;
+
+    protected $guarded = [];
+
+    protected $table = 'orders';
+
+    protected $casts = [
+        'name'  => 'string',
+        'price' => 'decimal:2',
+        'tax'   => 'float',
+    ];
+}

--- a/tests/Concerns/TestDatabase.php
+++ b/tests/Concerns/TestDatabase.php
@@ -80,6 +80,15 @@ class TestDatabase
             $table->foreignId('category_id');
             $table->timestamps();
         });
+
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->double('tax')->nullable();
+            $table->decimal('price')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+        });
     }
 
     public static function seed(array $dishes = []): void
@@ -91,6 +100,7 @@ class TestDatabase
         DB::table('chefs')->truncate();
         DB::table('restaurants')->truncate();
         DB::table('category_chef')->truncate();
+        DB::table('orders')->truncate();
 
         Schema::enableForeignKeyConstraints();
 
@@ -113,6 +123,12 @@ class TestDatabase
 
         DB::table('restaurants')->insert([
             ['name' => 'Not McDonalds'],
+        ]);
+
+        DB::table('orders')->insert([
+            ['name' => 'Order 1', 'price' => 10.00, 'tax' => 127.30],
+            ['name' => 'Order 2', 'price' => 20.00, 'tax' => 259.50],
+            ['name' => 'Order 3', 'price' => null, 'tax' => null],
         ]);
 
         if (empty($dishes)) {

--- a/tests/Concerns/TestDatabase.php
+++ b/tests/Concerns/TestDatabase.php
@@ -31,6 +31,7 @@ class TestDatabase
         Schema::dropIfExists('chefs');
         Schema::dropIfExists('restaurants');
         Schema::dropIfExists('category_chef');
+        Schema::dropIfExists('orders');
     }
 
     public static function migrate(): void

--- a/tests/Feature/Actions/ListModelsTest.php
+++ b/tests/Feature/Actions/ListModelsTest.php
@@ -13,6 +13,7 @@ it('list all Eloquent Models in a directory', function () {
             'PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Category',
             'PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Chef',
             'PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Dish',
+            'PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Order',
             'PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Restaurant',
         ]
     );

--- a/tests/Feature/PowerGridFieldsTest.php
+++ b/tests/Feature/PowerGridFieldsTest.php
@@ -1,0 +1,45 @@
+<?php
+use Illuminate\Database\Eloquent\Builder;
+use PowerComponents\LivewirePowerGrid\PowerGrid;
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Order;
+
+use function PowerComponents\LivewirePowerGrid\Tests\Plugins\livewire;
+
+use PowerComponents\LivewirePowerGrid\{Column, PowerGridComponent, PowerGridFields};
+
+$component = new class () extends PowerGridComponent {
+    public function datasource(): Builder
+    {
+        return Order::query();
+    }
+
+    public function fields(): PowerGridFields
+    {
+        return PowerGrid::fields()
+            ->add('name')
+            ->add('tax')
+            ->add('price')
+            ->add('price_formatted', fn (Order $model) => $model->price * 100);
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::make('Name', 'name'),
+            Column::make('Price', 'price_formatted', 'price'),
+            Column::make('Tax', 'tax'),
+        ];
+    }
+};
+
+it('can add fields', function (string $name, string|float $price, string|float $tax) use ($component) {
+    $component = livewire($component::class);
+
+    $component->assertSee($name)
+              ->assertSee($price)
+              ->assertSee($tax);
+})->with([
+    ['Order 1', 1000, 127.30],
+    ['Order 2', 2000, 259.50],
+    ['Order 3', '', ''],
+]);


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [X] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request adds...

#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.


This Pr fixes a bug, let's understand the problem. Let's say we have an Orders table with the amount field of decimal type in which NULL VALUE is allowed.

In the Order model, define the cast, e.g.: 


```php
 protected $casts = [
        'amount' => 'decimal:2',
    ];
 ```

Component PowerGrid

```php

 public function datasource(): Builder
    {
        return Order::query();
    }

    public function fields(): PowerGridFields
    {
        return PowerGrid::fields()
            ->add('amount')
            ->add('amount_formatted', fn (Order $model) => formatCurrency($model->amount));

    }

 ```

When I access the page, a cast error appears.

![image](https://github.com/Power-Components/livewire-powergrid/assets/6696213/ce91933a-fd50-4a96-9e21-0cf1ada588e8)

Reason for the error, this transforms all values into strings, when the amount field is null in the table, the code below transforms the value of the amount field into an empty string, ""

```php
     e(strval(data_get($model, $fieldName))
 ```
this ends up resulting in an error because it is trying to convert an empty string to decimal

```php
Illuminate\Database\Eloquent\Concerns\HasAttributes.php

 protected function asDecimal($value, $decimals)
    {
        
        try {
            return (string) BigDecimal::of($value)->toScale($decimals, RoundingMode::HALF_UP);
        } catch (BrickMathException $e) {
            throw new MathException('Unable to cast value to a decimal.', previous: $e);
        }
    }
 ```
There are three ways to solve the problem.

1. accept this PR.
2. send a PR to Laravel, inserting a check, that is, checking whether the $value is a number in the asDecimal() method.
3. add a callable to the field, forcing it to return the original value from the table, e.g.:

```php
 public function fields(): PowerGridFields
    {
        return PowerGrid::fields()
            ->add('amount', fn (Order $model) => $model->amount)
            ->add('amount_formatted', fn (Order $model) => formatCurrency($model->amount));

    }
 ```


