### PR TITLE
[BUG] Persist cookie name cannot feature specific characters

### DIFF
--- a/src/Traits/PersistData.php
+++ b/src/Traits/PersistData.php
@@ -25,7 +25,7 @@ trait PersistData
         if (!empty($this->persist)) {
             $url  = parse_url(strval(filter_input(INPUT_SERVER, 'HTTP_REFERER')));
             $path = $url && array_key_exists('path', $url) ? $url['path'] : '/';
-            setcookie('pg:' . $this->tableName, strval(json_encode($state)), now()->addYear()->unix(), $path);
+            setcookie($this->getPersistKey(), strval(json_encode($state)), now()->addYear()->unix(), $path);
         }
     }
 
@@ -35,7 +35,7 @@ trait PersistData
             return;
         }
 
-        $cookie = filter_input(INPUT_COOKIE, 'pg:' . $this->tableName);
+        $cookie = filter_input(INPUT_COOKIE, $this->getPersistKey());
         if (is_null($cookie)) {
             return;
         }
@@ -56,6 +56,11 @@ trait PersistData
             $this->filters        = $state['filters'];
             $this->enabledFilters = $state['enabledFilters'];
         }
+    }
+
+    protected function getPersistKey(): string
+    {
+        return 'pg:' . md5($this->tableName);
     }
 
     /**


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

As we can see [here](https://github.com/Power-Components/livewire-powergrid/blob/3.x/src/Traits/PersistData.php#L28), the `tableName` property is used to construct a persist cookie name. Table name can be any string, but if the string features characters such as " " (space) or other, the following exception will be thrown:

```php
setcookie(): Argument #1 ($name) cannot contain "=", ",", ";", " ", "\t", "\r", "\n", "\013", or "\014"
```

With this limitation in mind, it is logical to hash persist key using _cheap_ hash function such as `md5`. In addition to added table name hashing, this PR makes `getPersistKey` method protected which allows end user to customise it.

#### Related Issue(s):  None.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
