### PR TITLE
fix(powergrid): skip sorting when sortField is empty

### DIFF
--- a/src/Concerns/Sorting.php
+++ b/src/Concerns/Sorting.php
@@ -9,7 +9,7 @@ use stdClass;
 
 trait Sorting
 {
-    public string $sortField = 'id';
+    public string $sortField = '';
 
     public string $sortDirection = 'asc';
 
@@ -44,6 +44,10 @@ trait Sorting
     {
         if ($this->multiSort) {
             return $this->applySortingArray($query);
+        }
+		
+		if (empty($this->sortField)) {
+            return $query;
         }
 
         if (is_a($query, Collection::class)) {

--- a/src/Concerns/Sorting.php
+++ b/src/Concerns/Sorting.php
@@ -9,7 +9,7 @@ use stdClass;
 
 trait Sorting
 {
-    public string $sortField = '';
+    public string $sortField = 'id';
 
     public string $sortDirection = 'asc';
 
@@ -45,8 +45,8 @@ trait Sorting
         if ($this->multiSort) {
             return $this->applySortingArray($query);
         }
-		
-		if (empty($this->sortField)) {
+
+        if (empty($this->sortField)) {
             return $query;
         }
 

--- a/src/DataSource/Processors/ModelProcessor.php
+++ b/src/DataSource/Processors/ModelProcessor.php
@@ -41,8 +41,10 @@ class ModelProcessor extends DataSourceBase implements DataSourceProcessorInterf
         $this->applySummaries($results);
 
         $results = $this->component->multiSort
-                    ? $this->applyMultipleSort($results)
-                    : $results->orderBy($this->makeSortField($this->component->sortField), $this->component->sortDirection);
+            ? $this->applyMultipleSort($results)
+            : (filled($this->component->sortField)
+                ? $results->orderBy($this->makeSortField($this->component->sortField), $this->component->sortDirection)
+                : $results);
 
         $results = $this->applyPerPage($results);
 


### PR DESCRIPTION
Previously, PowerGrid would generate invalid SQL with "ORDER BY `` asc" when sortField was empty. This change:
- Adds check for filled(sortField) in ModelProcessor
- Returns unmodified query when no sort field is set
- Maintains existing sorting behavior when sortField is provided

## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

...

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
