### PR TITLE
[ENHANCEMENT] Query String: Improve Filter Control and add prefix (for usage w/ multiple tables)

### DIFF
--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -331,7 +331,7 @@ trait Filter
         }
     }
 
-    public function listColumnForFilters(): Collection
+    public function listColumnForQueryString(): Collection
     {
         $columns = collect();
 
@@ -348,17 +348,21 @@ trait Filter
         return $columns;
     }
 
-    /*
-    @TODO Figure out
-    */
-    protected function powerGridQueryString(): array
+    /**
+     *
+     * @param string $prefix Prefix each field in URL
+     */
+    protected function powerGridQueryString(string $prefix = ''): array
     {
         $queryString = [];
 
-        $columns = $this->listColumnForFilters();
+        $columns = $this->listColumnForQueryString();
 
         foreach (Arr::dot($this->filters()) as $filter) {
-            $as = str($filter->field)->replace('.', '_');
+            $as = str($filter->field)
+                ->when(!empty($prefix), fn ($c) => $c->prepend($prefix . '_'))
+                ->replace('.', '_')
+                ->replaceMatches('/\_+/', '_');
 
             if (!empty(request()->get($as))) {
                 $this->addEnabledFilters($filter->field, strval($columns->get($filter->field, $filter->field)));


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [X] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request aims to improve the filter control while using Query String and adds the possibility to prefix fields, to use query string with more than one component in the same page.

### Filter control 

❌ **BEFORE**

![CleanShot 2024-05-23 at 13 07 57@2x](https://github.com/Power-Components/livewire-powergrid/assets/79267265/72b1b004-11da-4c54-a99d-5529a2d88798)



🚀 **AFTER**


![CleanShot 2024-05-23 at 14 32 21@2x](https://github.com/Power-Components/livewire-powergrid/assets/79267265/9342a2b4-644d-4be3-b90a-ce3012f3863e)


### Prefix Query String (Multiple Components)


![CleanShot 2024-05-24 at 01 57 06@2x](https://github.com/Power-Components/livewire-powergrid/assets/79267265/70224398-65ad-4cbf-891c-06b10b0ec000)

When using multiple components, the user must pass the parameter `$prefix` to the `powerGridQueryString()`. As a result, each URL parameter will be prefixed with the provided prefix:

```php
class DemoTable extends PowerGridComponent
{
    protected function queryString()
    {
        return $this->powerGridQueryString('table1');
    }
```

```plain
http://powergrid-demo.test/two-tables-in-the-same-page?table1_name=ark&table2_name=a&table2_calories=true
```

While we could use the `$tableName` as a prefix, I think it's best to give the user control so they can decide what is in the URL. Some people my prefer "table_name" instead of "dish_table_name".

I could not find a way to write proper tests for query-string.
 
#### Related Issue(s):  https://github.com/Power-Components/livewire-powergrid/issues/1563

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [X] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
