### PR TITLE
[6.x - DaisyUI] Fixed searchBox.iconClose not showing

### DIFF
--- a/resources/views/components/frameworks/daisyui/header/search.blade.php
+++ b/resources/views/components/frameworks/daisyui/header/search.blade.php
@@ -1,5 +1,5 @@
 @if (data_get($setUp, 'header.searchInput'))
-    <label class="input">
+    <label class="input relative group">
         <x-livewire-powergrid::icons.search class="{{ theme_style($theme, 'searchBox.iconSearch') }}" />
 
         <input


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

When using DaisyUI the close icon did not appear in the search box. This PR fixes that.

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
