### PR TITLE
Add missing quote in dispatchTo rule

### DIFF
--- a/src/Components/Rules/Support/DispatchToRule.php
+++ b/src/Components/Rules/Support/DispatchToRule.php
@@ -14,7 +14,7 @@ class DispatchToRule
         $event  = strval(data_get($ruleData, 'event'));
         $params = (array) data_get($ruleData, 'params');
 
-        $output['attributes'] = ['wire:click' => "\$dispatchTo('{$to}',{$event}', " . Js::from($params) . ")"];
+        $output['attributes'] = ['wire:click' => "\$dispatchTo('{$to}','{$event}', " . Js::from($params) . ")"];
 
         return $output;
     }


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request adds a missing opening quote in the DispatchToRule class. Without this quote, the dispatchTo() wire:click attribute is incorrectly formatted (the event name is not a string) and does not work.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
