### PR TITLE
[6.x] Added functionality to pass custom params to a normal select

### DIFF
--- a/resources/views/components/frameworks/bootstrap5/filters/select.blade.php
+++ b/resources/views/components/frameworks/bootstrap5/filters/select.blade.php
@@ -4,6 +4,7 @@
     'column' => null,
     'inline' => null,
     'filter' => null,
+    'options' => [],
 ])
 
 @php
@@ -33,7 +34,10 @@
             style="{{ data_get($column, 'headerStyle') }}"
             {{ $defaultAttributes['selectAttributes'] }}
         >
-            <option value="">{{ trans('livewire-powergrid::datatable.select.all') }}</option>
+
+            @if(!data_get($params, 'params.disableOptionAll', false))
+                <option value="">{{ trans('livewire-powergrid::datatable.select.all') }}</option>
+            @endif
 
             @php
                 $computedDatasource = data_get($filter, 'computedDatasource');

--- a/resources/views/components/frameworks/tailwind/filters/select.blade.php
+++ b/resources/views/components/frameworks/tailwind/filters/select.blade.php
@@ -3,6 +3,7 @@
     'column' => null,
     'inline' => null,
     'filter' => null,
+    'options' => [],
 ])
 @php
     $field = data_get($filter, 'field');
@@ -43,7 +44,9 @@
                 style="{{ data_get($column, 'headerStyle') }}"
                 {{ $defaultAttributes['selectAttributes'] }}
             >
-                <option value="">{{ trans('livewire-powergrid::datatable.select.all') }}</option>
+                @if(!data_get($params, 'params.disableOptionAll', false))
+                    <option value="">{{ trans('livewire-powergrid::datatable.select.all') }}</option>
+                @endif
 
                 @php
                     $computedDatasource = data_get($filter, 'computedDatasource');

--- a/src/Components/Filters/FilterSelect.php
+++ b/src/Components/Filters/FilterSelect.php
@@ -17,6 +17,8 @@ class FilterSelect extends FilterBase
 
     public array $depends = [];
 
+    public array $params = [];
+
     public string $computedDatasource = '';
 
     public function depends(array $fields): FilterSelect
@@ -62,5 +64,12 @@ class FilterSelect extends FilterBase
                 'wire:input.live.debounce.600ms' => 'filterSelect(\'' . $field . '\', \'' . $title . '\')',
             ]))
             ->toArray();
+    }
+
+    public function params(array $params): FilterSelect
+    {
+        $this->params = $params;
+
+        return $this;
     }
 }


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [ ] Enhancement
- [x] New feature
- [ ] Breaking change

#### Description

This is for version 6.x

This pull requests is basically the same as [this](https://github.com/Power-Components/livewire-powergrid/commit/e148c0450ffdd79bec5374fe85582721776b4db0) but instead for MultiSelectFilter it is for a normal SelectFilter.

It also allows the user to pass a new function named **params()** to a normal **Filter::select**.
Just as the MultiSelectFilter there is the default option for "**disableOptionAll**" to either show or hide the option "All" in the select filter.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
