### PR TITLE
[Enhancement] Implement loading indicator at detail button for tailwind theme

### DIFF
--- a/resources/views/components/frameworks/tailwind/header/loading.blade.php
+++ b/resources/views/components/frameworks/tailwind/header/loading.blade.php
@@ -1,6 +1,7 @@
 <div class="hidden lg:!block">
     <div
         wire:loading
+        wire:target.except="toggleDetail"
         class="mt-2 hidden"
     >
         <x-livewire-powergrid::icons.loading

--- a/resources/views/components/frameworks/tailwind/header/loading.blade.php
+++ b/resources/views/components/frameworks/tailwind/header/loading.blade.php
@@ -3,25 +3,8 @@
         wire:loading
         class="mt-2 hidden"
     >
-        <svg
-            class="animate-spin h-5 w-5 text-pg-primary-300 dark:text-pg-primary-400"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-        >
-            <circle
-                class="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                stroke-width="4"
-            ></circle>
-            <path
-                class="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            ></path>
-        </svg>
+        <x-livewire-powergrid::icons.loading
+            class="text-pg-primary-300 dark:text-pg-primary-400 h-5 w-5 animate-spin"
+        />
     </div>
 </div>

--- a/resources/views/components/frameworks/tailwind/toggle-detail.blade.php
+++ b/resources/views/components/frameworks/tailwind/toggle-detail.blade.php
@@ -1,19 +1,30 @@
 <td
     class="{{ theme_style($theme, 'table.body.td') }}"
 >
+    @php
+        $realPrimaryKey = $row->{$this->realPrimaryKey};
+    @endphp
     <div
         class="cursor-pointer"
-        x-on:click.prevent="$wire.toggleDetail('{{ $row->{$this->realPrimaryKey} }}')"
+        x-on:click.prevent="$wire.toggleDetail('{{ $realPrimaryKey }}')"
     >
-        @includeIf(data_get($setUp, 'detail.viewIcon'))
-        @if (!data_get($setUp, 'detail.viewIcon'))
-            <x-livewire-powergrid::icons.arrow
-                @class([
-                    'rotate-90' => data_get($setUp, 'detail.state.' . $rowId),
-                    '-rotate-0' => !data_get($setUp, 'detail.state.' . $rowId),
-                    'text-pg-primary-600 w-5 h-5 transition-all duration-300 dark:text-pg-primary-200',
-                ])
+        <div wire:loading wire:target="toggleDetail('{{ $realPrimaryKey }}')">
+            <x-livewire-powergrid::icons.loading
+                class="text-pg-primary-300 dark:text-pg-primary-400 h-5 w-5 animate-spin"
             />
-        @endif
+        </div>
+
+        <div wire:loading.remove wire:target="toggleDetail('{{ $realPrimaryKey }}')">
+            @includeIf(data_get($setUp, 'detail.viewIcon'))
+            @unless(data_get($setUp, 'detail.viewIcon'))
+                <x-livewire-powergrid::icons.arrow
+                    @class([
+                        'rotate-90' => data_get($setUp, 'detail.state.' . $rowId),
+                        '-rotate-0' => !data_get($setUp, 'detail.state.' . $rowId),
+                        'text-pg-primary-600 w-5 h-5 transition-all duration-300 dark:text-pg-primary-200',
+                    ])
+                />
+            @endif
+        </div>
     </div>
 </td>

--- a/resources/views/components/icons/loading.blade.php
+++ b/resources/views/components/icons/loading.blade.php
@@ -1,0 +1,20 @@
+<svg
+    {{ $attributes }}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+>
+    <circle
+        class="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        stroke-width="4">
+    </circle>
+    <path
+        class="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+    />
+</svg>


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description
Since the detail row feature may take some time to toggle between open/closed, to improve the users' UI/UX, I've implemented a loading state in the chevron icon, which indicates to the user that the content is loading.

If the event comes from `toggleDetail`, the loading indicator in the header will not be shown, to prevent showing two loading states.

I know there is a loading state for the table header, but if the user scrolls through the table, making the header not visible, it may give the impression that the component isn't working.


https://github.com/user-attachments/assets/7cbfa43c-3c91-4ede-807c-9ce49840c697


#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
