### PR TITLE
fix: column toggle icons shrinking when column name is long (tailwind)

### DIFF
--- a/resources/views/components/frameworks/tailwind/header/toggle-columns.blade.php
+++ b/resources/views/components/frameworks/tailwind/header/toggle-columns.blade.php
@@ -40,16 +40,16 @@
                         @class([
                             'font-semibold bg-pg-primary-100 dark:bg-pg-primary-800 ' => data_get($column, 'hidden'),
                             'py-1' => $loop->first || $loop->last,
-                            'cursor-pointer text-sm flex justify-between block px-4 py-2 text-pg-primary-800 hover:bg-pg-primary-100 hover:text-black-300 dark:text-pg-primary-200 dark:hover:bg-pg-primary-800'
+                            'cursor-pointer text-sm flex gap-2 justify-between block px-4 py-2 text-pg-primary-800 hover:bg-pg-primary-100 hover:text-black-300 dark:text-pg-primary-200 dark:hover:bg-pg-primary-800'
                         ])
                     >
                         <div>
                             {!! data_get($column, 'title') !!}
                         </div>
                         @if (!data_get($column, 'hidden'))
-                            <x-livewire-powergrid::icons.eye class="h-5 w-5 text-pg-primary-200 dark:text-pg-primary-300" />
+                            <x-livewire-powergrid::icons.eye class="h-5 w-5 text-pg-primary-200 dark:text-pg-primary-300 shrink-0" />
                         @else
-                            <x-livewire-powergrid::icons.eye-off class="h-5 w-5 text-pg-primary-500 dark:text-pg-primary-300" />
+                            <x-livewire-powergrid::icons.eye-off class="h-5 w-5 text-pg-primary-500 dark:text-pg-primary-300 shrink-0" />
                         @endif
                     </div>
                 @endforeach


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description
Fixes icon shrinking.
Before:
<img width="268" height="290" alt="image" src="https://github.com/user-attachments/assets/62f60a27-30d3-4a2b-975e-7bd86309f04d" />


After:
<img width="268" height="290" alt="image" src="https://github.com/user-attachments/assets/07274d16-3989-4994-ac51-9a28ac5566b6" />


#### Related Issue(s): 
https://github.com/Power-Components/livewire-powergrid/discussions/2024

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
