### PR TITLE
use camelCame with generated table

### DIFF
--- a/src/Commands/Support/PowerGridComponentMaker.php
+++ b/src/Commands/Support/PowerGridComponentMaker.php
@@ -271,7 +271,7 @@ final class PowerGridComponentMaker
         $this->tableName = str($this->name)
             ->camel();
 
-        if (Str::doesntEndWith($this->name, 'Table')) {
+        if (! str_ends_with($this->name, 'Table')) {
             $this->tableName = str($this->tableName)->append('Table');
         }
 

--- a/src/Commands/Support/PowerGridComponentMaker.php
+++ b/src/Commands/Support/PowerGridComponentMaker.php
@@ -269,10 +269,11 @@ final class PowerGridComponentMaker
     private function resolveTableName(): self
     {
         $this->tableName = str($this->name)
-            ->kebab()
-            ->append('-'.Str::random(6))
-            ->append('-table')
-            ->lower();
+            ->camel();
+
+        if (Str::doesntEndWith($this->name, 'Table')) {
+            $this->tableName = str($this->tableName)->append('Table');
+        }
 
         return $this;
     }

--- a/tests/Feature/Support/PowerGridMakerTest.php
+++ b/tests/Feature/Support/PowerGridMakerTest.php
@@ -162,3 +162,15 @@ it('can create component in a custom Livewire namespace', function () {
 
     expect($component->savePath($component->filename))->toEndWith(str_replace('/', DIRECTORY_SEPARATOR, 'Domains/System/Office/Users/Admin/Active/ListTable.php'));
 });
+
+it('tableName is converted to camelCase', function () {
+    $component = PowerGridComponentMaker::make('System/Office/Users/Admin/Active/ListTable');
+
+    expect($component->tableName)->toBe('listTable');
+});
+
+it('tableName appends Table to the end of the name', function () {
+    $component = PowerGridComponentMaker::make('System/Office/Users/Admin/Active/List');
+
+    expect($component->tableName)->toBe('listTable');
+});


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Generate table name with camelCase when using `powergrid:create` command
And add a condition to suffix table name with `Table` only if it's not already present

#### Related Issue(s): 

Discussion #2030 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
