### PR TITLE
feat: confirmation before any action.

### DIFF
--- a/resources/lang/ar/datatable.php
+++ b/resources/lang/ar/datatable.php
@@ -67,10 +67,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/ar/datatable.php
+++ b/resources/lang/ar/datatable.php
@@ -62,4 +62,7 @@ return [
         'with_trashed'         => 'مع المحذوف',
         'only_trashed'         => 'فقط محذوف',
     ],
+    'multi_sort' => [
+        'message' => 'Multiple sort is active',
+    ],
 ];

--- a/resources/lang/ar/datatable.php
+++ b/resources/lang/ar/datatable.php
@@ -65,4 +65,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/ca/datatable.php
+++ b/resources/lang/ca/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/ca/datatable.php
+++ b/resources/lang/ca/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/cs/datatable.php
+++ b/resources/lang/cs/datatable.php
@@ -67,10 +67,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/cs/datatable.php
+++ b/resources/lang/cs/datatable.php
@@ -65,4 +65,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/cs/datatable.php
+++ b/resources/lang/cs/datatable.php
@@ -62,4 +62,7 @@ return [
         'with_trashed'         => 'Se smazanými',
         'only_trashed'         => 'Pouze smazané',
     ],
+    'multi_sort' => [
+        'message' => 'Multiple sort is active',
+    ],
 ];

--- a/resources/lang/de/datatable.php
+++ b/resources/lang/de/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple Suche ist aktiv',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/de/datatable.php
+++ b/resources/lang/de/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/en/datatable.php
+++ b/resources/lang/en/datatable.php
@@ -64,12 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
-    'buttons-macros' => [
+    'buttons_macros' => [
         'confirm' => [
             'message'   => 'Are you sure you want to perform this action?',
         ],
-        'confirm-prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirm_value to confirm.",
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
         ]
     ],
 ];

--- a/resources/lang/en/datatable.php
+++ b/resources/lang/en/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/en/datatable.php
+++ b/resources/lang/en/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons-macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm-prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirm_value to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/es/datatable.php
+++ b/resources/lang/es/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/es/datatable.php
+++ b/resources/lang/es/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/fa/datatable.php
+++ b/resources/lang/fa/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/fa/datatable.php
+++ b/resources/lang/fa/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/fr/datatable.php
+++ b/resources/lang/fr/datatable.php
@@ -67,10 +67,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/fr/datatable.php
+++ b/resources/lang/fr/datatable.php
@@ -65,4 +65,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/id/datatable.php
+++ b/resources/lang/id/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/id/datatable.php
+++ b/resources/lang/id/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Pengurutan ganda diaktifkan',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/it/datatable.php
+++ b/resources/lang/it/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/it/datatable.php
+++ b/resources/lang/it/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/ms_MY/datatable.php
+++ b/resources/lang/ms_MY/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/ms_MY/datatable.php
+++ b/resources/lang/ms_MY/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/nl/datatable.php
+++ b/resources/lang/nl/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Meervoudige sortering is actief',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/nl/datatable.php
+++ b/resources/lang/nl/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/pl/datatable.php
+++ b/resources/lang/pl/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Wielokolumnowe sortowanie jest aktywne',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/pl/datatable.php
+++ b/resources/lang/pl/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/pt_BR/datatable.php
+++ b/resources/lang/pt_BR/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/pt_BR/datatable.php
+++ b/resources/lang/pt_BR/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'A classificação múltipla está ativa',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/ru/datatable.php
+++ b/resources/lang/ru/datatable.php
@@ -67,10 +67,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/ru/datatable.php
+++ b/resources/lang/ru/datatable.php
@@ -65,4 +65,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/tr/datatable.php
+++ b/resources/lang/tr/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Çoklu sıralama etkin',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/tr/datatable.php
+++ b/resources/lang/tr/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/uk/datatable.php
+++ b/resources/lang/uk/datatable.php
@@ -67,10 +67,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/resources/lang/uk/datatable.php
+++ b/resources/lang/uk/datatable.php
@@ -65,4 +65,12 @@ return [
     'multi_sort' => [
         'message' => 'Сортувати за',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/yr/datatable.php
+++ b/resources/lang/yr/datatable.php
@@ -64,4 +64,12 @@ return [
     'multi_sort' => [
         'message' => 'Multiple sort is active',
     ],
+    'buttons_macros' => [
+        'confirm' => [
+            'message'   => 'Are you sure you want to perform this action?',
+        ],
+        'confirm_prompt' => [
+            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ]
+    ],
 ];

--- a/resources/lang/yr/datatable.php
+++ b/resources/lang/yr/datatable.php
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message'   => 'Are you sure you want to perform this action?',
+            'message' => 'Are you sure you want to perform this action?',
         ],
         'confirm_prompt' => [
-            'message'   => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
-        ]
+            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+        ],
     ],
 ];

--- a/src/Button.php
+++ b/src/Button.php
@@ -21,6 +21,8 @@ use Livewire\Wireable;
  * @method static bladeComponent(string $component, array $params)
  * @method static can(bool|\Closure $allowed = true)
  * @method static id(string $id = null)
+ * @method static confirm(string $message = 'Are you sure you want to perform this action?')
+ * @method static confirmPrompt(string $message = 'Are you sure you want to perform this action?', string $confirm_value = 'Confirm')
  *
  */
 final class Button implements Wireable

--- a/src/Button.php
+++ b/src/Button.php
@@ -22,7 +22,7 @@ use Livewire\Wireable;
  * @method static can(bool|\Closure $allowed = true)
  * @method static id(string $id = null)
  * @method static confirm(string $message = 'Are you sure you want to perform this action?')
- * @method static confirmPrompt(string $message = 'Are you sure you want to perform this action?', string $confirm_value = 'Confirm')
+ * @method static confirmPrompt(string $message = 'Are you sure you want to perform this action?', string $confirmValue = 'Confirm')
  *
  */
 final class Button implements Wireable

--- a/src/Components/Actions/Macros.php
+++ b/src/Components/Actions/Macros.php
@@ -205,13 +205,13 @@ class Macros
             return $this;
         });
 
-        Button::macro('confirmPrompt', function (?string $message = null, string $confirm_value = 'Confirm') {
-            $message = $message ?? trans('livewire-powergrid::datatable.buttons-macros.confirm-prompt.message', ['confirm_value' => $confirm_value]);
-            $confirm_value = trim($confirm_value);
+        Button::macro('confirmPrompt', function (?string $message = null, string $confirmValue = 'Confirm') {
+            $message = $message ?? trans('livewire-powergrid::datatable.buttons-macros.confirm-prompt.message', ['confirm_value' => $confirmValue]);
+            $confirm_value = trim($confirmValue);
             $this->dynamicProperties['confirmPrompt'] = [
                 'component' => 'button',
                 'attribute' => 'wire:confirm.prompt',
-                'value'     => "$message |$confirm_value",
+                'value'     => "$message |$confirmValue",
             ];
 
             return $this;

--- a/src/Components/Actions/Macros.php
+++ b/src/Components/Actions/Macros.php
@@ -204,6 +204,7 @@ class Macros
 
             return $this;
         });
+
         Button::macro('confirmPrompt', function (?string $message = null, string $confirm_value = 'Confirm') {
             $message = $message ?? trans('livewire-powergrid::datatable.buttons-macros.confirm-prompt.message', ['confirm_value' => $confirm_value]);
             $confirm_value = trim($confirm_value);

--- a/src/Components/Actions/Macros.php
+++ b/src/Components/Actions/Macros.php
@@ -199,14 +199,14 @@ class Macros
             $this->dynamicProperties['confirm'] = [
                 'component' => 'button',
                 'attribute' => 'wire:confirm',
-                'value'     => $message ?? trans('livewire-powergrid::datatable.buttons-macros.confirm.message'),
+                'value'     => $message ?? trans('livewire-powergrid::datatable.buttons_macros.confirm.message'),
             ];
 
             return $this;
         });
 
         Button::macro('confirmPrompt', function (?string $message = null, string $confirmValue = 'Confirm') {
-            $message = $message ?? trans('livewire-powergrid::datatable.buttons-macros.confirm-prompt.message', ['confirm_value' => $confirmValue]);
+            $message = $message ?? trans('livewire-powergrid::datatable.buttons_macros.confirm_prompt.message', ['confirm_value' => $confirmValue]);
             $confirm_value = trim($confirmValue);
             $this->dynamicProperties['confirmPrompt'] = [
                 'component' => 'button',

--- a/src/Components/Actions/Macros.php
+++ b/src/Components/Actions/Macros.php
@@ -194,5 +194,26 @@ class Macros
 
             return $this;
         });
+
+        Button::macro('confirm', function (?string $message = null) {
+            $this->dynamicProperties['confirm'] = [
+                'component' => 'button',
+                'attribute' => 'wire:confirm',
+                'value'     => $message ?? trans('livewire-powergrid::datatable.buttons-macros.confirm.message'),
+            ];
+
+            return $this;
+        });
+        Button::macro('confirmPrompt', function (?string $message = null, string $confirm_value = 'Confirm') {
+            $message = $message ?? trans('livewire-powergrid::datatable.buttons-macros.confirm-prompt.message', ['confirm_value' => $confirm_value]);
+            $confirm_value = trim($confirm_value);
+            $this->dynamicProperties['confirmPrompt'] = [
+                'component' => 'button',
+                'attribute' => 'wire:confirm.prompt',
+                'value'     => "$message |$confirm_value",
+            ];
+
+            return $this;
+        });
     }
 }

--- a/src/Components/Actions/Macros.php
+++ b/src/Components/Actions/Macros.php
@@ -206,8 +206,8 @@ class Macros
         });
 
         Button::macro('confirmPrompt', function (?string $message = null, string $confirmValue = 'Confirm') {
-            $message = $message ?? trans('livewire-powergrid::datatable.buttons_macros.confirm_prompt.message', ['confirm_value' => $confirmValue]);
-            $confirm_value = trim($confirmValue);
+            $message                                  = $message ?? trans('livewire-powergrid::datatable.buttons_macros.confirm_prompt.message', ['confirm_value' => $confirmValue]);
+            $confirm_value                            = trim($confirmValue);
             $this->dynamicProperties['confirmPrompt'] = [
                 'component' => 'button',
                 'attribute' => 'wire:confirm.prompt',

--- a/tests/Feature/Buttons/ConfirmPromptTest.php
+++ b/tests/Feature/Buttons/ConfirmPromptTest.php
@@ -29,11 +29,11 @@ it('properly displays "confirm" on button click', function (string $component, o
     ])
         ->call($params->theme)
         ->set('search', 'Pastel de Nata')
-        ->assertSeeHtml('wire:confirm.prompt="1 Are you sure? Enter CONFIRM to confirm | CONFIRM"')
-        ->assertDontSeeHtml('wire:confirm.prompt="2 Are you sure? Enter CONFIRM to confirm | CONFIRM"')
+        ->assertSeeHtml('wire:confirm.prompt="1 Are you sure? Enter CONFIRM to confirm |CONFIRM"')
+        ->assertDontSeeHtml('wire:confirm.prompt="2 Are you sure? Enter CONFIRM to confirm |CONFIRM"')
         ->set('search', 'Peixada da chef Nábia')
-        ->assertSeeHtml('wire:confirm.prompt="2 Are you sure? Enter CONFIRM to confirm | CONFIRM"')
-        ->assertDontSeeHtml('wire:confirm.prompt="1 Are you sure? Enter CONFIRM to confirm | CONFIRM"');
+        ->assertSeeHtml('wire:confirm.prompt="2 Are you sure? Enter CONFIRM to confirm |CONFIRM"')
+        ->assertDontSeeHtml('wire:confirm.prompt="1 Are you sure? Enter CONFIRM to confirm |CONFIRM"');
 })
     ->with('action:confirm-prompt')
     ->group('action');

--- a/tests/Feature/Buttons/ConfirmPromptTest.php
+++ b/tests/Feature/Buttons/ConfirmPromptTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use PowerComponents\LivewirePowerGrid\Button;
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Components\DishTableBase;
+
+use function PowerComponents\LivewirePowerGrid\Tests\Plugins\livewire;
+
+$component = new class () extends DishTableBase {
+    public function actions($row): array
+    {
+        return [
+            Button::make('confirm-prompt')
+                ->slot('confirm-prompt: ' . $row->id)
+                ->confirmPrompt("$row->id Are you sure? Enter CONFIRM to confirm","CONFIRM"),
+        ];
+    }
+};
+
+dataset('action:confirm-prompt', [
+    'tailwind'       => [$component::class, (object) ['theme' => 'tailwind', 'join' => false]],
+    'bootstrap'      => [$component::class, (object) ['theme' => 'bootstrap', 'join' => false]],
+    'tailwind join'  => [$component::class, (object) ['theme' => 'tailwind', 'join' => true]],
+    'bootstrap join' => [$component::class, (object) ['theme' => 'bootstrap', 'join' => true]],
+]);
+
+it('properly displays "confirm" on button click', function (string $component, object $params) {
+    livewire($component, [
+        'join' => $params->join,
+    ])
+        ->call($params->theme)
+        ->set('search', 'Pastel de Nata')
+        ->assertSeeHtml('wire:confirm.prompt="1 Are you sure? Enter CONFIRM to confirm | CONFIRM"')
+        ->assertDontSeeHtml('wire:confirm.prompt="2 Are you sure? Enter CONFIRM to confirm | CONFIRM"')
+        ->set('search', 'Peixada da chef Nábia')
+        ->assertSeeHtml('wire:confirm.prompt="2 Are you sure? Enter CONFIRM to confirm | CONFIRM"')
+        ->assertDontSeeHtml('wire:confirm.prompt="1 Are you sure? Enter CONFIRM to confirm | CONFIRM"');
+})
+    ->with('action:confirm-prompt')
+    ->group('action');

--- a/tests/Feature/Buttons/ConfirmPromptTest.php
+++ b/tests/Feature/Buttons/ConfirmPromptTest.php
@@ -11,7 +11,7 @@ $component = new class () extends DishTableBase {
         return [
             Button::make('confirm-prompt')
                 ->slot('confirm-prompt: ' . $row->id)
-                ->confirmPrompt("$row->id Are you sure? Enter CONFIRM to confirm","CONFIRM"),
+                ->confirmPrompt("$row->id Are you sure? Enter CONFIRM to confirm", "CONFIRM"),
         ];
     }
 };

--- a/tests/Feature/Buttons/ConfirmTest.php
+++ b/tests/Feature/Buttons/ConfirmTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use PowerComponents\LivewirePowerGrid\Button;
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Components\DishTableBase;
+
+use function PowerComponents\LivewirePowerGrid\Tests\Plugins\livewire;
+
+$component = new class () extends DishTableBase {
+    public function actions($row): array
+    {
+        return [
+            Button::make('confirm')
+                ->slot('confirm: ' . $row->id)
+                ->confirm('Are you sure? ' . $row->id),
+        ];
+    }
+};
+
+dataset('action:confirm', [
+    'tailwind'       => [$component::class, (object) ['theme' => 'tailwind', 'join' => false]],
+    'bootstrap'      => [$component::class, (object) ['theme' => 'bootstrap', 'join' => false]],
+    'tailwind join'  => [$component::class, (object) ['theme' => 'tailwind', 'join' => true]],
+    'bootstrap join' => [$component::class, (object) ['theme' => 'bootstrap', 'join' => true]],
+]);
+
+it('properly displays "confirm" on button click', function (string $component, object $params) {
+    livewire($component, [
+        'join' => $params->join,
+    ])
+        ->call($params->theme)
+        ->set('search', 'Pastel de Nata')
+        ->assertSeeHtml('wire:confirm="Are you sure? 1"')
+        ->assertDontSeeHtml('wire:confirm="Are you sure? 2"')
+        ->set('search', 'Peixada da chef Nábia')
+        ->assertSeeHtml('wire:confirm="Are you sure? 2"')
+        ->assertDontSeeHtml('wire:confirm="Are you sure? 1"');
+})
+    ->with('action:confirm')
+    ->group('action');


### PR DESCRIPTION

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [ ] Enhancement
- [x] New feature
- [ ] Breaking change

#### Description

**Feature:** 
This PR adds a confirmation popup before executing any action via action buttons.
**Purpose:** 
To prevent unintended actions and improve user experience by adding an extra layer of confirmation.


As we know we use macros for additional functionality to add id and trigger dispatch events. In the same way, we can add wire:confirm attribute to buttons.

[Read more Livewire wire:confirm](https://livewire.laravel.com/docs/wire-confirm)

#### Example:
- Implemented simple confirmation using the following syntax:
```php
Button::add('delete')->id()->confirm("Are you sure?")
```
- Implemented confirmation prompts using the following syntax:
```php
Button::add('delete')->id()->confirmPrompt("Are you sure you want to delete ?", "Confirm")
```
#### Result:

<img width="361" alt="confirm" src="https://github.com/Power-Components/livewire-powergrid/assets/38046347/065fe796-9a41-4634-97e1-0fa6ec8501b7">

<img width="412" alt="confrim-prompt" src="https://github.com/Power-Components/livewire-powergrid/assets/38046347/c30e33cf-d650-407e-a583-e969a9cb2f9e">


#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] Yes
- [ ] No
- [x] I have already submitted a Documentation pull request.
