### PR TITLE
[FIX] Placeholder not working on `Filter::number`

### DIFF
--- a/resources/views/components/frameworks/bootstrap5/filters/number.blade.php
+++ b/resources/views/components/frameworks/bootstrap5/filters/number.blade.php
@@ -7,6 +7,7 @@
 
 @php
     $fieldClassName = data_get($filter, 'className');
+
     $field = data_get($filter, 'field');
 
     $componentAttributes = (array) data_get($filter, 'attributes');
@@ -14,6 +15,8 @@
     $defaultAttributes = $fieldClassName::getWireAttributes($field, array_merge($filter, (array)$column));
 
     $filterClasses = Arr::toCssClasses([data_get($theme, 'inputClass'), data_get($column, 'headerClass'), 'power_grid']);
+    
+    $placeholder = data_get($filter, 'placeholder');
 
     $params = array_merge([...data_get($filter, 'attributes'), ...$defaultAttributes, $filterClasses], $filter);
 @endphp

--- a/resources/views/components/frameworks/tailwind/filters/number.blade.php
+++ b/resources/views/components/frameworks/tailwind/filters/number.blade.php
@@ -5,7 +5,9 @@
     'column' => '',
 ])
 @php
+
     $fieldClassName = data_get($filter, 'className');
+
     $field = data_get($filter, 'field');
 
     $componentAttributes = (array) data_get($filter, 'attributes');
@@ -13,6 +15,8 @@
     $defaultAttributes = $fieldClassName::getWireAttributes($field, array_merge($filter, (array)$column));
 
     $filterClasses = Arr::toCssClasses([data_get($theme, 'inputClass'), data_get($column, 'headerClass'), 'power_grid']);
+
+    $placeholder = data_get($filter, 'placeholder');
 
     $params = array_merge([...data_get($filter, 'attributes'), ...$defaultAttributes, $filterClasses], $filter);
 @endphp

--- a/tests/Feature/Filters/FilterMultipleTest.php
+++ b/tests/Feature/Filters/FilterMultipleTest.php
@@ -14,11 +14,10 @@ $component = new class () extends DishesTable {
     public function filters(): array
     {
         return [
-            Filter::number('price')
-                ->thousands('.')
-                ->decimal(','),
-            Filter::inputText('name')->operators(),
-            Filter::number('price')->thousands('.')->decimal(','),
+            Filter::number('price_BRL')->placeholder('min_xyz_placeholder', 'max_xyz_placeholder')->thousands('.') ->decimal(','),
+            Filter::number('price') ->placeholder('min_xyz_placeholder', 'max_xyz_placeholder')->thousands('.') ->decimal(','),
+            Filter::inputText('name')->placeholder('dish_name_xyz_placeholder')->operators(),
+            Filter::number('price')->placeholder('min_xyz_placeholder', 'max_xyz_placeholder')->thousands('.')->decimal(','),
             Filter::boolean('in_stock'),
         ];
     }
@@ -28,11 +27,10 @@ $componentQueryBuilder = new class () extends DishesQueryBuilderTable {
     public function filters(): array
     {
         return [
-            Filter::number('price')
-                ->thousands('.')
-                ->decimal(','),
-            Filter::inputText('name')->operators(),
-            Filter::number('price')->thousands('.')->decimal(','),
+            Filter::number('price_BRL')->placeholder('min_xyz_placeholder', 'max_xyz_placeholder')->thousands('.') ->decimal(','),
+            Filter::number('price') ->placeholder('min_xyz_placeholder', 'max_xyz_placeholder')->thousands('.') ->decimal(','),
+            Filter::inputText('name')->placeholder('dish_name_xyz_placeholder')->operators(),
+            Filter::number('price')->placeholder('min_xyz_placeholder', 'max_xyz_placeholder')->thousands('.')->decimal(','),
             Filter::boolean('in_stock'),
         ];
     }
@@ -42,11 +40,9 @@ $componentJoin = new class () extends DishesTableWithJoin {
     public function filters(): array
     {
         return [
-            Filter::number('price')
-                ->thousands('.')
-                ->decimal(','),
-            Filter::inputText('name')->operators(),
-            Filter::number('price')->thousands('.')->decimal(','),
+            Filter::number('price_BRL') ->placeholder('min_xyz_placeholder', 'max_xyz_placeholder')->thousands('.') ->decimal(','),
+            Filter::inputText('dish_name')->placeholder('dish_name_xyz_placeholder')->operators(),
+            Filter::number('price')->placeholder('min_xyz_placeholder', 'max_xyz_placeholder')->thousands('.')->decimal(','),
             Filter::boolean('in_stock'),
         ];
     }
@@ -92,11 +88,14 @@ it('properly filters by inputText, number, boolean filter and clearAll', functio
             ]);
     }
 
-    $component->assertSee('Barco-Sushi da Sueli');
+    $component->assertSee('Barco-Sushi da Sueli')
+        ->assertSeeHtml('dish_name_xyz_placeholder');
 
     $filters = array_merge($component->filters, filterNumber('price', '80.00', '100'));
 
     $component->set('filters', $filters)
+        ->assertSeeHtml('placeholder="min_xyz_placeholder"')
+        ->assertSeeHtml('placeholder="max_xyz_placeholder"')
         ->assertDontSee('Barco-Sushi da Sueli')
         ->assertSee('Barco-Sushi Simples')
         ->assertDontSee('Polpetone Filé Mignon')


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [X] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request fixes the placeholder not being rendered when using  `Filter::number('price', 'price')->placeholder('foo', 'bar')`.

![CleanShot 2024-05-08 at 00 35 02@2x](https://github.com/Power-Components/livewire-powergrid/assets/79267265/dab4eec9-7bbb-4c6b-a681-b9e3908dce97)

#### Related Issue(s): 
https://github.com/Power-Components/livewire-powergrid/issues/1535
https://github.com/Power-Components/livewire-powergrid/issues/1534

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
