### PR TITLE
Fix: Exclude Disabled and Hidden Checkboxes from "Select All" Functionality

### DIFF
--- a/src/Concerns/Checkbox.php
+++ b/src/Concerns/Checkbox.php
@@ -45,13 +45,15 @@ trait Checkbox
             $hide = (bool) data_get(
                 collect((array) $model->__powergrid_rules) //@phpstan-ignore-line
                     ->where('apply', true)
+                    ->where('forAction', 'pg:checkbox')
                     ->last(),
-                'disable',
+                'hide',
             );
 
             $disable = (bool) data_get(
                 collect((array) $model->__powergrid_rules) //@phpstan-ignore-line
                     ->where('apply', true)
+                    ->where('forAction', 'pg:checkbox')
                     ->last(),
                 'disable',
             );


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This PR fixes an issue where the "Select All" checkbox unintentionally includes checkboxes that are disabled or hidden. Previously, when "Select All" was checked, it would select all checkboxes regardless of their visibility or state, leading to incorrect selections.

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
