### PR TITLE
Improve performance on search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "laradumps/laradumps-core": "^2.0",
     "larastan/larastan": "^2.9.0",
     "pestphp/pest": "^2.34.0",
-    "orchestra/testbench": "8.19|^9.0"
+    "orchestra/testbench": "8.19|^9.0",
+    "laradumps/laradumps": "^3.1"
   },
   "suggest": {
     "openspout/openspout": "Required to export XLS and CSV"

--- a/src/DataSource/Builder.php
+++ b/src/DataSource/Builder.php
@@ -5,7 +5,7 @@ namespace PowerComponents\LivewirePowerGrid\DataSource;
 use Illuminate\Database\Eloquent\{Builder as EloquentBuilder, RelationNotFoundException};
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\{Cache, DB, Schema};
+use Illuminate\Support\Facades\{Cache, Schema};
 use PowerComponents\LivewirePowerGrid\Components\Filters\{Builders\Number};
 use PowerComponents\LivewirePowerGrid\{Column,
     Components\Filters\Builders\Boolean,
@@ -147,16 +147,16 @@ class Builder
 
                         $search = $this->getBeforeSearchMethod($field, $search);
 
-                        $hasColumn = in_array($field, $columnList, true);
+                        $hasColumn = isset($columnList[$field]);
 
-                        $query->when($search, function () use ($column, $query, $search, $table, $field, $hasColumn) {
+                        $query->when($search != '', function () use ($column, $query, $search, $table, $field, $hasColumn) {
                             if (($sqlRaw = strval(data_get($column, 'searchableRaw')))) {
                                 $query->orWhereRaw($sqlRaw . ' ' . Sql::like($query) . ' \'%' . $search . '%\'');
                             }
 
-                            if ($hasColumn && blank(data_get($column, 'searchableRaw')) && $search) {
+                            if ($hasColumn && blank(data_get($column, 'searchableRaw'))) {
                                 try {
-                                    $columnType = DB::getSchemaBuilder()->getColumnType($table, $field);
+                                    $columnType = $this->getColumnType($table, $field);
 
                                     /** @phpstan-ignore-next-line  */
                                     $driverName = $query->getConnection()->getConfig('driver');
@@ -299,11 +299,37 @@ class Builder
         return [$table, $field];
     }
 
+    private function getColumnType(string $modelTable, string $field = null): ?string
+    {
+        try {
+            return $this->getColumnList($modelTable)[$field];
+        } catch (\Throwable $throwable) {
+            logger()->warning('PowerGrid [getColumnType] warning: ', [
+                'table'     => $modelTable,
+                'field'     => $field,
+                'throwable' => $throwable->getTrace(),
+            ]);
+
+            return null;
+        }
+    }
+
     private function getColumnList(string $modelTable): array
     {
         try {
-            return (array) Cache::remember('powergrid_columns_in_' . $modelTable, 600, fn () => Schema::getColumnListing($modelTable));
-        } catch (\Exception) {
+            return (array) Cache::remember(
+                'powergrid_columns_in_' . $modelTable,
+                60 * 60 * 3,
+                fn () => collect(Schema::getColumns($modelTable))
+                ->pluck('type', 'name')
+                ->toArray()
+            );
+        } catch (\Throwable $throwable) {
+            logger()->warning('PowerGrid [getColumnList] warning: ', [
+                'table'     => $modelTable,
+                'throwable' => $throwable->getTrace(),
+            ]);
+
             return Schema::getColumnListing($modelTable);
         }
     }

--- a/src/DataSource/Builder.php
+++ b/src/DataSource/Builder.php
@@ -299,10 +299,10 @@ class Builder
         return [$table, $field];
     }
 
-    private function getColumnType(string $modelTable, string $field = null): ?string
+    private function getColumnType(string $modelTable, string $field): ?string
     {
         try {
-            return $this->getColumnList($modelTable)[$field];
+            return $this->getColumnList($modelTable)[$field] ?? null;
         } catch (\Throwable $throwable) {
             logger()->warning('PowerGrid [getColumnType] warning: ', [
                 'table'     => $modelTable,

--- a/tests/Concerns/Components/DishesBeforeSearchTable.php
+++ b/tests/Concerns/Components/DishesBeforeSearchTable.php
@@ -25,6 +25,18 @@ class DishesBeforeSearchTable extends PowerGridComponent
         return 'Peixada';
     }
 
+    public function beforeSearch(?string $field = null, ?string $search = null): ?string
+    {
+        if ($field === 'in_stock') {
+            return str($search)
+                ->replace('without_stock', '0')
+                ->replace('with_stock', '1')
+                ->toString();
+        }
+
+        return $search;
+    }
+
     public function datasource(): Builder
     {
         return Dish::query();
@@ -47,6 +59,9 @@ class DishesBeforeSearchTable extends PowerGridComponent
             Column::make('Dish', 'name', 'dishes.name')
                 ->searchable()
                 ->sortable(),
+
+            Column::make('Stock', 'in_stock', 'dishes.in_stock')
+                ->searchable(),
 
             Column::action('Action'),
         ];

--- a/tests/Concerns/Components/DishesBeforeSearchTable.php
+++ b/tests/Concerns/Components/DishesBeforeSearchTable.php
@@ -3,6 +3,7 @@
 namespace PowerComponents\LivewirePowerGrid\Tests\Concerns\Components;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 use PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Dish;
 use PowerComponents\LivewirePowerGrid\{Column, Footer, Header, PowerGrid, PowerGridComponent, PowerGridFields};
 
@@ -29,8 +30,8 @@ class DishesBeforeSearchTable extends PowerGridComponent
     {
         if ($field === 'in_stock') {
             return str($search)
-                ->replace('without_stock', '0')
-                ->replace('with_stock', '1')
+                ->replace('without_stock', DB::getDriverName() === 'pgsql' ? 'false' : '0')
+                ->replace('with_stock', DB::getDriverName() === 'pgsql' ? 'true' : '1')
                 ->toString();
         }
 

--- a/tests/Feature/BeforeSearchTest.php
+++ b/tests/Feature/BeforeSearchTest.php
@@ -24,8 +24,8 @@ it('can use beforeSearch in boolean field', function (string $component, object 
         # without_stock => in_stock = 0
         ->set('search', 'without_stock')
         ->assertDontSee('Pastel de Nata')
+        ->assertDontSee('Carne Louca')
         ->assertSee('Barco-Sushi Simples')
-        ->assertDontSee('Pastel de Nata')
         # with_stock => in_stock = 1
         ->set('search', 'with_stock')
         ->assertSee('Pastel de Nata')
@@ -35,7 +35,8 @@ it('can use beforeSearch in boolean field', function (string $component, object 
         ->set('search', 'without_stock')
         ->assertDontSee('Pastel de Nata')
         ->assertSee('Barco-Sushi Simples')
-        ->assertDontSee('Pastel de Nata');
+        ->assertDontSee('Pastel de Nata')
+    ;
 })->with([
     'tailwind'  => [DishesBeforeSearchTable::class, (object) ['theme' => 'tailwind']],
     'bootstrap' => [DishesBeforeSearchTable::class, (object) ['theme' => 'bootstrap']],

--- a/tests/Feature/BeforeSearchTest.php
+++ b/tests/Feature/BeforeSearchTest.php
@@ -35,8 +35,7 @@ it('can use beforeSearch in boolean field', function (string $component, object 
         ->set('search', 'without_stock')
         ->assertDontSee('Pastel de Nata')
         ->assertSee('Barco-Sushi Simples')
-        ->assertDontSee('Pastel de Nata')
-    ;
+        ->assertDontSee('Pastel de Nata');
 })->with([
     'tailwind'  => [DishesBeforeSearchTable::class, (object) ['theme' => 'tailwind']],
     'bootstrap' => [DishesBeforeSearchTable::class, (object) ['theme' => 'bootstrap']],

--- a/tests/Feature/BeforeSearchTest.php
+++ b/tests/Feature/BeforeSearchTest.php
@@ -13,9 +13,30 @@ it('searches data using beforeSearch', function (string $component, object $para
         ->assertSee('Peixada')
         ->set('search', '')
         ->assertSee('Peixada');
-})->with('before_search_themes');
+})->with([
+    'tailwind'  => [DishesBeforeSearchTable::class, (object) ['theme' => 'tailwind']],
+    'bootstrap' => [DishesBeforeSearchTable::class, (object) ['theme' => 'bootstrap']],
+]);
 
-dataset('before_search_themes', [
+it('can use beforeSearch in boolean field', function (string $component, object $params) {
+    livewire($component)
+        ->call($params->theme)
+        # without_stock => in_stock = 0
+        ->set('search', 'without_stock')
+        ->assertDontSee('Pastel de Nata')
+        ->assertSee('Barco-Sushi Simples')
+        ->assertDontSee('Pastel de Nata')
+        # with_stock => in_stock = 1
+        ->set('search', 'with_stock')
+        ->assertSee('Pastel de Nata')
+        ->assertSee('Carne Louca')
+        ->assertDontSee('Barco-Sushi Simples')
+        # without_stock => in_stock = 0
+        ->set('search', 'without_stock')
+        ->assertDontSee('Pastel de Nata')
+        ->assertSee('Barco-Sushi Simples')
+        ->assertDontSee('Pastel de Nata');
+})->with([
     'tailwind'  => [DishesBeforeSearchTable::class, (object) ['theme' => 'tailwind']],
     'bootstrap' => [DishesBeforeSearchTable::class, (object) ['theme' => 'bootstrap']],
 ]);


### PR DESCRIPTION
#### Motivation

- [x] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This PR removes unnecessary queries when we are searching for some text. The queries executed were to get the column type to check the `JSON` type column and not break when using `PGSQL`, however, this made Powergrid a little slow. The best solution found was to cache the column name and type

### Before

![1](https://github.com/Power-Components/livewire-powergrid/assets/33601626/e609fc92-c46b-484e-a06e-599514d7ea26)

---

### After

![2](https://github.com/Power-Components/livewire-powergrid/assets/33601626/c8f2a1d8-1119-405f-aca7-909dd69a0f24)


#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
