### PR TITLE
Fix: MultiSelect now correctly uses it's theme class

### DIFF
--- a/resources/views/components/inputs/select.blade.php
+++ b/resources/views/components/inputs/select.blade.php
@@ -69,7 +69,7 @@
             @endif
             <select
                 @if ($multiple) multiple @endif
-                class="{{ theme_style($theme, 'filterSelect.select') }}"
+                class="{{ theme_style($theme, 'filterMultiSelect.select') }}"
                 wire:model="filters.multi_select.{{ data_get($filter, 'field') }}.values"
                 x-ref="select_picker_{{ data_get($filter, 'field') }}_{{ $tableName }}"
             >


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This is probably still unrelated to this discussion here https://github.com/Power-Components/livewire-powergrid/discussions/1948

When using the multiselect filter I noticed it applying styles that resulted in the filter looking like this
<img width="307" height="264" alt="grafik" src="https://github.com/user-attachments/assets/2b680d51-ed6c-4060-9298-0a5cc7a7c2d3" />

After further investigation I noticed that [in the component](https://github.com/Power-Components/livewire-powergrid/blob/6.x/resources/views/components/inputs/select.blade.php#L72) it still uses the styling classes from the normal select thus resulting in the appearance.

After adjusting it to use 

`class="{{ theme_style($theme, 'filterMultiSelect.select') }}"`

it now looks like this

<img width="311" height="268" alt="grafik" src="https://github.com/user-attachments/assets/594b5116-b69f-4dc7-919f-3ad14e54fc98" />

Thus resulting in the filters style are not being broken anymore
#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
