### PR TITLE
[6.X] Enum Support for Table Rows

### DIFF
--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -40,6 +40,13 @@
         }
 
         $contentClassField = data_get($column, 'contentClassField');
+
+        if ($content instanceof \UnitEnum) {
+            $content = $content instanceof \BackedEnum 
+                ? $content->value 
+                : $content->name;
+        }
+
         $content = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $content ?? '');
         $field = data_get($column, 'dataField', data_get($column, 'field'));
 


### PR DESCRIPTION
Table rows now also support fields that are being casted as Enums

## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

If you have a Model on which a Attribute is being casted into an Enum the rows before failed due to it trying to use preg_replace() on the Enum. This PR fixes that by checking before if we have an Enum. Works for both UnitEnum and BackedEnum.

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
