### PR TITLE
fix: toggleDispatch do not dispatch the right event

### DIFF
--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -262,7 +262,7 @@ class PowerGridComponent extends Component
 
     public function toggleDetail(string $rowId): void
     {
-        $this->dispatch('toggle-detail-'.$rowId, collapsed: null);
+        $this->dispatch('pg-toggle-detail-'.$this->tableName.'-'.$rowId, collapsed: null);
     }
 
     public function render(): Application|Factory|View


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

See #1993 for reporting / [Demo](https://demo.livewire-powergrid.com/examples/dishes-detail-row) for example

After investigation into code, i noticed the function isn't triggering the good event, this pr aims to fix that

#### Related Issue(s): #1993 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
