### PR TITLE
feat: add perPage value to perPageValues if not present

### DIFF
--- a/src/Components/SetUp/Footer.php
+++ b/src/Components/SetUp/Footer.php
@@ -24,6 +24,21 @@ final class Footer implements Wireable
 
     public function showPerPage(int $perPage = 10, array $perPageValues = [10, 25, 50, 100, 0]): Footer
     {
+        if (! in_array($perPage, $perPageValues, true)) {
+            $hasZero = in_array(0, $perPageValues, true);
+
+            if ($hasZero) {
+                $perPageValues = array_filter($perPageValues);
+            }
+
+            $perPageValues[] = $perPage;
+            sort($perPageValues);
+
+            if ($hasZero) {
+                $perPageValues[] = 0;
+            }
+        }
+
         $this->perPage = $perPage;
         $this->perPageValues = $perPageValues;
 

--- a/tests/Feature/FooterTest.php
+++ b/tests/Feature/FooterTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use PowerComponents\LivewirePowerGrid\Components\SetUp\Footer;
+
+it('adds custom perPage value when not in default array', function () {
+    $footer = new Footer();
+    $result = $footer->showPerPage(30);
+
+    expect($result->perPage)->toBe(30)
+        ->and($result->perPageValues)->toBe([10, 25, 30, 50, 100, 0]);
+});
+
+it('accepts custom perPageValues', function () {
+    $footer = new Footer();
+    $perPageValues = [5, 15, 30, 50];
+    $result = $footer->showPerPage(15, $perPageValues);
+
+    expect($result->perPage)->toBe(15)
+        ->and($result->perPageValues)->toBe([5, 15, 30, 50]);
+});
+
+it('adds custom perPage value when not in custom perPageValues without zero', function () {
+    $footer = new Footer();
+    $perPageValues = [5, 15, 50];
+    $result = $footer->showPerPage(30, $perPageValues);
+
+    expect($result->perPage)->toBe(30)
+        ->and($result->perPageValues)->toBe([5, 15, 30, 50]);
+});
+
+it('adds custom perPage value when not in custom perPageValues with zero', function () {
+    $footer = new Footer();
+    $perPageValues = [5, 15, 50, 0];
+    $result = $footer->showPerPage(30, $perPageValues);
+
+    expect($result->perPage)->toBe(30)
+        ->and($result->perPageValues)->toBe([5, 15, 30, 50, 0]);
+});


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

See #1996 
With this PR, when an user choose a custom value for `perPage` this value will be automatically added to `perPageValues`

#### Related Issue(s): #1996 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
