### PR TITLE
Remove redundant class attributes

### DIFF
--- a/resources/views/components/icons/filter.blade.php
+++ b/resources/views/components/icons/filter.blade.php
@@ -4,7 +4,6 @@
     viewBox="0 0 24 24"
     stroke-width="1.5"
     stroke="currentColor"
-    class="w-4 h-4"
 >
     <path
         stroke-linecap="round"

--- a/resources/views/components/icons/search.blade.php
+++ b/resources/views/components/icons/search.blade.php
@@ -1,12 +1,11 @@
 <svg
-    {{ $attributes->merge(['class' => 'h-5 w-5']) }}
+    {{ $attributes->merge(['class' => 'h-5 w-5 dark:text-gray-300 text-gray-400']) }}
     fill="none"
     stroke="currentColor"
     stroke-linecap="round"
     stroke-linejoin="round"
     stroke-width="2"
     viewBox="0 0 24 24"
-    class="w-6 h-6 dark:text-gray-300 text-gray-400"
 >
     <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
 </svg>


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

#### Motivation

- [ ] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change
- [x] Minor improvement

#### Description

The class attributes of the two icons `search` and `filter` are redundant, as they were explicitly specified on the one hand and are injected by the component attributes on the other.

#### Related Issue(s):  none

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
