### PR TITLE
[TEMPORARY FIX] Data Export doesn't work when using withAvg() 

### DIFF
--- a/src/ProcessDataSource.php
+++ b/src/ProcessDataSource.php
@@ -393,7 +393,7 @@ class ProcessDataSource
                 foreach ($summaries as $summary) {
                     if (data_get($column, $summary . '.header') || data_get($column, $summary . '.footer')) {
                         $value = $results->{$summary}($field);
-                        $applySummaryFormat($summary, $column, $field, $value);
+                        rescue(fn () => $applySummaryFormat($summary, $column, $field, $value), report: false);
                     }
                 }
 


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [X] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request is a temporary fix for problems exporting data under certain conditions, for example when using `withAvg()`. While I had this problem in the [Demo](https://demo.livewire-powergrid.com/), I could not replicate the bug in the tests. 

In the bug I encountered, the Exception is thrown because `WithExport` tries to access a field that doesn't exist. This doesn't prevent data being exported, as existing fields will be included in the CSV/XLS. However, the Exception will impact the user experience.

I decided to add a [`rescure()`](https://laravel.com/docs/11.x/helpers#method-rescue) to let the application continue running, but this is **NOT A FIX** and we should continue investigating the issue.

#### Related Issue(s):  https://github.com/Power-Components/livewire-powergrid/issues/1540

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
