### PR TITLE
Batch exporting was missing properties in the datasource

### DIFF
--- a/src/DataSource/ProcessDataSource.php
+++ b/src/DataSource/ProcessDataSource.php
@@ -35,10 +35,10 @@ class ProcessDataSource
             if ($processor::match($this->component->datasource($this->properties))) {
                 $instance = new $processor($this->component, $isExport);
 
-                return $instance->process();
+                return $instance->process($this->properties);
             }
         }
 
-        return (new ModelProcessor($this->component, $isExport))->process();
+        return (new ModelProcessor($this->component, $isExport))->process($this->properties);
     }
 }

--- a/src/DataSource/Processors/CollectionProcessor.php
+++ b/src/DataSource/Processors/CollectionProcessor.php
@@ -16,9 +16,9 @@ class CollectionProcessor extends DataSourceBase
         return $key instanceof Collection;
     }
 
-    public function process(): array
+    public function process(array $properties = []): array
     {
-        $datasource = $this->component->datasource($this->component->properties ?? []);
+        $datasource = $this->component->datasource($properties);
 
         $collection = new BaseCollection($datasource);
 

--- a/src/DataSource/Processors/ModelProcessor.php
+++ b/src/DataSource/Processors/ModelProcessor.php
@@ -14,9 +14,9 @@ class ModelProcessor extends DataSourceBase
         return true;
     }
 
-    public function process(): array
+    public function process(array $properties = []): array
     {
-        $datasource = $this->component->datasource($this->component->properties ?? []);
+        $datasource = $this->component->datasource($properties);
 
         $this->setCurrentTable($datasource);
 

--- a/src/DataSource/Processors/ScoutBuilderProcessor.php
+++ b/src/DataSource/Processors/ScoutBuilderProcessor.php
@@ -15,10 +15,10 @@ class ScoutBuilderProcessor extends DataSourceBase
         return $key instanceof ScoutBuilder;
     }
 
-    public function process(): array
+    public function process(array $properties = []): array
     {
         /** @var ScoutBuilder $datasource */
-        $datasource = $this->component->datasource($this->component->properties ?? []);
+        $datasource = $this->component->datasource($properties);
 
         /** @var ScoutBuilder $query */
         $query = app(Pipeline::class)


### PR DESCRIPTION
Properties didn't went into the datasource via ```$properties``` property on the component. Send them to the process method on the Processors which is working now for batch exporting 

## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Batch exporting is working now with all the passed properties

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
