### PR TITLE
fix/primary-key-with-selected-items-export

### DIFF
--- a/src/Traits/WithExport.php
+++ b/src/Traits/WithExport.php
@@ -190,6 +190,7 @@ trait WithExport
         $currentTable = $processDataSource->component->currentTable;
 
         $sortField = Support\Str::of($processDataSource->component->sortField)->contains('.') ? $processDataSource->component->sortField : $currentTable . '.' . $processDataSource->component->sortField;
+        $primaryKey = Support\Str::of($processDataSource->component->primaryKey)->contains('.') ? $processDataSource->component->primaryKey : $currentTable . '.' . $processDataSource->component->primaryKey;
 
         $results = $processDataSource->component->datasource()
             ->where(
@@ -197,8 +198,8 @@ trait WithExport
                     ->filterContains()
                     ->filter()
             )
-            ->when($filtered, function ($query, $filtered) use ($processDataSource) {
-                return $query->whereIn($processDataSource->component->primaryKey, $filtered);
+            ->when($filtered, function ($query, $filtered) use ($primaryKey) {
+                return $query->whereIn($primaryKey, $filtered);
             })
             ->orderBy($sortField, $processDataSource->component->sortDirection)
             ->get();


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description
With a complex query as datasource with joins, when exporting selected items you get an ambiguous primary key error. Table name is missing in the where query.

Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous


#### Related Issue(s): #1841 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
