### PR TITLE
Failsafe for fields that are not in the hidden states array

### DIFF
--- a/src/Jobs/ExportJob.php
+++ b/src/Jobs/ExportJob.php
@@ -45,7 +45,7 @@ class ExportJob implements ShouldQueue
             ->mapWithKeys(fn ($column) => [data_get($column, 'field') => data_get($column, 'hidden')]);
 
         $columnsWithHiddenState = array_map(function ($column) use ($currentHiddenStates) {
-            $column->hidden = $currentHiddenStates[data_get($column, 'field')];
+            $column->hidden = data_get($currentHiddenStates, data_get($column, 'field'), true);
 
             return $column;
         }, $this->componentTable->columns());


### PR DESCRIPTION
Failsafe for fields that are not in the hidden states array; for example while having more or less fields defined that columns in the select query from the datasource

## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

silently continues now

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
