### PR TITLE
Add Bangla (bn_BD) translation for datatable

### DIFF
--- a/resources/lang/bn_BD/datatable.php
+++ b/resources/lang/bn_BD/datatable.php
@@ -1,86 +1,75 @@
 <?php
 
 return [
-    'buttons'            => [
-        'filter'            => 'ফিল্টার',
+    'buttons' => [
+        'filter' => 'ফিল্টার',
         'clear_all_filters' => 'সব ফিল্টার মুছুন',
     ],
-
-    'labels'             => [
-        'action'           => 'কার্যসমূহ',
+    'labels' => [
+        'action' => 'কার্যসমূহ',
         'results_per_page' => 'প্রতি পাতায় রেকর্ড',
-        'clear_filter'     => 'ফিল্টার মুছুন',
-        'no_data'          => 'কোনো রেকর্ড পাওয়া যায়নি',
-        'all'              => 'সব',
-        'selected'         => 'নির্বাচিত',
-        'filtered'         => 'ফিল্টারকৃত',
+        'clear_filter' => 'ফিল্টার মুছুন',
+        'no_data' => 'কোনো রেকর্ড পাওয়া যায়নি',
+        'all' => 'সব',
+        'selected' => 'নির্বাচিত',
+        'filtered' => 'ফিল্টার করা',
     ],
-
-    'placeholders'       => [
+    'placeholders' => [
         'search' => 'অনুসন্ধান...',
-        'select' => 'নির্বাচন করুন',
+        'select' => 'একটি সময়কাল নির্বাচন করুন',
     ],
-
-    'pagination'         => [
+    'pagination' => [
         'showing' => 'দেখানো হচ্ছে',
-        'to'      => 'থেকে',
-        'of'      => 'মোট',
+        'to' => 'থেকে',
+        'of' => 'মোট',
         'results' => 'ফলাফল',
-        'all'     => 'সব',
-    ],
-
-    'multi_select'       => [
-        'select' => 'নির্বাচন করুন',
-        'all'    => 'সব',
-    ],
-
-    'select'             => [
-        'select' => 'নির্বাচন করুন',
-        'all'    => 'সব',
-    ],
-
-    'boolean_filter'     => [
         'all' => 'সব',
     ],
-
+    'multi_select' => [
+        'select' => 'নির্বাচন করুন',
+        'all' => 'সব',
+    ],
+    'select' => [
+        'select' => 'নির্বাচন করুন',
+        'all' => 'সব',
+    ],
+    'boolean_filter' => [
+        'all' => 'সব',
+    ],
     'input_text_options' => [
-        'is'           => 'সমান',
-        'is_not'       => 'সমান নয়',
-        'contains'     => 'অন্তর্ভুক্ত করে',
+        'is' => 'হয়',
+        'is_not' => 'হয় না',
+        'contains' => 'অন্তর্ভুক্ত করে',
         'contains_not' => 'অন্তর্ভুক্ত করে না',
-        'starts_with'  => 'দিয়ে শুরু',
-        'ends_with'    => 'দিয়ে শেষ',
-        'is_empty'     => 'ফাঁকা',
+        'starts_with' => 'দিয়ে শুরু',
+        'ends_with' => 'দিয়ে শেষ',
+        'is_empty' => 'ফাঁকা',
         'is_not_empty' => 'ফাঁকা নয়',
-        'is_null'      => 'নাল',
-        'is_not_null'  => 'নাল নয়',
-        'is_blank'     => 'খালি',
+        'is_null' => 'নাল',
+        'is_not_null' => 'নাল নয়',
+        'is_blank' => 'খালি',
         'is_not_blank' => 'খালি নয়',
     ],
-
-    'export'             => [
+    'export' => [
         'exporting' => 'দয়া করে অপেক্ষা করুন!',
-        'completed' => 'রপ্তানি সম্পন্ন! আপনার ফাইল ডাউনলোডের জন্য প্রস্তুত।',
+        'completed' => 'রপ্তানি সম্পন্ন! আপনার ফাইল ডাউনলোডের জন্য প্রস্তুত',
     ],
-
-    'soft_deletes'       => [
-        'message_with_trashed' => 'মুছে ফেলা রেকর্ডসহ সব রেকর্ড দেখানো হচ্ছে।',
-        'message_only_trashed' => 'শুধু মুছে ফেলা রেকর্ড দেখানো হচ্ছে।',
-        'without_trashed'      => 'মুছে ফেলা ছাড়া',
-        'with_trashed'         => 'মুছে ফেলা সহ',
-        'only_trashed'         => 'শুধু মুছে ফেলা',
+    'soft_deletes' => [
+        'message_with_trashed' => 'মুছে ফেলা রেকর্ডসহ সব রেকর্ড প্রদর্শিত হচ্ছে।',
+        'message_only_trashed' => 'শুধু মুছে ফেলা রেকর্ড প্রদর্শিত হচ্ছে।',
+        'without_trashed' => 'মুছে ফেলা ছাড়া',
+        'with_trashed' => 'মুছে ফেলা সহ',
+        'only_trashed' => 'শুধু মুছে ফেলা',
     ],
-
-    'multi_sort'         => [
+    'multi_sort' => [
         'message' => 'একাধিক সাজানো সক্রিয়',
     ],
-
-    'buttons_macros'     => [
-        'confirm'        => [
+    'buttons_macros' => [
+        'confirm' => [
             'message' => 'আপনি কি নিশ্চিত যে এই কাজটি করতে চান?',
         ],
         'confirm_prompt' => [
-            'message' => "আপনি কি নিশ্চিত যে এই কাজটি করতে চান?\n\n নিশ্চিত করতে :confirmValue লিখুন।",
+            'message' => "আপনি কি নিশ্চিত যে এই কাজটি করতে চান? \n\n নিশ্চিত করতে :confirmValue লিখুন।",
         ],
     ],
 ];

--- a/resources/lang/bn_BD/datatable.php
+++ b/resources/lang/bn_BD/datatable.php
@@ -1,0 +1,86 @@
+<?php
+
+return [
+    'buttons'            => [
+        'filter'            => 'ফিল্টার',
+        'clear_all_filters' => 'সব ফিল্টার মুছুন',
+    ],
+
+    'labels'             => [
+        'action'           => 'কার্যসমূহ',
+        'results_per_page' => 'প্রতি পাতায় রেকর্ড',
+        'clear_filter'     => 'ফিল্টার মুছুন',
+        'no_data'          => 'কোনো রেকর্ড পাওয়া যায়নি',
+        'all'              => 'সব',
+        'selected'         => 'নির্বাচিত',
+        'filtered'         => 'ফিল্টারকৃত',
+    ],
+
+    'placeholders'       => [
+        'search' => 'অনুসন্ধান...',
+        'select' => 'নির্বাচন করুন',
+    ],
+
+    'pagination'         => [
+        'showing' => 'দেখানো হচ্ছে',
+        'to'      => 'থেকে',
+        'of'      => 'মোট',
+        'results' => 'ফলাফল',
+        'all'     => 'সব',
+    ],
+
+    'multi_select'       => [
+        'select' => 'নির্বাচন করুন',
+        'all'    => 'সব',
+    ],
+
+    'select'             => [
+        'select' => 'নির্বাচন করুন',
+        'all'    => 'সব',
+    ],
+
+    'boolean_filter'     => [
+        'all' => 'সব',
+    ],
+
+    'input_text_options' => [
+        'is'           => 'সমান',
+        'is_not'       => 'সমান নয়',
+        'contains'     => 'অন্তর্ভুক্ত করে',
+        'contains_not' => 'অন্তর্ভুক্ত করে না',
+        'starts_with'  => 'দিয়ে শুরু',
+        'ends_with'    => 'দিয়ে শেষ',
+        'is_empty'     => 'ফাঁকা',
+        'is_not_empty' => 'ফাঁকা নয়',
+        'is_null'      => 'নাল',
+        'is_not_null'  => 'নাল নয়',
+        'is_blank'     => 'খালি',
+        'is_not_blank' => 'খালি নয়',
+    ],
+
+    'export'             => [
+        'exporting' => 'দয়া করে অপেক্ষা করুন!',
+        'completed' => 'রপ্তানি সম্পন্ন! আপনার ফাইল ডাউনলোডের জন্য প্রস্তুত।',
+    ],
+
+    'soft_deletes'       => [
+        'message_with_trashed' => 'মুছে ফেলা রেকর্ডসহ সব রেকর্ড দেখানো হচ্ছে।',
+        'message_only_trashed' => 'শুধু মুছে ফেলা রেকর্ড দেখানো হচ্ছে।',
+        'without_trashed'      => 'মুছে ফেলা ছাড়া',
+        'with_trashed'         => 'মুছে ফেলা সহ',
+        'only_trashed'         => 'শুধু মুছে ফেলা',
+    ],
+
+    'multi_sort'         => [
+        'message' => 'একাধিক সাজানো সক্রিয়',
+    ],
+
+    'buttons_macros'     => [
+        'confirm'        => [
+            'message' => 'আপনি কি নিশ্চিত যে এই কাজটি করতে চান?',
+        ],
+        'confirm_prompt' => [
+            'message' => "আপনি কি নিশ্চিত যে এই কাজটি করতে চান?\n\n নিশ্চিত করতে :confirmValue লিখুন।",
+        ],
+    ],
+];


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This PR adds a complete **Bangla (bn_BD)** translation for PowerGrid’s `datatable` language file.

- Translation is fully based on the existing English source.
- Wording has been refined to ensure clarity, natural language flow, and UI-friendly length.
- Tested in a real Laravel application with `locale = bn_BD`.
- Ensures consistent terminology across filters, pagination, buttons, and soft-delete messages.

If preferred, I can also provide an additional `bn` locale version (generic Bangla).

#### Related Issue(s):

N/A — This is a localization enhancement.

#### Documentation

This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
