### PR TITLE
[DaisyUI] Made toggleable to have a color when toggled

### DIFF
--- a/resources/views/components/frameworks/daisyui/toggleable.blade.php
+++ b/resources/views/components/frameworks/daisyui/toggleable.blade.php
@@ -20,7 +20,7 @@
         <input
             x-data="pgToggleable(@js($params))"
             type="checkbox"
-            class="toggle toggle-sm"
+            class="toggle toggle-sm toggle-success"
             :checked="toggle"
             x-on:click="save"
         />


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

See here: https://daisyui.com/components/toggle/#colors A toggle in DaisyUI can only hold one color. Therefore we simply can set the toggles color to "toggle-success" resulting in the toggle being displayed green when true and gray when false

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
