### PR TITLE
make isExporting property available so column definitions can use it

### DIFF
--- a/src/Concerns/Base.php
+++ b/src/Concerns/Base.php
@@ -45,6 +45,8 @@ trait Base
 
     public bool $measurePerformance = false;
 
+    public bool $isExporting = false;
+
     public function fields(): PowerGridFields
     {
         return PowerGrid::fields();

--- a/src/Jobs/ExportJob.php
+++ b/src/Jobs/ExportJob.php
@@ -37,6 +37,8 @@ class ExportJob implements ShouldQueue
         $this->properties = (array) Crypt::decrypt($params['parameters']);
 
         $this->componentTable = new $componentTable();
+
+        $this->componentTable->isExporting = true;
     }
 
     public function handle(): void

--- a/src/Traits/WithExport.php
+++ b/src/Traits/WithExport.php
@@ -45,6 +45,8 @@ trait WithExport
 
     public bool $batchErrors = false;
 
+    public bool $isExporting = false;
+
     public function getExportBatchProperty(): ?Batch
     {
         if (empty($this->batchId)) {

--- a/src/Traits/WithExport.php
+++ b/src/Traits/WithExport.php
@@ -45,8 +45,6 @@ trait WithExport
 
     public bool $batchErrors = false;
 
-    public bool $isExporting = false;
-
     public function getExportBatchProperty(): ?Batch
     {
         if (empty($this->batchId)) {


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Just to do some magic within your column while using the exportjob like:

```php
public function fields(): PowerGridFields
    {
        return PowerGrid::fields()
            // ...
            ->add('displayActual', fn (Supplier $model) => $this->isExporting ? ($model->is_actual ? 'Yes' : 'No') : Blade::render('...'))
            // ...
```

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
