### PR TITLE
[BUGFIX] Add fallback on search

### DIFF
--- a/src/DataSource/Builder.php
+++ b/src/DataSource/Builder.php
@@ -162,6 +162,7 @@ class Builder
                             ->when(
                                 $hasColumn && $table,
                                 fn (EloquentBuilder|QueryBuilder $query) => $query->orWhere("{$table}.{$field}", Sql::like($query), "%{$search}%"),
+                                fn (EloquentBuilder|QueryBuilder $query) => $query->orWhere($field, Sql::like($query), "%{$search}%"),
                             );
                     } catch (\Throwable) {
                         $query


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description
If you have a builder with alias like:

```
User::query()->select([
  'name as user_name'
])
```

the search might not work as expected, because at this point the `user_name` does not exist, and it returns false at:

`$hasColumn = isset($columnList[$field]);`

As a result, this block of code is ignored

```
try {
    $query
        ->when(
            $hasColumn && $table,
            fn (EloquentBuilder|QueryBuilder $query) => $query->orWhere("{$table}.{$field}", Sql::like($query), "%{$search}%"),
        );
} catch (\Throwable) {
    $query
        ->when(
            $table,
            fn (EloquentBuilder|QueryBuilder $query) => $query->orWhere("{$table}.{$field}", Sql::like($query), "%{$search}%"),
            fn (EloquentBuilder|QueryBuilder $query) => $query->orWhere($field, Sql::like($query), "%{$search}%")
        );
}
```




...

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
