### PR TITLE
Table name with primary key for selected items export

### DIFF
--- a/src/Traits/ExportableJob.php
+++ b/src/Traits/ExportableJob.php
@@ -62,7 +62,7 @@ trait ExportableJob
                     ->filterContains()
                     ->filter()
             )
-            ->when($filtered, function ($query, $filtered) use ($processDataSource, $property) {
+            ->when($filtered, function ($query, $filtered) use ($property) {
                 return $query->whereIn($property('primaryKey'), $filtered);
             })
             ->offset($this->offset)

--- a/src/Traits/ExportableJob.php
+++ b/src/Traits/ExportableJob.php
@@ -45,11 +45,16 @@ trait ExportableJob
             fn ($datasource) => $datasource->get()
         );
 
-        $filtered = $processDataSource->component->filtered ?? [];
-
+        $filtered     = $processDataSource->component->filtered ?? [];
         $currentTable = $processDataSource->component->currentTable;
 
-        $sortField = Str::of($processDataSource->component->sortField)->contains('.') ? $processDataSource->component->sortField : $currentTable . '.' . $processDataSource->component->sortField;
+        $property = function (string $property) use ($processDataSource, $currentTable) {
+            $property = $processDataSource->component->{$property};
+
+            return Str::of($property)->contains('.')
+                ? $property
+                : $currentTable . '.' . $property;
+        };
 
         $results = $this->componentTable->datasource($this->properties ?? []) // @phpstan-ignore-line
             ->where(
@@ -57,12 +62,12 @@ trait ExportableJob
                     ->filterContains()
                     ->filter()
             )
-            ->when($filtered, function ($query, $filtered) use ($processDataSource) {
-                return $query->whereIn($processDataSource->component->primaryKey, $filtered);
+            ->when($filtered, function ($query, $filtered) use ($processDataSource, $property) {
+                return $query->whereIn($property('primaryKey'), $filtered);
             })
             ->offset($this->offset)
             ->limit($this->limit)
-            ->orderBy($sortField, $processDataSource->component->sortDirection)
+            ->orderBy($property('sortField'), $processDataSource->component->sortDirection)
             ->get();
 
         return DataSourceBase::transform($results, $this->componentTable);

--- a/src/Traits/WithExport.php
+++ b/src/Traits/WithExport.php
@@ -190,6 +190,7 @@ trait WithExport
         $currentTable = $processDataSource->component->currentTable;
 
         $sortField = Support\Str::of($processDataSource->component->sortField)->contains('.') ? $processDataSource->component->sortField : $currentTable . '.' . $processDataSource->component->sortField;
+        $primaryKey = Support\Str::of($processDataSource->component->primaryKey)->contains('.') ? $processDataSource->component->primaryKey : $currentTable . '.' . $processDataSource->component->primaryKey;
 
         $results = $processDataSource->component->datasource()
             ->where(
@@ -197,8 +198,8 @@ trait WithExport
                     ->filterContains()
                     ->filter()
             )
-            ->when($filtered, function ($query, $filtered) use ($processDataSource) {
-                return $query->whereIn($processDataSource->component->primaryKey, $filtered);
+            ->when($filtered, function ($query, $filtered) use ($primaryKey) {
+                return $query->whereIn($primaryKey, $filtered);
             })
             ->orderBy($sortField, $processDataSource->component->sortDirection)
             ->get();

--- a/src/Traits/WithExport.php
+++ b/src/Traits/WithExport.php
@@ -189,8 +189,13 @@ trait WithExport
         /** @phpstan-ignore-next-line */
         $currentTable = $processDataSource->component->currentTable;
 
-        $sortField = Support\Str::of($processDataSource->component->sortField)->contains('.') ? $processDataSource->component->sortField : $currentTable . '.' . $processDataSource->component->sortField;
-        $primaryKey = Support\Str::of($processDataSource->component->primaryKey)->contains('.') ? $processDataSource->component->primaryKey : $currentTable . '.' . $processDataSource->component->primaryKey;
+        $property = function (string $property) use ($processDataSource, $currentTable) {
+            $property = $processDataSource->component->{$property};
+
+            return Support\Str::of($property)->contains('.')
+                ? $property
+                : $currentTable . '.' . $property;
+        };
 
         $results = $processDataSource->component->datasource()
             ->where(
@@ -198,10 +203,10 @@ trait WithExport
                     ->filterContains()
                     ->filter()
             )
-            ->when($filtered, function ($query, $filtered) use ($primaryKey) {
-                return $query->whereIn($primaryKey, $filtered);
+            ->when($filtered, function ($query, $filtered) use ($property) {
+                return $query->whereIn($property('primaryKey'), $filtered);
             })
-            ->orderBy($sortField, $processDataSource->component->sortDirection)
+            ->orderBy($property('sortField'), $processDataSource->component->sortDirection)
             ->get();
 
         return DataSourceBase::transform($results, $processDataSource->component);

--- a/tests/cypress/cypress/e2e/actions/attributes.cy.js
+++ b/tests/cypress/cypress/e2e/actions/attributes.cy.js
@@ -35,13 +35,12 @@ describe('render javascript actions attributes', () => {
 
         cy.get('[data-cy=btn-view-1]').click()
 
-        cy.wait('@requestIntercept')
+        cy.wait('@requestIntercept', { timeout: 8000 })
             .its('response.body')
             .should((response) => {
-                expect(response.components[0].effects.xjs[0])
-                    .to.deep
-                    .equal('console.log("Editing #view -  Luan")');
-        });
+                expect(response.components[0].effects.xjs[0].expression)
+                    .to.deep.equal('console.log("Editing #view -  Luan")');
+            });
     });
 
     it('can render "Edit" button and click for row 1', () => {
@@ -78,7 +77,7 @@ describe('render javascript actions attributes', () => {
         cy.wait('@requestIntercept')
             .its('response.body')
             .should((response) => {
-            expect(response.components[0].effects.xjs[0])
+            expect(response.components[0].effects.xjs[0].expression)
                 .to.deep
                 .equal('console.log("Editing #edit -  Luan")');
         });
@@ -113,7 +112,7 @@ describe('render javascript actions attributes', () => {
         cy.wait('@requestIntercept')
             .its('response.body')
             .should((response) => {
-            expect(response.components[0].effects.xjs[0])
+            expect(response.components[0].effects.xjs[0].expression)
                 .to.deep
                 .equal('console.log("Editing #view -  Daniel")');
         });
@@ -151,7 +150,7 @@ describe('render javascript actions attributes', () => {
         cy.wait('@requestIntercept')
             .its('response.body')
             .should((response) => {
-            expect(response.components[0].effects.xjs[0])
+            expect(response.components[0].effects.xjs[0].expression)
                 .to.deep
                 .equal('console.log("Editing #edit -  Daniel")');
         });


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description
With a complex query as datasource with joins, when exporting selected items you get an ambiguous primary key error. Table name is missing in the where query.

#### Related Issue(s): #1841 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
