### PR TITLE
[6.x] Fix DatePicker Filter parsing Dates in collection

### DIFF
--- a/src/DataSource/Builders/DatePicker.php
+++ b/src/DataSource/Builders/DatePicker.php
@@ -45,8 +45,8 @@ class DatePicker extends BuilderBase
 
         /** @var array $values */
         [$startDate, $endDate] = [
-            0 => Carbon::parse($values[0])->format('Y-m-d'),
-            1 => Carbon::parse($values[1])->format('Y-m-d'),
+            0 => Carbon::parse($values['start'])->format('Y-m-d'),
+            1 => Carbon::parse($values['end'])->format('Y-m-d'),
         ];
 
         if (data_get($this->filterBase, 'collection')) {


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

When using an collection as datasource the DatePicker tried to use array keys 0 and 1 to parse the dates.. however the dates are stored in the keys **start** and **end** which resulted in an error. This pr fixes that.

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
