### PR TITLE
Adds the page name to pagination links in the tailwind template

### DIFF
--- a/resources/views/components/frameworks/tailwind/pagination.blade.php
+++ b/resources/views/components/frameworks/tailwind/pagination.blade.php
@@ -75,7 +75,7 @@
 
                         <a
                             class="cursor-pointer relative inline-flex items-center px-2 py-2 text-sm font-medium text-pg-primary-500 dark:text-pg-primary-300 bg-white dark:bg-pg-primary-600 border border-pg-primary-300 dark:border-transparent leading-5 hover:text-pg-primary-400 focus:z-10 focus:outline-none focus:shadow-outline-blue active:bg-pg-primary-100 active:text-pg-primary-500 transition ease-in-out duration-150"
-                            wire:click="previousPage"
+                            wire:click="previousPage('{{ $paginator->getPageName() }}')"
                             rel="next"
                         >
                             <svg
@@ -120,7 +120,7 @@
                         @if ($paginator->lastPage() - $paginator->currentPage() >= 2)
                             <a
                                 class="select-none cursor-pointer relative inline-flex items-center px-2 py-2 text-sm font-medium text-pg-primary-500 dark:text-pg-primary-300 bg-white dark:bg-pg-primary-600 border border-pg-primary-300 dark:border-transparent leading-5 hover:text-pg-primary-400 focus:z-10 focus:outline-none focus:shadow-outline-blue active:bg-pg-primary-100 active:text-pg-primary-500 transition ease-in-out duration-150"
-                                wire:click="nextPage"
+                                wire:click="nextPage('{{ $paginator->getPageName() }}')"
                                 rel="next"
                             >
                                 <svg

--- a/tests/Feature/PaginationTest.php
+++ b/tests/Feature/PaginationTest.php
@@ -53,17 +53,17 @@ it('displays next links ">" and ">>"')
     ->livewire(DishesTable::class)
     ->set('setUp.footer.perPage', '4')
 
-    ->assertSeeHtml('wire:click="nextPage(\'default\')"')
+    ->assertSeeHtml('wire:click="nextPage(\'page\')"')
     //page #2
     ->call('gotoPage', '2')
-    ->assertSeeHtml('wire:click="nextPage(\'default\')"');
+    ->assertSeeHtml('wire:click="nextPage(\'page\')"');
 
 it('displays previous links "<" and "<<"')
     ->livewire(DishesTable::class)
-    ->assertDontSeeHtml('wire:click="previousPage(\'default\')"')
+    ->assertDontSeeHtml('wire:click="previousPage(\'page\')"')
     //page #2
     ->call('gotoPage', '2')
-    ->assertSeeHtml('wire:click="previousPage(\'default\')"');
+    ->assertSeeHtml('wire:click="previousPage(\'page\')"');
 
 it('searches for something that is not on the current page')
     ->livewire(DishesTable::class)

--- a/tests/Feature/PaginationTest.php
+++ b/tests/Feature/PaginationTest.php
@@ -53,17 +53,17 @@ it('displays next links ">" and ">>"')
     ->livewire(DishesTable::class)
     ->set('setUp.footer.perPage', '4')
 
-    ->assertSeeHtml('wire:click="nextPage"')
+    ->assertSeeHtml('wire:click="nextPage(\'default\')"')
     //page #2
     ->call('gotoPage', '2')
-    ->assertSeeHtml('wire:click="nextPage"');
+    ->assertSeeHtml('wire:click="nextPage(\'default\')"');
 
 it('displays previous links "<" and "<<"')
     ->livewire(DishesTable::class)
-    ->assertDontSeeHtml('wire:click="previousPage"')
+    ->assertDontSeeHtml('wire:click="previousPage(\'default\')"')
     //page #2
     ->call('gotoPage', '2')
-    ->assertSeeHtml('wire:click="previousPage"');
+    ->assertSeeHtml('wire:click="previousPage(\'default\')"');
 
 it('searches for something that is not on the current page')
     ->livewire(DishesTable::class)


### PR DESCRIPTION
#### Motivation

- [ X ] Bug fix
- [    ] Enhancement
- [    ] New feature
- [    ] Breaking change

#### Description

This pull request adds the page name to the links to the previous and next page in the tailwind pagination template and corrects the corresponding tests.

#### Related Issue(s):  I have not created a separate issue.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [    ] Yes
- [ X ] No
- [    ] I have already submitted a Documentation pull request.
