### PR TITLE
test: unskip sort with string-number

### DIFF
--- a/tests/Feature/SortTest.php
+++ b/tests/Feature/SortTest.php
@@ -113,21 +113,20 @@ it('properly sorts ASC/DESC with: string-number', function (string $component, o
         ->set('ignoreTablePrefix', false)
         ->call('sortBy', 'stored_at')
         ->set('sortDirection', 'asc')
-        ->assertSeeHtml('Dish K')
-        ->assertSeeHtml('Dish L')
         ->assertSeeHtml('Dish A')
+        ->assertSeeHtml('Dish J')
+        ->assertSeeHtml('Dish L')
+        ->assertSeeHtml('Dish K')
         ->assertSeeHtml('Dish B')
-        ->assertSeeHtml('Dish C')
+        ->assertSeeHtml('Dish D')
         ->assertSeeHtml('Dish D')
         ->assertSeeHtml('Dish E')
         ->assertSeeHtml('Dish F')
         ->assertSeeHtml('Dish G')
-        ->assertSeeHtml('Dish H')
         ->assertDontSeeHtml('Dish I')
         ->set('sortDirection', 'desc')
-        ->assertSeeHtml('Dish J')
         ->assertSeeHtml('Dish I')
-        ->assertSeeHtml('Dish H')
+        ->assertSeeHtml('Zebra Dish H')
         ->assertSeeHtml('Dish G')
         ->assertSeeHtml('Dish F')
         ->assertSeeHtml('Dish E')
@@ -135,8 +134,9 @@ it('properly sorts ASC/DESC with: string-number', function (string $component, o
         ->assertSeeHtml('Dish C')
         ->assertSeeHtml('Dish B')
         ->assertSeeHtml('Dish K')
+        ->assertSeeHtml('Dish L')
         ->assertDontSeeHtml('Dish A');
-})->with('sort join')->skip();
+})->with('sort join');
 
 dataset('sort join', [
     'tailwind -> id' => [DishesTable::class, (object) ['theme' => \PowerComponents\LivewirePowerGrid\Themes\Tailwind::class, 'field' => 'id']],


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Enable sort test with string-number and order assertions with order

`1a` and `1b` values are sorted between `1` and `2`

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
