### PR TITLE
Clear Table Cache when running migrations

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,16 @@ parameters:
         - '#^Method .*::fromLivewire\(\) has no return type specified\.#'
         - '#^Method .*::fromLivewire\(\) has parameter \$value with no type specified\.#'
         - '#Call to an undefined method PowerComponents\\LivewirePowerGrid\\PowerGridComponent::datasource\(\).#'
+        -
+            message: "#^Unable to resolve the template type TKey in call to function collect$#"
+            count: 1
+            path: src/Support/PowerGridTableCache.php
+
+        -
+            message: "#^Unable to resolve the template type TValue in call to function collect$#"
+            count: 1
+            path: src/Support/PowerGridTableCache.php
+
     paths:
         - src
 

--- a/src/DataSource/Builder.php
+++ b/src/DataSource/Builder.php
@@ -5,8 +5,10 @@ namespace PowerComponents\LivewirePowerGrid\DataSource;
 use Illuminate\Database\Eloquent\{Builder as EloquentBuilder, RelationNotFoundException};
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\{Cache, Schema};
+use Illuminate\Support\Facades\Schema;
 use PowerComponents\LivewirePowerGrid\Components\Filters\{Builders\Number};
+use PowerComponents\LivewirePowerGrid\Support\PowerGridTableCache;
+
 use PowerComponents\LivewirePowerGrid\{Column,
     Components\Filters\Builders\Boolean,
     Components\Filters\Builders\DatePicker,
@@ -317,12 +319,11 @@ class Builder
     private function getColumnList(string $modelTable): array
     {
         try {
-            return (array) Cache::remember(
-                'powergrid_columns_in_' . $modelTable,
-                60 * 60 * 3,
+            return PowerGridTableCache::getOrCreate(
+                $modelTable,
                 fn () => collect(Schema::getColumns($modelTable))
-                ->pluck('type', 'name')
-                ->toArray()
+                            ->pluck('type', 'name')
+                            ->toArray()
             );
         } catch (\Throwable $throwable) {
             logger()->warning('PowerGrid [getColumnList] warning: ', [

--- a/src/Providers/PowerGridServiceProvider.php
+++ b/src/Providers/PowerGridServiceProvider.php
@@ -2,7 +2,8 @@
 
 namespace PowerComponents\LivewirePowerGrid\Providers;
 
-use Illuminate\Support\Facades\Blade;
+use Illuminate\Database\Events\MigrationStarted;
+use Illuminate\Support\Facades\{Blade, Event};
 use Illuminate\Support\ServiceProvider;
 use Livewire\Features\SupportLegacyModels\{EloquentCollectionSynth, EloquentModelSynth};
 use Livewire\Livewire;
@@ -11,6 +12,7 @@ use PowerComponents\LivewirePowerGrid\Commands\{CreateCommand, PublishCommand, U
 use PowerComponents\LivewirePowerGrid\Components\Actions\Macros;
 use PowerComponents\LivewirePowerGrid\Components\Filters\FilterManager;
 use PowerComponents\LivewirePowerGrid\Components\Rules\RuleManager;
+use PowerComponents\LivewirePowerGrid\Support\PowerGridTableCache;
 use PowerComponents\LivewirePowerGrid\Themes\ThemeManager;
 use PowerComponents\LivewirePowerGrid\{Livewire\LazyChild, Livewire\PerformanceCard, PowerGridManager};
 
@@ -55,6 +57,8 @@ class PowerGridServiceProvider extends ServiceProvider
         $this->app->alias(FilterManager::class, 'filter');
 
         Livewire::component('lazy-child', LazyChild::class);
+
+        Event::listen(MigrationStarted::class, fn () => PowerGridTableCache::forgetAll());
 
         if (class_exists(\Laravel\Pulse\Facades\Pulse::class)) {
             Livewire::component('powergrid-performance-card', PerformanceCard::class);

--- a/src/Providers/PowerGridServiceProvider.php
+++ b/src/Providers/PowerGridServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace PowerComponents\LivewirePowerGrid\Providers;
 
-use Illuminate\Database\Events\MigrationStarted;
+use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Support\Facades\{Blade, Event};
 use Illuminate\Support\ServiceProvider;
 use Livewire\Features\SupportLegacyModels\{EloquentCollectionSynth, EloquentModelSynth};
@@ -58,7 +58,7 @@ class PowerGridServiceProvider extends ServiceProvider
 
         Livewire::component('lazy-child', LazyChild::class);
 
-        Event::listen(MigrationStarted::class, fn () => PowerGridTableCache::forgetAll());
+        Event::listen(MigrationsEnded::class, fn () => PowerGridTableCache::forgetAll());
 
         if (class_exists(\Laravel\Pulse\Facades\Pulse::class)) {
             Livewire::component('powergrid-performance-card', PerformanceCard::class);

--- a/src/Support/PowerGridTableCache.php
+++ b/src/Support/PowerGridTableCache.php
@@ -3,29 +3,28 @@
 namespace PowerComponents\LivewirePowerGrid\Support;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\{Cache};
 
 final class PowerGridTableCache
 {
-    private static function list(): Collection
+    private const THREE_HOURS = 60 * 60 * 3;
+
+    private static string $cachedTablesListTag = 'pg_cached_tables';
+
+    private static string $cachedTableTag = 'powergrid_columns_in_';
+
+    public static function getOrCreate(string $tableName, callable $tableColumns): array
     {
-        $cachedTableTags = rescue(fn () => Cache::get('pg_cached_tables')) ?? '';
+        $tag = self::generateTag($tableName);
+
+        if (Cache::has($tag)) {
+            return (array) Cache::get($tag);
+        }
+
+        self::addToCachedTablesList($tag);
 
         /** @phpstan-ignore-next-line */
-        return collect(json_decode($cachedTableTags, true));
-    }
-
-    public static function put(string $modelTable, array $tableColumns): array
-    {
-        $tag = 'powergrid_columns_in_' . $modelTable;
-
-        Cache::put('pg_cached_tables', self::list()->push($tag)->unique()->toJson());
-
-        return (array) Cache::remember(
-            $tag,
-            60 * 60 * 3,
-            fn () => $tableColumns
-        );
+        return (array) Cache::remember($tag, self::THREE_HOURS, $tableColumns);
     }
 
     public static function forgetAll(): void
@@ -35,6 +34,28 @@ final class PowerGridTableCache
             self::list()->each(fn (string $tag): bool => Cache::forget($tag));
 
             Cache::forget('pg_cached_tables');
-        });
+        }, report: false);
+    }
+
+    private static function list(): Collection
+    {
+        return collect(
+            /** @phpstan-ignore-next-line */
+            rescue(
+                fn () => (Cache::get(self::$cachedTablesListTag) ?? []),
+                [],
+                report: false
+            )
+        );
+    }
+
+    private static function addToCachedTablesList(string $tag): void
+    {
+        rescue(fn () => Cache::put(self::$cachedTablesListTag, self::list()->push($tag)->unique()->toArray()), report: false);
+    }
+
+    private static function generateTag(string $tableName): string
+    {
+        return self::$cachedTableTag . $tableName;
     }
 }

--- a/src/Support/PowerGridTableCache.php
+++ b/src/Support/PowerGridTableCache.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Support;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+final class PowerGridTableCache
+{
+    private static function list(): Collection
+    {
+        $cachedTableTags = rescue(fn () => Cache::get('pg_cached_tables')) ?? '';
+
+        /** @phpstan-ignore-next-line */
+        return collect(json_decode($cachedTableTags, true));
+    }
+
+    public static function put(string $modelTable, array $tableColumns): array
+    {
+        $tag = 'powergrid_columns_in_' . $modelTable;
+
+        Cache::put('pg_cached_tables', self::list()->push($tag)->unique()->toJson());
+
+        return (array) Cache::remember(
+            $tag,
+            60 * 60 * 3,
+            fn () => $tableColumns
+        );
+    }
+
+    public static function forgetAll(): void
+    {
+        rescue(function (): void {
+            /** @phpstan-ignore-next-line */
+            self::list()->each(fn (string $tag): bool => Cache::forget($tag));
+
+            Cache::forget('pg_cached_tables');
+        });
+    }
+}


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [X] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

While this might be a bit of overengineering, this PR aims to mitgate the risk of using cached table schema after running a migration.

Users might face this problem during development, wasting time on debug and building frustration. We could also assume that an app might be deployed without cleaning caches.

Since we cannot retrieve the cache keys with a wildcard (e.g, `Cache::get('powergrid_columns_in_*)`, my idea is to keep a list of which columns are being cached. Alternativelly, we could just list every table in the database and try to wipe it's PG key.

Of course, we can just discard this idea if it is too much.

#### Related Issue(s):

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
