### PR TITLE
Fix for custom page name for collections

### DIFF
--- a/src/DataSource/Processors/CollectionProcessor.php
+++ b/src/DataSource/Processors/CollectionProcessor.php
@@ -63,7 +63,7 @@ class CollectionProcessor extends DataSourceBase
             : intval(data_get($this->component->setUp, 'footer.perPage', 10));
 
         $perPage = $perPage > 0 ? $perPage : $results->count();
-        $pageName = (string) data_get($this->component->setUp, 'footer.pageName', 'page');
+        $pageName = data_get($this->component->setUp, 'footer.pageName', 'page');
 
         $page = Paginator::resolveCurrentPage($pageName);
 

--- a/src/DataSource/Processors/CollectionProcessor.php
+++ b/src/DataSource/Processors/CollectionProcessor.php
@@ -63,8 +63,9 @@ class CollectionProcessor extends DataSourceBase
             : intval(data_get($this->component->setUp, 'footer.perPage', 10));
 
         $perPage = $perPage > 0 ? $perPage : $results->count();
+        $pageName = (string) data_get($this->component->setUp, 'footer.pageName', 'page');
 
-        $page = Paginator::resolveCurrentPage('page');
+        $page = Paginator::resolveCurrentPage($pageName);
 
         return new LengthAwarePaginator(
             items: $results->forPage($page, $perPage),
@@ -73,7 +74,7 @@ class CollectionProcessor extends DataSourceBase
             currentPage: $page,
             options: [
                 'path' => Paginator::resolveCurrentPath(),
-                'pageName' => 'page',
+                'pageName' => $pageName,
             ]
         );
     }


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description
#1363 adds custom `pageName` per component, but it was not working when the component returns a collection.
...

#### Related Issue(s): 
#1855 (probably)

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
