### PR TITLE
Support for models with different database connection property

### DIFF
--- a/src/DataSource/Builder.php
+++ b/src/DataSource/Builder.php
@@ -253,10 +253,14 @@ class Builder
 
     private function getColumnList(string $modelTable): array
     {
+        $connection = $this->query instanceof EloquentBuilder
+            ? $this->query->getModel()->getConnection()->getName()
+            : $this->query->getConnection()->getName();
+
         try {
             return PowerGridTableCache::getOrCreate(
                 $modelTable,
-                fn () => collect(Schema::getColumns($modelTable))
+                fn () => collect(Schema::connection($connection)->getColumns($modelTable))
                     ->pluck('type', 'name')
                     ->toArray()
             );
@@ -266,7 +270,7 @@ class Builder
                 'throwable' => $throwable->getTrace(),
             ]);
 
-            return Schema::getColumnListing($modelTable);
+            return Schema::connection($connection)->getColumnListing($modelTable);
         }
     }
 

--- a/src/DataSource/Builder.php
+++ b/src/DataSource/Builder.php
@@ -255,7 +255,8 @@ class Builder
     {
         $connection = $this->query instanceof EloquentBuilder
             ? $this->query->getModel()->getConnection()->getName()
-            : $this->query->getConnection()->getName();
+            /** @phpstan-ignore-next-line  */
+            : $this->query->getConnection()->getConfig('name');
 
         try {
             return PowerGridTableCache::getOrCreate(


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [ ] Bug fix
- [X] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This pull request add the support for the models which have a connection property defined which is different from the default one. 

Issue:
When models haves database connection property defined which is different from the default one, then the global search doesn't work as the getColumnList() function was using the default database connection.

#### Related Issue(s):  #1798 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
