### PR TITLE
Added support for custom options to a MultiSelectFilter

### DIFF
--- a/resources/views/components/inputs/select.blade.php
+++ b/resources/views/components/inputs/select.blade.php
@@ -4,6 +4,7 @@
     'tableName' => null,
     'multiple' => true,
     'initialValues' => [],
+    'options' => [],
     'title' => '',
     'theme' => null,
 ])
@@ -36,6 +37,7 @@
         'dataField' => data_get($filter, 'field'),
         'optionValue' => data_get($filter, 'optionValue'),
         'optionLabel' => data_get($filter, 'optionLabel'),
+        'options' => data_get($filter, 'params'),
         'initialValues' => $initialValues,
         'framework' => $framework[config('livewire-powergrid.plugins.select.default')],
     ];
@@ -71,7 +73,10 @@
                 wire:model="filters.multi_select.{{ data_get($filter, 'field') }}.values"
                 x-ref="select_picker_{{ data_get($filter, 'field') }}_{{ $tableName }}"
             >
-                <option value="">{{ trans('livewire-powergrid::datatable.multi_select.all') }}</option>
+                @if (!data_get($params, 'options.disableOptionAll', false))
+                    <option value="">{{ trans('livewire-powergrid::datatable.multi_select.all') }}</option>
+                @endif
+
                 @if (blank(data_get($params, 'asyncData', [])))
                     @foreach ($collection->toArray() as $item)
                         <option wire:key="multi-select-option-{{ $loop->index }}"

--- a/src/Components/Filters/FilterMultiSelect.php
+++ b/src/Components/Filters/FilterMultiSelect.php
@@ -14,6 +14,8 @@ class FilterMultiSelect extends FilterBase
 
     public string $optionLabel = '';
 
+    public array $params = [];
+
     public function dataSource(Collection|array $collection): FilterMultiSelect
     {
         $this->dataSource = $collection;
@@ -31,6 +33,13 @@ class FilterMultiSelect extends FilterBase
     public function optionLabel(string $value): FilterMultiSelect
     {
         $this->optionLabel = $value;
+
+        return $this;
+    }
+
+    public function params(array $params): FilterMultiSelect
+    {
+        $this->params = $params;
 
         return $this;
     }


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [ ] Enhancement
- [x] New feature
- [ ] Breaking change

#### Description

This request allows the user to pass a new function to the filter. 
![test](https://github.com/user-attachments/assets/06ff1395-8a99-431b-bffd-bee77caaa812)

With this function the user can pass custom options to the filter in order to decide what it can do or not.
I added the option "**disableOptionAll**" which allows the user to control whether or not the filter should display the option "**All**" like discussed in [this thread](https://github.com/Power-Components/livewire-powergrid/discussions/1693).

More options and how the filter should react can be added later on.

#### Related Issue(s): No issue just a [discussion](https://github.com/Power-Components/livewire-powergrid/discussions/1693).

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
