### PR TITLE
set properties so they can be used in column definitions while exporting

### DIFF
--- a/src/Jobs/ExportJob.php
+++ b/src/Jobs/ExportJob.php
@@ -43,6 +43,10 @@ class ExportJob implements ShouldQueue
 
     public function handle(): void
     {
+        collect($this->componentTable->getPublicPropertiesDefinedInComponent())
+            ->intersectByKeys($this->properties)
+            ->each(fn ($value, $key) => $this->componentTable->{$key} = data_get($this->properties, $key));
+
         $currentHiddenStates = collect($this->columns)
             ->mapWithKeys(fn ($column) => [data_get($column, 'field') => data_get($column, 'hidden')]);
 


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Properties should be set ealier to use them also in column definitions 

#### Related Issue(s): 
close #2035 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
