### PR TITLE
Remove redundant `else` in toggle-detail views

### DIFF
--- a/resources/views/components/frameworks/daisyui/toggle-detail.blade.php
+++ b/resources/views/components/frameworks/daisyui/toggle-detail.blade.php
@@ -10,11 +10,9 @@
                 if (this.collapseOthers) {
                     this.$dispatch('pg-toggle-detail-{{ $tableName }}-hidden-all');
                     expandedId = '{{ $rowId }}';
-                    this.loading = true;
-                } else {
-                    this.loading = true;
                 }
-    
+                
+                this.loading = true;
                 this.collapsed = !isOpen;
     
                 this.$dispatch('pg-toggle-detail-{{ $tableName }}-{{ $rowId }}', {

--- a/resources/views/components/frameworks/tailwind/toggle-detail.blade.php
+++ b/resources/views/components/frameworks/tailwind/toggle-detail.blade.php
@@ -10,11 +10,9 @@
                 if (this.collapseOthers) {
                     this.$dispatch('pg-toggle-detail-{{ $tableName }}-hidden-all');
                     expandedId = '{{ $rowId }}';
-                    this.loading = true;
-                } else {
-                    this.loading = true;
                 }
     
+                this.loading = true;
                 this.collapsed = !isOpen;
     
                 this.$dispatch('pg-toggle-detail-{{ $tableName }}-{{ $rowId }}', {


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

PR #2002 and #2003 introduced a duplication between `if` and `else` branch of a condition
Little change to fix this and align with code for Bootstrap
https://github.com/Power-Components/livewire-powergrid/blob/740b8a0c9b1d66bddcde2df539771100a6b80373/resources/views/components/frameworks/bootstrap5/toggle-detail.blade.php#L10-L16

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
