### PR TITLE
Add missing method annotations to Button class

### DIFF
--- a/src/Button.php
+++ b/src/Button.php
@@ -22,6 +22,8 @@ use Livewire\Wireable;
  * @method static id(string $id = null)
  * @method static confirm(string $message = 'Are you sure you want to perform this action?')
  * @method static confirmPrompt(string $message = 'Are you sure you want to perform this action?', string $confirmValue = 'Confirm')
+ * @method static class(string $classes)
+ * @method static disable(bool = true)
  */
 final class Button implements Wireable
 {

--- a/src/Button.php
+++ b/src/Button.php
@@ -23,7 +23,7 @@ use Livewire\Wireable;
  * @method static confirm(string $message = 'Are you sure you want to perform this action?')
  * @method static confirmPrompt(string $message = 'Are you sure you want to perform this action?', string $confirmValue = 'Confirm')
  * @method static class(string $classes)
- * @method static disable(bool = true)
+ * @method static disable(bool $disable = true)
  */
 final class Button implements Wireable
 {


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Add missing `method `annotation in `Button` class for IDE completion

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
