### PR TITLE
Escape title in filterSelect function call

### DIFF
--- a/src/FilterAttributes/Select.php
+++ b/src/FilterAttributes/Select.php
@@ -11,7 +11,7 @@ class Select
         return [
             'selectAttributes' => new ComponentAttributeBag([
                 'wire:model' => 'filters.select.'.$field,
-                'wire:input.live.debounce.600ms' => 'filterSelect(\''.$field.'\', \''.$title.'\')',
+                'wire:input.live.debounce.600ms' => 'filterSelect(\''.$field.'\', \''.addslashes($title).'\')',
             ]),
         ];
     }


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Javascript crashes while using quotes in the title.

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
