### PR TITLE
move orphaned semicolon in templates

### DIFF
--- a/resources/views/components/cols.blade.php
+++ b/resources/views/components/cols.blade.php
@@ -41,7 +41,7 @@
     @if ($isFixedOnResponsive) fixed @endif
     @if (data_get($column, 'enableSort')) x-multisort-shift-click="{{ $this->getId() }}"
         wire:click="sortBy('{{ $field }}')" @endif
-    style="{{ data_get($column, 'hidden') === true ? 'display:none' : '' }}; width: max-content !important; @if (data_get($column, 'enableSort')) cursor:pointer; @endif {{ data_get($column, 'headerStyle') }}"
+    style="{{ data_get($column, 'hidden') === true ? 'display:none' : ''; }} width: max-content !important; @if (data_get($column, 'enableSort')) cursor:pointer; @endif {{ data_get($column, 'headerStyle') }}"
 >
     <div
         class="{{ theme_style($theme, 'cols.div') }}"

--- a/resources/views/components/table-footer.blade.php
+++ b/resources/views/components/table-footer.blade.php
@@ -13,7 +13,7 @@
     @foreach ($this->visibleColumns as $column)
         <td
             class="{{ theme_style($theme, 'table.body.tdSummarize') . ' ' . data_get($column, 'bodyClass') ?? '' }}"
-            style="{{ data_get($column, 'hidden') === true ? 'display:none' : '' }}; . {{ data_get($column, 'bodyStyle') ?? '' }}"
+            style="{{ data_get($column, 'hidden') === true ? 'display:none;' : '' }} . {{ data_get($column, 'bodyStyle') ?? '' }}"
         >
             @include('livewire-powergrid::components.summarize', [
                 'sum' => data_get($column, 'properties.summarize.sum.footer') ? data_get($column, 'properties.summarize_values.sum') : null,

--- a/resources/views/components/table-header.blade.php
+++ b/resources/views/components/table-header.blade.php
@@ -8,7 +8,7 @@
     @endif
     @foreach ($this->visibleColumns as $column)
         <td class="{{ theme_style($theme, 'table.body.tdSummarize') . ' '.data_get($column, 'bodyClass') ?? '' }}"
-            style="{{ data_get($column, 'hidden') === true ? 'display:none': '' }}; {{ data_get($column, 'bodyStyle') ?? ''  }}">
+            style="{{ data_get($column, 'hidden') === true ? 'display:none;': '' }} {{ data_get($column, 'bodyStyle') ?? ''  }}">
             @include('livewire-powergrid::components.summarize', [
                 'sum' => data_get($column, 'properties.summarize.sum.header') ? data_get($column, 'properties.summarize_values.sum') : null,
                 'labelSum' => data_get($column, 'properties.summarize.sum.label'),


### PR DESCRIPTION
<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Minor change on templates to move semicolon orphaned if previous condition is false

Obviously details but to avoid this kind of render 

![Capture d’écran 2024-11-08 143347](https://github.com/user-attachments/assets/39891051-2272-4cc3-a11c-21178631fe1f)

#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
