### PR TITLE
[FIX] summarizeFormat() -  Format leaking across columns

### DIFF
--- a/tests/Concerns/Components/DishesCalculationsTable.php
+++ b/tests/Concerns/Components/DishesCalculationsTable.php
@@ -67,6 +67,7 @@ class DishesCalculationsTable extends PowerGridComponent
         return PowerGrid::fields()
             ->add('id')
             ->add('name')
+            ->add('calories', fn ($dish) => $dish->calories . ' kcal')
             ->add('price');
     }
 
@@ -84,6 +85,10 @@ class DishesCalculationsTable extends PowerGridComponent
                 ->searchable()
                 ->field('name'),
 
+            Column::make('Calories', 'calories', 'calories')
+                ->withAvg('Average', header: true, footer: false)
+                ->sortable(),
+
             Column::add()
                 ->title(__('Price'))
                 ->field('price')
@@ -99,12 +104,16 @@ class DishesCalculationsTable extends PowerGridComponent
 
     public function summarizeFormat(): array
     {
+        $fmt = (new \NumberFormatter('pt-PT', \NumberFormatter::DEFAULT_STYLE));
+
         return [
             'price.{sum,avg,min,max}' => function ($value) {
                 return (new \NumberFormatter('en_US', \NumberFormatter::CURRENCY))
                     ->formatCurrency($value, 'USD');
             },
-            'price.{count}' => fn ($value) => $value,
+            'price.{count}'  => fn ($value) => $fmt->format($value) . ' item(s)',
+            'calories.{avg}' => fn ($value) => $fmt->format($value) . ' kcal',
+
         ];
     }
 

--- a/tests/Feature/CalculationsTest.php
+++ b/tests/Feature/CalculationsTest.php
@@ -11,7 +11,7 @@ beforeEach(
     }
 );
 
-it('calculate "count" on id field', function (string $component, object $params) {
+it('calculates "count" on id field', function (string $component, object $params) {
     livewire($component)
         ->call($params->theme)
         ->assertSee('Count ID: 12')
@@ -19,7 +19,7 @@ it('calculate "count" on id field', function (string $component, object $params)
         ->assertSee('Count ID: 1');
 })->with('calculations');
 
-it('calculate "sum" on price field', function (string $component, object $params) {
+it('calculates "sum" on price field', function (string $component, object $params) {
     livewire($component)
         ->call($params->theme)
         ->assertSeeHtml('<span>Sum Price: $15,000.60</span>')
@@ -29,29 +29,30 @@ it('calculate "sum" on price field', function (string $component, object $params
         ->assertSeeHtml('<span>Sum Price: $600.00</span>');
 })->with('calculations')->skip('Refactoring');
 
-it('calculate "count" on price field', function (string $component, object $params) {
+it('calculates "count" and formats on price field', function (string $component, object $params) {
     livewire($component)
         ->call($params->theme)
-        ->assertSeeHtml('Count Price: 12')
+        ->assertSeeHtml('Count Price: 12 item(s)')
         ->set('search', 'Dish C')
-        ->assertSeeHtml('Count Price: 1')
+        ->assertSeeHtml('Count Price: 1 item(s)')
         ->set('search', 'Dish F')
-        ->assertSeeHtml('Count Price: 1');
+        ->assertSeeHtml('Count Price: 1 item(s)');
 })->with('calculations');
 
-it('calculate "avg" on price field', function (string $component, object $params) {
+it('calculates and formats "avg" on price field and calorie fields', function (string $component, object $params) {
     livewire($component)
         ->call($params->theme)
-        ->assertSeeHtml('<span>Avg Price: $1,250.05</span>');
+        ->assertSeeHtml('<span>Avg Price: $1,250.05</span>')
+        ->assertSeeHtml('<span>Average: 224 kcal</span>');
 })->with('calculations');
 
-it('calculate "min" on price field', function (string $component, object $params) {
+it('calculates "min" on price field', function (string $component, object $params) {
     livewire($component)
         ->call($params->theme)
         ->assertSeeHtml('<span>Min Price: $100.00</span>');
 })->with('calculations');
 
-it('calculate "max" on price field', function (string $component, object $params) {
+it('calculates "max" on price field', function (string $component, object $params) {
     livewire($component)
         ->call($params->theme)
         ->assertSeeHtml('<span>Max Price: $7,500.00</span>');


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [X] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request fixes the bug described in the issue, which prevents applying a different Summary method formatting in each column.

```php
    public function summarizeFormat(): array
    {
        return [
            'price.{sum,avg,min,max}' => fn ($value) => Number::currency($value, in: 'USD'),
            'price.{count}'    => fn ($value) => Number::format($value, locale: 'br') . ' price(s)',
            'calories.{avg}'   => fn ($value) => Number::format($value, locale: 'br', precision: 2) . ' kcal',
        ];
    }
```
Result:

![CleanShot 2024-05-06 at 01 04 26@2x](https://github.com/Power-Components/livewire-powergrid/assets/79267265/a81caba5-16c5-46fc-a017-2ff700ff57f1)

<br/>

In addition, from now on PowerGrid will throw an exception if the user does not follow the syntax `column_name.{summarize_method}` or does not send a `callable` in `summarizeFormat()`.


#### Related Issue(s):  https://github.com/Power-Components/livewire-powergrid/issues/1529.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
