### PR TITLE
Bugfix: Fix validation attribute

### DIFF
--- a/resources/js/components/pg-row-attributes.js
+++ b/resources/js/components/pg-row-attributes.js
@@ -7,7 +7,7 @@ export default (params) => ({
     init() {
         if (this.rules) {
             Object.values(this.rules).forEach((rule) => {
-                if (rule.applyLoop || rule.apply) {
+                if ((rule.applyLoop || rule.apply) && rule?.attributes) {
                     this.attributes.push(rule.attributes)
                 }
             })

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -247,7 +247,7 @@ class PowerGridComponent extends Component
 
     public function getPublicPropertiesDefinedInComponent(): array
     {
-        return collect((new \ReflectionClass($this))->getProperties(\ReflectionProperty::IS_PUBLIC))
+        return collect((new \ReflectionClass($this))->getProperties(\ReflectionProperty::IS_PUBLIC)) // @phpstan-ignore-line
             ->where('class', get_class($this))
             ->pluck('name')
             ->intersect(array_keys($this->all()))


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix  
- [ ] Enhancement  
- [ ] New feature  
- [ ] Breaking change  

### Description  

**Issue related:** [#1849](https://github.com/Power-Components/livewire-powergrid/issues/1849)  

Added missing validation at `rule.attributes` on `pg-row-attributes.js`.  

**Before:**  
<img width="1480" alt="image" src="https://github.com/user-attachments/assets/ba508d67-5510-4563-8873-61ed7cbb9526" />

**After:**  
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/cfa3f3b4-53f7-403d-b763-1ee824f8ef20" />

```php
public function actionRules(): array
{
    return [
        Rule::rows()
            ->when(fn($row) => (int) $row->id == 1)
            ->setAttribute('class', 'bg-green-200'),

        Rule::rows()
            ->when(fn($row) => (int) $row->id == 2)
            ->setAttribute('class', 'bg-red-200'),

        Rule::button('edit')
            ->when(fn($row) => $row->id == 1)
            ->hide(),

        Rule::button('mover-pago')
            ->when(fn($row) => $row->id == 2)
            ->hide(),
    ];
}
