### PR TITLE
[TESTS] Enhance PowerGrid Fields tests

### DIFF
--- a/tests/Concerns/Components/OrderTable.php
+++ b/tests/Concerns/Components/OrderTable.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests\Concerns\Components;
+
+use Illuminate\Database\Eloquent\Builder;
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Order;
+use PowerComponents\LivewirePowerGrid\{
+    Column,
+    PowerGrid,
+    PowerGridComponent,
+    PowerGridFields,
+};
+
+class OrderTable extends PowerGridComponent
+{
+    public function datasource(): Builder
+    {
+        return Order::query();
+    }
+
+    public function fields(): PowerGridFields
+    {
+        return PowerGrid::fields()
+            ->add('name')
+            ->add('tax')
+            ->add('price')
+            ->add('link', fn (Order $order): string|null => $order->link)
+            ->add('is_active_label', fn (Order $order): string => $order->price ? 'active' : 'inactive')
+            ->add('price_formatted', fn (Order $order): float => $order->price * 100);
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::make('Name', 'name'),
+            Column::make('Link', 'link'),
+            Column::make('Is Active', 'is_active_label'),
+            Column::make('Price', 'price_formatted', 'price'),
+            Column::make('Tax', 'tax'),
+        ];
+    }
+
+    public function bootstrap()
+    {
+        config(['livewire-powergrid.theme' => 'bootstrap']);
+    }
+
+    public function tailwind()
+    {
+        config(['livewire-powergrid.theme' => 'tailwind']);
+    }
+}

--- a/tests/Concerns/Models/Order.php
+++ b/tests/Concerns/Models/Order.php
@@ -23,8 +23,10 @@ class Order extends Model
     protected $table = 'orders';
 
     protected $casts = [
-        'name'  => 'string',
-        'price' => 'decimal:2',
-        'tax'   => 'float',
+        'name'      => 'string',
+        'link'      => 'string',
+        'price'     => 'decimal:2',
+        'tax'       => 'float',
+        'is_active' => 'boolean',
     ];
 }

--- a/tests/Concerns/TestDatabase.php
+++ b/tests/Concerns/TestDatabase.php
@@ -4,7 +4,7 @@ namespace PowerComponents\LivewirePowerGrid\Tests\Concerns;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\{DB, Schema};
-use PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Chef;
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\{Category, Chef};
 
 class TestDatabase
 {
@@ -85,8 +85,10 @@ class TestDatabase
         Schema::create('orders', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            $table->string('link')->nullable();
             $table->double('tax')->nullable();
             $table->decimal('price')->nullable();
+            $table->boolean('is_active')->default(false);
             $table->softDeletes();
             $table->timestamps();
         });
@@ -127,9 +129,9 @@ class TestDatabase
         ]);
 
         DB::table('orders')->insert([
-            ['name' => 'Order 1', 'price' => 10.00, 'tax' => 127.30],
-            ['name' => 'Order 2', 'price' => 20.00, 'tax' => 259.50],
-            ['name' => 'Order 3', 'price' => null, 'tax' => null],
+            ['name' => 'Order 1', 'price' => 10.00, 'tax' => 127.30, 'is_active' => true],
+            ['name' => 'Order 2', 'price' => 20.00, 'tax' => 259.50, 'is_active' => true],
+            ['name' => 'Order 3', 'price' => null, 'tax' => null, 'is_active' => false],
         ]);
 
         if (empty($dishes)) {
@@ -138,15 +140,10 @@ class TestDatabase
 
         DB::table('dishes')->insert($dishes);
 
-        $chefCategories = [
-            'Luan'    => [1, 3, 4],
-            'Dan'     => [2, 5],
-            'Vitor'   => [5, 6],
-            'Claudio' => [1, 6, 7],
-        ];
+        $chefCategories = Category::all();
 
         Chef::query()->get()->each(function (Chef $chef) use ($chefCategories) {
-            $chef->categories()->attach($chefCategories[$chef->name]);
+            $chef->categories()->attach($chefCategories->shuffle()->take(rand(1, 4)));
         });
     }
 

--- a/tests/Feature/PowerGridFieldsTest.php
+++ b/tests/Feature/PowerGridFieldsTest.php
@@ -5,6 +5,36 @@ use PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Order;
 
 use function PowerComponents\LivewirePowerGrid\Tests\Plugins\livewire;
 
+it('removes <script> tag from custom field', function (string $component, object $params) {
+    Order::first()->update(['link' => 'hello there! <script>alert(document.cookie)</script>']);
+
+    livewire($component)
+        ->call($params->theme)
+        ->assertDontSeeHtml('&lt;script&gt;alert')
+        ->assertDontSeeHtml('<script>alert')
+        ->assertSeeHtml('hello there!');
+})->with('order_table');
+
+it('runs e() helper in PG fields', function (string $component, object $params) {
+    Order::first()->update(['name' => '<img src="invalid_url.png" onerror=alert(document.cookie)>']);
+
+    livewire($component)
+        ->call($params->theme)
+        ->assertDontSeeHtml('<img src="invalid_url.png"')
+        ->assertSeeHtml('<div>&lt;img src=&quot;invalid_url.png&quot; onerror=alert(document.cookie)&gt;');
+})->with('order_table');
+
+it('does not run e() in custom PG fields', function (string $component, object $params) {
+    $link = '<a href="https://google.com" target="_blank">Link from closure</a>';
+
+    Order::first()->update(['link' => $link]);
+
+    livewire($component)
+        ->call($params->theme)
+        ->assertDontSeeHtml(e($link))
+        ->assertSeeHtml($link);
+})->with('order_table');
+
 it('can fields with casting and custom fields', function (string $component, object $params) {
     livewire($component)
         ->call($params->theme)

--- a/tests/Feature/PowerGridFieldsTest.php
+++ b/tests/Feature/PowerGridFieldsTest.php
@@ -1,45 +1,20 @@
 <?php
-use Illuminate\Database\Eloquent\Builder;
-use PowerComponents\LivewirePowerGrid\PowerGrid;
+
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Components\OrderTable;
 use PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Order;
 
 use function PowerComponents\LivewirePowerGrid\Tests\Plugins\livewire;
 
-use PowerComponents\LivewirePowerGrid\{Column, PowerGridComponent, PowerGridFields};
+it('can fields with casting and custom fields', function (string $component, object $params) {
+    livewire($component)
+        ->call($params->theme)
+        ->assertSeeHtmlInOrder(['Order 1', 'Order 2', 'Order 3'])
+        ->assertSeeHtmlInOrder(['active', 'active', 'inactive'])
+        ->assertSeeHtmlInOrder(['1000', '2000', '0'])
+        ->assertSeeHtmlInOrder(['127.3', '259.5', '']);
+})->with('order_table');
 
-$component = new class () extends PowerGridComponent {
-    public function datasource(): Builder
-    {
-        return Order::query();
-    }
-
-    public function fields(): PowerGridFields
-    {
-        return PowerGrid::fields()
-            ->add('name')
-            ->add('tax')
-            ->add('price')
-            ->add('price_formatted', fn (Order $model) => $model->price * 100);
-    }
-
-    public function columns(): array
-    {
-        return [
-            Column::make('Name', 'name'),
-            Column::make('Price', 'price_formatted', 'price'),
-            Column::make('Tax', 'tax'),
-        ];
-    }
-};
-
-it('can add fields', function (string $name, string|float $price, string|float $tax) use ($component) {
-    $component = livewire($component::class);
-
-    $component->assertSee($name)
-              ->assertSee($price)
-              ->assertSee($tax);
-})->with([
-    ['Order 1', 1000, 127.30],
-    ['Order 2', 2000, 259.50],
-    ['Order 3', '', ''],
+dataset('order_table', [
+    'tailwind'  => [OrderTable::class, (object) ['theme' => 'tailwind']],
+    'bootstrap' => [OrderTable::class, (object) ['theme' => 'bootstrap']],
 ]);


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [X] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request aims to enhance the tests for PowerGrid Fields, covering the following topics:

- Automatic usage of `htmlentities` via Laravel's [e() helper](https://laravel.com/docs/strings#method-e) in `PowerGrid::fields->add()`;
- No utilization of the `e()` helper in PowerGrid Custom Fields `PowerGrid::fields->add('field', closure)`;
- Automatic removal of `<script>` tag in Custom Fields;
- Table with Model Casting (string, decimal, float and boolean) and `nullable` fields.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
