### PR TITLE
Fix loading spinner when details are toggled tailwind

### DIFF
--- a/resources/views/components/frameworks/tailwind/toggle-detail.blade.php
+++ b/resources/views/components/frameworks/tailwind/toggle-detail.blade.php
@@ -10,6 +10,7 @@
                 if (this.collapseOthers) {
                     this.$dispatch('pg-toggle-detail-{{ $tableName }}-hidden-all');
                     expandedId = '{{ $rowId }}';
+                    this.loading = true;
                 } else {
                     this.loading = true;
                 }


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

So basically when you had collapseOthers() enabled the loading variable was never set to true resulting in the loading spinner not showing. This pr fixes that.

I did this fix quick and dirty so the else-block could basically be removed so that the loading variable always gets set to true.

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
