### PR TITLE
[FIX] Query String + Filters not clearing and duplicated filter button

### DIFF
--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -404,16 +404,19 @@ trait Filter
             }
 
             if ($filter->key === 'number') {
-                $_start = $as->append('_start')->toString();
-                $_end   = $as->append('_end')->toString();
+                $_start         = $as->append('_start')->toString();
+                $_end           = $as->append('_end')->toString();
+                $fieldProcessed = false;
 
                 $queryString['filters.number.' . $filter->field . '.start'] = [
                     'as'     => $_start,
                     'except' => '',
                 ];
 
-                if (!is_null(request()->get($_start))) {
+                if ($fieldProcessed === false && !is_null(request()->get($_start))) {
                     $this->addEnabledFilters($filter->field . '_start', strval($columns->get($filter->field, $filter->field)));
+
+                    $fieldProcessed = true;
                 }
 
                 $queryString['filters.number.' . $filter->field . '.end'] = [
@@ -421,8 +424,10 @@ trait Filter
                     'except' => '',
                 ];
 
-                if (!is_null(request()->get($_end))) {
+                if ($fieldProcessed === false && !is_null(request()->get($_end))) {
                     $this->addEnabledFilters($filter->field . '_end', strval($columns->get($filter->field, $filter->field)));
+
+                    $fieldProcessed = true;
                 }
 
                 continue;

--- a/src/Concerns/ToggleDetail.php
+++ b/src/Concerns/ToggleDetail.php
@@ -46,7 +46,7 @@ trait ToggleDetail
             /** @var \Illuminate\Support\Enumerable<(int|string), (int|string)> $except */
             $except = $id;
             collect($detailStates)->except($except)
-                ->filter(fn ($state) => $state)->keys()
+                ->filter(fn ($state) => boolval($state))->keys()
                 ->each(
                     fn ($key) => data_set($this->setUp, "detail.state.$key", false)
                 );

--- a/src/Traits/ExportableJob.php
+++ b/src/Traits/ExportableJob.php
@@ -46,7 +46,7 @@ trait ExportableJob
 
         $sortField = Str::of($processDataSource->component->sortField)->contains('.') ? $processDataSource->component->sortField : $currentTable . '.' . $processDataSource->component->sortField;
 
-        $results = $processDataSource->prepareDataSource()
+        $results = $processDataSource->prepareDataSource() // @phpstan-ignore-line
             ->where(
                 fn ($query) => Builder::make($query, $this->componentTable)
                     ->filterContains()


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [X] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request aims to fix the filter number not clearing when clicking on button. I could reproduce the bug while using querystring.

### Duplicated Buttons
![CleanShot 2024-05-25 at 16 19 36@2x](https://github.com/Power-Components/livewire-powergrid/assets/79267265/88febaf1-9278-4a93-b050-dffcb82731dd)

### Filter not clearning

##### Before

![antes](https://github.com/Power-Components/livewire-powergrid/assets/79267265/84bcaf11-007f-47f7-8e31-be546eebf423)

##### After

![CleanShot 2024-05-25 at 16 01 47](https://github.com/Power-Components/livewire-powergrid/assets/79267265/ebeb76c6-a0bf-4b42-a4d0-0b9e4b6ed2ff)
s):

#### Related Issue


#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
