### PR TITLE
Moved filter attribute functions to separate classes for error "Your configuration files are not serializable."

### DIFF
--- a/resources/config/livewire-powergrid.php
+++ b/resources/config/livewire-powergrid.php
@@ -112,38 +112,9 @@ return [
     */
 
     'filter_attributes' => [
-        'input_text' => function (string $field, string $title): array {
-            return [
-                'inputAttributes' => new ComponentAttributeBag([
-                    'wire:model'                     => 'filters.input_text.' . $field,
-                    'wire:input.live.debounce.600ms' => 'filterInputText(\'' . $field . '\', $event.target.value, \'' . $title . '\')',
-                ]),
-                'selectAttributes' => new ComponentAttributeBag([
-                    'wire:model'                     => 'filters.input_text_options.' . $field,
-                    'wire:input.live.debounce.600ms' => 'filterInputTextOptions(\'' . $field . '\', $event.target.value, \'' . $title . '\')',
-                ]),
-            ];
-        },
-        'boolean' => function (string $field, string $title): array {
-            return [
-                'selectAttributes' => new ComponentAttributeBag([
-                    'wire:input.live.debounce.600ms' => 'filterBoolean(\'' . $field . '\', $event.target.value, \'' . $title . '\')',
-                    'wire:model'                     => 'filters.boolean.' . $field,
-                ]),
-            ];
-        },
-        'number' => function (string $field, array $filter): array {
-            return [
-                'inputStartAttributes' => new ComponentAttributeBag([
-                    'wire:model'                     => 'filters.number.' . $field . '.start',
-                    'wire:input.live.debounce.600ms' => 'filterNumberStart(\'' . $field . '\', ' . Js::from($filter) . ', $event.target.value)',
-                ]),
-                'inputEndAttributes' => new ComponentAttributeBag([
-                    'wire:model'                     => 'filters.number.' . $field . '.end',
-                    'wire:input.live.debounce.600ms' => 'filterNumberEnd(\'' . $field . '\', ' . Js::from($filter) . ', $event.target.value)',
-                ]),
-            ];
-        },
+        'input_text' => \PowerComponents\LivewirePowerGrid\FilterAttributes\InputText::class,
+        'boolean'    => \PowerComponents\LivewirePowerGrid\FilterAttributes\Boolean::class,
+        'number'     => \PowerComponents\LivewirePowerGrid\FilterAttributes\Number::class,
     ],
 
     /*

--- a/resources/config/livewire-powergrid.php
+++ b/resources/config/livewire-powergrid.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\Js;
-use Illuminate\View\ComponentAttributeBag;
 
 return [
 

--- a/resources/config/livewire-powergrid.php
+++ b/resources/config/livewire-powergrid.php
@@ -114,6 +114,7 @@ return [
         'input_text' => \PowerComponents\LivewirePowerGrid\FilterAttributes\InputText::class,
         'boolean'    => \PowerComponents\LivewirePowerGrid\FilterAttributes\Boolean::class,
         'number'     => \PowerComponents\LivewirePowerGrid\FilterAttributes\Number::class,
+        'select'     => \PowerComponents\LivewirePowerGrid\FilterAttributes\Select::class,
     ],
 
     /*

--- a/src/Components/Filters/FilterBoolean.php
+++ b/src/Components/Filters/FilterBoolean.php
@@ -2,6 +2,8 @@
 
 namespace PowerComponents\LivewirePowerGrid\Components\Filters;
 
+use PowerComponents\LivewirePowerGrid\FilterAttributes\Boolean;
+
 class FilterBoolean extends FilterBase
 {
     public string $key = 'boolean';
@@ -20,7 +22,7 @@ class FilterBoolean extends FilterBase
 
     public static function getWireAttributes(string $field, string $title): array
     {
-        $configAttributes = config('livewire-powergrid.filter_attributes.boolean', \PowerComponents\LivewirePowerGrid\FilterAttributes\Boolean::class);
+        $configAttributes = config('livewire-powergrid.filter_attributes.boolean', Boolean::class);
 
         /** @var callable $class */
         $class = new $configAttributes();

--- a/src/Components/Filters/FilterBoolean.php
+++ b/src/Components/Filters/FilterBoolean.php
@@ -20,8 +20,11 @@ class FilterBoolean extends FilterBase
 
     public static function getWireAttributes(string $field, string $title): array
     {
-        $configAttributes = config('livewire-powergrid.filter_attributes.boolean');
+        $configAttributes = config('livewire-powergrid.filter_attributes.boolean', \PowerComponents\LivewirePowerGrid\FilterAttributes\Boolean::class);
 
-        return is_callable($configAttributes) ? $configAttributes($field, $title) : [];
+        /** @var callable $class */
+        $class = new $configAttributes();
+
+        return $class($field, $title);
     }
 }

--- a/src/Components/Filters/FilterInputText.php
+++ b/src/Components/Filters/FilterInputText.php
@@ -2,6 +2,8 @@
 
 namespace PowerComponents\LivewirePowerGrid\Components\Filters;
 
+use PowerComponents\LivewirePowerGrid\FilterAttributes\InputText;
+
 class FilterInputText extends FilterBase
 {
     public string $key = 'input_text';
@@ -38,7 +40,7 @@ class FilterInputText extends FilterBase
 
     public static function getWireAttributes(string $field, string $title): array
     {
-        $configAttributes = config('livewire-powergrid.filter_attributes.input_text', \PowerComponents\LivewirePowerGrid\FilterAttributes\InputText::class);
+        $configAttributes = config('livewire-powergrid.filter_attributes.input_text', InputText::class);
 
         /** @var callable $class */
         $class = new $configAttributes();

--- a/src/Components/Filters/FilterInputText.php
+++ b/src/Components/Filters/FilterInputText.php
@@ -38,9 +38,12 @@ class FilterInputText extends FilterBase
 
     public static function getWireAttributes(string $field, string $title): array
     {
-        $configAttributes = config('livewire-powergrid.filter_attributes.input_text');
+        $configAttributes = config('livewire-powergrid.filter_attributes.input_text', \PowerComponents\LivewirePowerGrid\FilterAttributes\InputText::class);
 
-        return is_callable($configAttributes) ? $configAttributes($field, $title) : [];
+        /** @var callable $class */
+        $class = new $configAttributes();
+
+        return $class($field, $title);
     }
 
     public function placeholder(string $placeholder): FilterInputText

--- a/src/Components/Filters/FilterNumber.php
+++ b/src/Components/Filters/FilterNumber.php
@@ -2,6 +2,8 @@
 
 namespace PowerComponents\LivewirePowerGrid\Components\Filters;
 
+use PowerComponents\LivewirePowerGrid\FilterAttributes\Number;
+
 class FilterNumber extends FilterBase
 {
     public string $key = 'number';
@@ -38,7 +40,7 @@ class FilterNumber extends FilterBase
 
     public static function getWireAttributes(string $field, array $filter): array
     {
-        $configAttributes = config('livewire-powergrid.filter_attributes.number', \PowerComponents\LivewirePowerGrid\FilterAttributes\Number::class);
+        $configAttributes = config('livewire-powergrid.filter_attributes.number', Number::class);
 
         /** @var callable $class */
         $class = new $configAttributes();

--- a/src/Components/Filters/FilterNumber.php
+++ b/src/Components/Filters/FilterNumber.php
@@ -38,8 +38,11 @@ class FilterNumber extends FilterBase
 
     public static function getWireAttributes(string $field, array $filter): array
     {
-        $configAttributes = config('livewire-powergrid.filter_attributes.number');
+        $configAttributes = config('livewire-powergrid.filter_attributes.number', \PowerComponents\LivewirePowerGrid\FilterAttributes\Number::class);
 
-        return is_callable($configAttributes) ? $configAttributes($field, $filter) : [];
+        /** @var callable $class */
+        $class = new $configAttributes();
+
+        return $class($field, $filter);
     }
 }

--- a/src/Components/Filters/FilterSelect.php
+++ b/src/Components/Filters/FilterSelect.php
@@ -4,7 +4,6 @@ namespace PowerComponents\LivewirePowerGrid\Components\Filters;
 
 use Closure;
 use Illuminate\Support\{Collection};
-use Illuminate\View\ComponentAttributeBag;
 
 class FilterSelect extends FilterBase
 {
@@ -59,12 +58,12 @@ class FilterSelect extends FilterBase
 
     public static function getWireAttributes(string $field, string $title): array
     {
-        return collect()
-            ->put('selectAttributes', new ComponentAttributeBag([
-                'wire:model'                     => 'filters.select.' . $field,
-                'wire:input.live.debounce.600ms' => 'filterSelect(\'' . $field . '\', \'' . $title . '\')',
-            ]))
-            ->all();
+        $configAttributes = config('livewire-powergrid.filter_attributes.select', \PowerComponents\LivewirePowerGrid\FilterAttributes\Select::class);
+
+        /** @var callable $class */
+        $class = new $configAttributes();
+
+        return $class($field, $title);
     }
 
     public function params(array $params): FilterSelect

--- a/src/Components/Filters/FilterSelect.php
+++ b/src/Components/Filters/FilterSelect.php
@@ -4,6 +4,7 @@ namespace PowerComponents\LivewirePowerGrid\Components\Filters;
 
 use Closure;
 use Illuminate\Support\{Collection};
+use PowerComponents\LivewirePowerGrid\FilterAttributes\Select;
 
 class FilterSelect extends FilterBase
 {
@@ -58,7 +59,7 @@ class FilterSelect extends FilterBase
 
     public static function getWireAttributes(string $field, string $title): array
     {
-        $configAttributes = config('livewire-powergrid.filter_attributes.select', \PowerComponents\LivewirePowerGrid\FilterAttributes\Select::class);
+        $configAttributes = config('livewire-powergrid.filter_attributes.select', Select::class);
 
         /** @var callable $class */
         $class = new $configAttributes();

--- a/src/FilterAttributes/Boolean.php
+++ b/src/FilterAttributes/Boolean.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\FilterAttributes;
+
+class Boolean
+{
+    public function __invoke(string $field, string $title): array
+    {
+        return [
+            'selectAttributes' => [
+                'wire:model' => 'filters.boolean.' . $field,
+                'wire:input.live.debounce.600ms' => "filterBoolean('{$field}', \$event.target.value, '{$title}')",
+            ],
+        ];
+    }
+}

--- a/src/FilterAttributes/Boolean.php
+++ b/src/FilterAttributes/Boolean.php
@@ -8,7 +8,7 @@ class Boolean
     {
         return [
             'selectAttributes' => [
-                'wire:model' => 'filters.boolean.' . $field,
+                'wire:model'                     => 'filters.boolean.' . $field,
                 'wire:input.live.debounce.600ms' => "filterBoolean('{$field}', \$event.target.value, '{$title}')",
             ],
         ];

--- a/src/FilterAttributes/InputText.php
+++ b/src/FilterAttributes/InputText.php
@@ -10,14 +10,14 @@ class InputText
     public function __invoke(string $field, string $title): array
     {
         return [
-            'inputAttributes' => new ComponentAttributeBag([
+            'inputAttributes' => [
                 'wire:model' => 'filters.input_text.' . $field,
                 'wire:input.live.debounce.600ms' => "filterInputText('{$field}', \$event.target.value, '{$title}')",
-            ]),
-            'selectAttributes' => new ComponentAttributeBag([
+            ],
+            'selectAttributes' => [
                 'wire:model' => 'filters.input_text_options.' . $field,
                 'wire:input.live.debounce.600ms' => "filterInputTextOptions('{$field}', \$event.target.value, '{$title}')",
-            ]),
+            ],
         ];
     }
 }

--- a/src/FilterAttributes/InputText.php
+++ b/src/FilterAttributes/InputText.php
@@ -2,7 +2,6 @@
 
 namespace PowerComponents\LivewirePowerGrid\FilterAttributes;
 
-use Illuminate\Support\Js;
 use Illuminate\View\ComponentAttributeBag;
 
 class InputText
@@ -10,14 +9,14 @@ class InputText
     public function __invoke(string $field, string $title): array
     {
         return [
-            'inputAttributes' => [
-                'wire:model' => 'filters.input_text.' . $field,
+            'inputAttributes' => new ComponentAttributeBag([
+                'wire:model'                     => 'filters.input_text.' . $field,
                 'wire:input.live.debounce.600ms' => "filterInputText('{$field}', \$event.target.value, '{$title}')",
-            ],
-            'selectAttributes' => [
-                'wire:model' => 'filters.input_text_options.' . $field,
+            ]),
+            'selectAttributes' => new ComponentAttributeBag([
+                'wire:model'                     => 'filters.input_text_options.' . $field,
                 'wire:input.live.debounce.600ms' => "filterInputTextOptions('{$field}', \$event.target.value, '{$title}')",
-            ],
+            ]),
         ];
     }
 }

--- a/src/FilterAttributes/InputText.php
+++ b/src/FilterAttributes/InputText.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\FilterAttributes;
+
+use Illuminate\Support\Js;
+use Illuminate\View\ComponentAttributeBag;
+
+class InputText
+{
+    public function __invoke(string $field, string $title): array
+    {
+        return [
+            'inputAttributes' => new ComponentAttributeBag([
+                'wire:model' => 'filters.input_text.' . $field,
+                'wire:input.live.debounce.600ms' => "filterInputText('{$field}', \$event.target.value, '{$title}')",
+            ]),
+            'selectAttributes' => new ComponentAttributeBag([
+                'wire:model' => 'filters.input_text_options.' . $field,
+                'wire:input.live.debounce.600ms' => "filterInputTextOptions('{$field}', \$event.target.value, '{$title}')",
+            ]),
+        ];
+    }
+}

--- a/src/FilterAttributes/Number.php
+++ b/src/FilterAttributes/Number.php
@@ -8,11 +8,11 @@ class Number
     {
         return [
             'inputStartAttributes' => [
-                'wire:model' => "filters.number.{$field}.start",
+                'wire:model'                     => "filters.number.{$field}.start",
                 'wire:input.live.debounce.600ms' => "filterNumberStart('{$field}', " . json_encode($filter) . ", \$event.target.value)",
             ],
             'inputEndAttributes' => [
-                'wire:model' => "filters.number.{$field}.end",
+                'wire:model'                     => "filters.number.{$field}.end",
                 'wire:input.live.debounce.600ms' => "filterNumberEnd('{$field}', " . json_encode($filter) . ", \$event.target.value)",
             ],
         ];

--- a/src/FilterAttributes/Number.php
+++ b/src/FilterAttributes/Number.php
@@ -2,6 +2,7 @@
 
 namespace PowerComponents\LivewirePowerGrid\FilterAttributes;
 
+use Illuminate\Support\Js;
 use Illuminate\View\ComponentAttributeBag;
 
 class Number
@@ -11,11 +12,11 @@ class Number
         return [
             'inputStartAttributes' => new ComponentAttributeBag([
                 'wire:model'                     => "filters.number.{$field}.start",
-                'wire:input.live.debounce.600ms' => "filterNumberStart('{$field}', " . json_encode($filter) . ", \$event.target.value)",
+                'wire:input.live.debounce.600ms' => 'filterNumberStart(\'' . $field . '\', ' . Js::from($filter) . ', $event.target.value)',
             ]),
             'inputEndAttributes' => new ComponentAttributeBag([
                 'wire:model'                     => "filters.number.{$field}.end",
-                'wire:input.live.debounce.600ms' => "filterNumberEnd('{$field}', " . json_encode($filter) . ", \$event.target.value)",
+                'wire:input.live.debounce.600ms' => 'filterNumberEnd(\'' . $field . '\', ' . Js::from($filter) . ', $event.target.value)',
             ]),
         ];
     }

--- a/src/FilterAttributes/Number.php
+++ b/src/FilterAttributes/Number.php
@@ -2,19 +2,21 @@
 
 namespace PowerComponents\LivewirePowerGrid\FilterAttributes;
 
+use Illuminate\View\ComponentAttributeBag;
+
 class Number
 {
     public function __invoke(string $field, array $filter): array
     {
         return [
-            'inputStartAttributes' => [
+            'inputStartAttributes' => new ComponentAttributeBag([
                 'wire:model'                     => "filters.number.{$field}.start",
                 'wire:input.live.debounce.600ms' => "filterNumberStart('{$field}', " . json_encode($filter) . ", \$event.target.value)",
-            ],
-            'inputEndAttributes' => [
+            ]),
+            'inputEndAttributes' => new ComponentAttributeBag([
                 'wire:model'                     => "filters.number.{$field}.end",
                 'wire:input.live.debounce.600ms' => "filterNumberEnd('{$field}', " . json_encode($filter) . ", \$event.target.value)",
-            ],
+            ]),
         ];
     }
 }

--- a/src/FilterAttributes/Number.php
+++ b/src/FilterAttributes/Number.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\FilterAttributes;
+
+class Number
+{
+    public function __invoke(string $field, array $filter): array
+    {
+        return [
+            'inputStartAttributes' => [
+                'wire:model' => "filters.number.{$field}.start",
+                'wire:input.live.debounce.600ms' => "filterNumberStart('{$field}', " . json_encode($filter) . ", \$event.target.value)",
+            ],
+            'inputEndAttributes' => [
+                'wire:model' => "filters.number.{$field}.end",
+                'wire:input.live.debounce.600ms' => "filterNumberEnd('{$field}', " . json_encode($filter) . ", \$event.target.value)",
+            ],
+        ];
+    }
+}

--- a/src/FilterAttributes/Select.php
+++ b/src/FilterAttributes/Select.php
@@ -4,14 +4,14 @@ namespace PowerComponents\LivewirePowerGrid\FilterAttributes;
 
 use Illuminate\View\ComponentAttributeBag;
 
-class Boolean
+class Select
 {
     public function __invoke(string $field, string $title): array
     {
         return [
             'selectAttributes' => new ComponentAttributeBag([
-                'wire:model'                     => 'filters.boolean.' . $field,
-                'wire:input.live.debounce.600ms' => "filterBoolean('{$field}', \$event.target.value, '{$title}')",
+                'wire:model'                     => 'filters.select.' . $field,
+                'wire:input.live.debounce.600ms' => 'filterSelect(\'' . $field . '\', \'' . $title . '\')',
             ]),
         ];
     }

--- a/tests/cypress/mysql.sh
+++ b/tests/cypress/mysql.sh
@@ -45,6 +45,12 @@ composer require power-components/livewire-powergrid
 # | ------------------------- |
 php artisan key:generate
 
+php artisan optimize:clear
+
+php artisan config:cache
+
+php artisan view:cache
+
 npm install
 
 npm run build

--- a/tests/cypress/pgsql.sh
+++ b/tests/cypress/pgsql.sh
@@ -45,6 +45,12 @@ composer require power-components/livewire-powergrid
 # | ------------------------- |
 php artisan key:generate
 
+php artisan optimize:clear
+
+php artisan config:cache
+
+php artisan view:cache
+
 npm install
 
 npm run build


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Working on thi error.

```
   INFO  Caching framework bootstrap, configuration, and metadata.  

  config ............................................................................................................................... 7.83ms FAIL

   LogicException 

  Your configuration files are not serializable.

  at vendor/laravel/framework/src/Illuminate/Foundation/Console/ConfigCacheCommand.php:73
     69▕             require $configPath;
     70▕         } catch (Throwable $e) {
     71▕             $this->files->delete($configPath);
     72▕ 
  ➜  73▕             throw new LogicException('Your configuration files are not serializable.', 0, $e);
     74▕         }
     75▕ 
     76▕         $this->components->info('Configuration cached successfully.');
     77▕     }

  1   bootstrap/cache/config.php:1147
      Error::("Call to undefined method Closure::__set_state()")
      +29 vendor frames 

  31  artisan:16
      Illuminate\Foundation\Application::handleCommand()
```

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
