### PR TITLE
fix: allow detail row with stdclass

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -64,6 +64,12 @@
                                 }
                             @endphp
 
+                            @php
+                                if ($row instanceof stdClass) {
+                                    $row = collect($row);
+                                }
+                            @endphp
+
                             <livewire:powergrid-detail
                                 key="powergrid-detail-{{ $rowId }}"
                                 :view="$detailView"

--- a/tests/Concerns/Components/DatasourceCollectionTable.php
+++ b/tests/Concerns/Components/DatasourceCollectionTable.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests\Concerns\Components;
+
+use Illuminate\Support\Collection;
+use PowerComponents\LivewirePowerGrid\{Column,
+    Facades\PowerGrid,
+    PowerGridComponent,
+    PowerGridFields};
+
+class DatasourceCollectionTable extends PowerGridComponent
+{
+    public string $tableName = 'testing-datasource-collection-table';
+
+    public function datasource(): Collection
+    {
+        return collect([
+            [
+                'id' => 1,
+                'name' => 'Name 1',
+                'price' => 1.58,
+                'chef_name' => '',
+            ],
+            [
+                'id' => 2,
+                'name' => 'Name 2',
+                'price' => 1.68,
+                'chef_name' => null,
+            ],
+            [
+                'id' => 3,
+                'name' => 'Name 3',
+                'price' => 1.78,
+                'chef_name' => 'Luan',
+            ],
+            [
+                'id' => 4,
+                'name' => 'Name 4',
+                'price' => 1.88,
+                'chef_name' => 'Luan',
+            ],
+            [
+                'id' => 5,
+                'name' => 'Name 5',
+                'price' => 1.98,
+                'chef_name' => 'Luan',
+            ],
+        ]);
+    }
+
+    public function setUp(): array
+    {
+        return [
+            PowerGrid::detail()
+                ->view('livewire-powergrid::tests.detail')
+                ->showCollapseIcon(),
+        ];
+    }
+
+    public function fields(): PowerGridFields
+    {
+        return PowerGrid::fields()
+            ->add('id')
+            ->add('name')
+            ->add('chef_name')
+            ->add('price');
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::add()
+                ->title(__('ID'))
+                ->field('id')
+                ->searchable()
+                ->sortable(),
+
+            Column::add()
+                ->title(__('Name'))
+                ->field('name')
+                ->searchable()
+                ->sortable(),
+
+            Column::add()
+                ->title(__('Chef'))
+                ->field('chef_name')
+                ->searchable()
+                ->sortable(),
+
+            Column::add()
+                ->title(__('Price'))
+                ->field('price')
+                ->sortable(),
+        ];
+    }
+}

--- a/tests/Feature/CollectionWithDetailTest.php
+++ b/tests/Feature/CollectionWithDetailTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Components\DatasourceCollectionTable;
+
+use function PowerComponents\LivewirePowerGrid\Tests\Plugins\livewire;
+
+it('collection detail', function () {
+    livewire(DatasourceCollectionTable::class)
+        ->assertSee('Name 1')
+        ->assertDontSeeHtml([
+            '<div>Id 1</div>',
+            '<div>Options {"name":"Luan"}</div>',
+        ])
+        ->call('toggleDetail', 2)
+        ->assertDispatched('pg-toggle-detail-testing-datasource-collection-table-2');
+});


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

If a row is a `StdClass`, transform it to collection to allow `toArray()` call

I'm currently struggling to add tests interacting with toggleDetail, maybe @luanfreitasdev you can give me some tips ? 

#### Related Issue(s): 

#2019 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
