### PR TITLE
fix: relational join search inconsistency

### DIFF
--- a/src/DataSource/Builder.php
+++ b/src/DataSource/Builder.php
@@ -160,20 +160,13 @@ class Builder
 
                         $hasColumn = isset($columnList[$field]);
 
-                        $query->when(
-                            $table,
-                            function (EloquentBuilder|QueryBuilder $query) use ($table, $field, $hasColumn, $search, $hasRelationSearch) {
-                                if ($hasColumn) {
-                                    return $query->orWhere("{$table}.{$field}", Sql::like($query), "%{$search}%");
-                                }
+                        if (empty($table)) {
+                            return $query->orWhere($field, Sql::like($query), "%{$search}%");
+                        }
 
-                                return $query->when(
-                                    !$hasRelationSearch,
-                                    fn (EloquentBuilder|QueryBuilder $query) => $query->orWhere($field, Sql::like($query), "%{$search}%")
-                                );
-                            },
-                            fn (EloquentBuilder|QueryBuilder $query) => $query->orWhere($field, Sql::like($query), "%{$search}%")
-                        );
+                        if ($hasColumn || !$hasRelationSearch) {
+                            return $query->orWhere("{$table}.{$field}", Sql::like($query), "%{$search}%");
+                        }
                     });
 
                 return $query;


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This PR fixes #1884 where the Query Builder won't comply relational syntax such `table.column`.  After this PR, the default query should be using `table.column` all the time, unless the `table` is not specified (which will be using the default model query).

I also improved the readability of the code quite a bit, that nested `$query->when()` was a mess.


#### Related Issue(s): 

#1884 


#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
