### PR TITLE
fix: flatpickr error when using custom format

### DIFF
--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -134,11 +134,15 @@ trait Filter
         $appTimezone = config('app.timezone');
         $isDatetime = $type === 'datetime';
         $hasTime = str_contains($dateFormat, 'H');
+        
+        $makeDate = function ($dateStr) use ($hasTime, $appTimezone) {
+            try {
+                $date = Carbon::parse($dateStr, $appTimezone);
+            } catch (InvalidFormatException) {
+                return now($appTimezone);
+            }
 
-        $makeDate = function ($dateStr) use ($dateFormat, $hasTime, $appTimezone) {
-            $date = Carbon::createFromFormat($dateFormat, $dateStr, $appTimezone);
-
-            if (! $hasTime) {
+            if (!$hasTime) {
                 $date->setTime(0, 0, 0);
             }
 


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Let's say you use the format **"d.m.Y"** in the flatpickr config. What happened before was that the $makeDate function used

```php
$date = Carbon::createFromFormat($dateFormat, $dateStr, $appTimezone);
```

However in the pg-flatpickr.js it already parses it to the format of **"Y-m-d"**
```js
selectedDates = selectedDates.map((date) => this.element.formatDate(date, 'Y-m-d'));
```

This ultimately results in the $makeDate function trying to use the createFromFormat function on a date that is in the format of d.m.Y with the format being Y-m-d.

This pr fixes this by switching from createFromFormat to simply parse.


#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
