### PR TITLE
Add trim to search terms in order to improve search

### DIFF
--- a/src/DataSource/Builder.php
+++ b/src/DataSource/Builder.php
@@ -140,7 +140,7 @@ class Builder
             return $this;
         }
 
-        $search            = strtolower(htmlspecialchars($this->component->search, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        $search            = trim(strtolower(htmlspecialchars($this->component->search, ENT_QUOTES | ENT_HTML5, 'UTF-8')));
         $hasRelationSearch = count($this->component->relationSearch()) && $this->query instanceof EloquentBuilder;
 
         $this->query = $this->query->where(

--- a/src/DataSource/Collection.php
+++ b/src/DataSource/Collection.php
@@ -68,7 +68,7 @@ class Collection
 
     public function search(): BaseCollection
     {
-        $searchTerm = strtolower($this->powerGridComponent->search);
+        $searchTerm = trim(strtolower($this->powerGridComponent->search));
 
         if (empty($searchTerm)) {
             return $this->collection;


### PR DESCRIPTION
Sometimes when users copy paste terms into the search field, an additional space gets added before the term. If this happens the search fails to find the items. This PR fixes it by adding trims to the search for the Builder and Collection Datasources.

## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Sometimes when a user is typing into the search field, a trailing space or a prepending space can cause the item to not be found if this space does not occur in the item's field. This can cause frustration for the user to find things when they are in a hurry (often spaces in the start of terms are not easy to see). This happens more often when users copy and paste into the search field, as sometimes the copying process also copies prepending and trailing spaces.

This PR provides a simple fix by trimming the search input.

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
