### PR TITLE
[6.x] Add default values for filters

### DIFF
--- a/src/Components/Filters/FilterBase.php
+++ b/src/Components/Filters/FilterBase.php
@@ -21,6 +21,8 @@ class FilterBase implements Wireable
 
     public array $filterRelation = [];
 
+    public mixed $defaultValue = null;
+
     public function __construct(
         public string $column,
         public ?string $field = null,
@@ -66,6 +68,13 @@ class FilterBase implements Wireable
     public function baseClass(string $attrClass): self
     {
         $this->baseClass = $attrClass;
+
+        return $this;
+    }
+
+    public function default(mixed $value): self
+    {
+        $this->defaultValue = $value;
 
         return $this;
     }

--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -172,6 +172,10 @@ trait Filter
 
                     unset($this->filters[$key][$field]);
 
+                    if (empty($this->filters[$key])) {
+                        unset($this->filters[$key]);
+                    }
+                    
                     $this->enabledFilters = array_filter(
                         $this->enabledFilters,
                         fn ($filter) => $filter['field'] !== ($column ?? $field)

--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -21,6 +21,108 @@ trait Filter
 
     public bool $showFilters = false;
 
+    protected function applyDefaultFilters(): void
+    {
+        // Only apply defaults if no filters are currently set
+        // This prevents overriding persisted filters
+        if (!empty($this->filters)) {
+            return;
+        }
+
+        $defaultFiltersApplied = false;
+
+        collect($this->filters())
+            ->each(function ($filter) use (&$defaultFiltersApplied) {
+                // Check if filter has a default value set
+                if (!isset($filter->defaultValue) || is_null($filter->defaultValue)) {
+                    return;
+                }
+
+                $field = data_get($filter, 'field');
+                $column = data_get($filter, 'column');
+                $key = data_get($filter, 'key');
+                $defaultValue = $filter->defaultValue;
+
+                // Find the column to get the label
+                $columnData = collect($this->columns)
+                    ->first(fn ($col) =>
+                        data_get($col, 'field') === $column ||
+                        data_get($col, 'dataField') === $column
+                    );
+
+                $label = data_get($columnData, 'title', $field);
+
+                // Apply the default value based on filter type
+                switch ($key) {
+                    case 'select':
+                        data_set($this->filters, "select.{$field}", $defaultValue);
+                        $this->addEnabledFilters($field, $label);
+                        $defaultFiltersApplied = true;
+                        break;
+
+                    case 'multi_select':
+                        $values = is_array($defaultValue) ? $defaultValue : [$defaultValue];
+                        data_set($this->filters, "multi_select.{$field}", $values);
+                        $this->addEnabledFilters($field, $label);
+                        $defaultFiltersApplied = true;
+                        break;
+
+                    case 'boolean':
+                        data_set($this->filters, "boolean.{$field}", $defaultValue);
+                        $this->addEnabledFilters($field, $label);
+                        $defaultFiltersApplied = true;
+                        break;
+
+                    case 'input_text':
+                        if (is_array($defaultValue)) {
+                            // Support for both value and operator
+                            data_set($this->filters, "input_text.{$field}", $defaultValue['value'] ?? '');
+                            if (isset($defaultValue['operator'])) {
+                                data_set($this->filters, "input_text_options.{$field}", $defaultValue['operator']);
+                            }
+                        } else {
+                            data_set($this->filters, "input_text.{$field}", $defaultValue);
+                        }
+                        $this->addEnabledFilters($field, $label);
+                        $defaultFiltersApplied = true;
+                        break;
+
+                    case 'number':
+                        if (is_array($defaultValue)) {
+                            if (isset($defaultValue['start'])) {
+                                data_set($this->filters, "number.{$field}.start", $defaultValue['start']);
+                            }
+                            if (isset($defaultValue['end'])) {
+                                data_set($this->filters, "number.{$field}.end", $defaultValue['end']);
+                            }
+                        } else {
+                            data_set($this->filters, "number.{$field}.start", $defaultValue);
+                        }
+                        $this->addEnabledFilters($field, $label);
+                        $defaultFiltersApplied = true;
+                        break;
+
+                    case 'date':
+                    case 'datetime':
+                        if (is_array($defaultValue) && isset($defaultValue['start']) && isset($defaultValue['end'])) {
+                            $this->filters[$key][$field] = [
+                                'start' => $defaultValue['start'],
+                                'end' => $defaultValue['end'],
+                                'formatted' => $defaultValue['formatted'] ?? '',
+                            ];
+                            $this->addEnabledFilters($field, $label);
+                            $defaultFiltersApplied = true;
+                        }
+                        break;
+                }
+            });
+
+        // Persist the default filters if any were applied
+        if ($defaultFiltersApplied) {
+            $this->persistState('filters');
+        }
+    }
+
     /**
      * @throws Exception
      */
@@ -69,10 +171,6 @@ trait Filter
                     }
 
                     unset($this->filters[$key][$field]);
-
-                    if (empty($this->filters[$key])) {
-                        unset($this->filters[$key]);
-                    }
 
                     $this->enabledFilters = array_filter(
                         $this->enabledFilters,

--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -34,7 +34,7 @@ trait Filter
         collect($this->filters())
             ->each(function ($filter) use (&$defaultFiltersApplied) {
                 // Check if filter has a default value set
-                if (! isset($filter->defaultValue) || is_null($filter->defaultValue)) {
+                if (empty($filter->defaultValue)) {
                     return;
                 }
 

--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -175,7 +175,7 @@ trait Filter
                     if (empty($this->filters[$key])) {
                         unset($this->filters[$key]);
                     }
-                    
+
                     $this->enabledFilters = array_filter(
                         $this->enabledFilters,
                         fn ($filter) => $filter['field'] !== ($column ?? $field)

--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -25,7 +25,7 @@ trait Filter
     {
         // Only apply defaults if no filters are currently set
         // This prevents overriding persisted filters
-        if (!empty($this->filters)) {
+        if (! empty($this->filters)) {
             return;
         }
 
@@ -34,7 +34,7 @@ trait Filter
         collect($this->filters())
             ->each(function ($filter) use (&$defaultFiltersApplied) {
                 // Check if filter has a default value set
-                if (!isset($filter->defaultValue) || is_null($filter->defaultValue)) {
+                if (! isset($filter->defaultValue) || is_null($filter->defaultValue)) {
                     return;
                 }
 
@@ -45,8 +45,7 @@ trait Filter
 
                 // Find the column to get the label
                 $columnData = collect($this->columns)
-                    ->first(fn ($col) =>
-                        data_get($col, 'field') === $column ||
+                    ->first(fn ($col) => data_get($col, 'field') === $column ||
                         data_get($col, 'dataField') === $column
                     );
 

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -104,7 +104,7 @@ class PowerGridComponent extends Component
     public function hasColumnFilters(): bool
     {
         return collect($this->columns)
-           ->filter(fn ($column) => filled(data_get($column, 'filters')))->count() > 0;
+            ->filter(fn ($column) => filled(data_get($column, 'filters')))->count() > 0;
     }
 
     #[Computed]

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -64,6 +64,8 @@ class PowerGridComponent extends Component
 
         $this->restoreState();
 
+        $this->applyDefaultFilters();
+
         $this->resolveSummarizeColumn();
     }
 
@@ -102,7 +104,7 @@ class PowerGridComponent extends Component
     public function hasColumnFilters(): bool
     {
         return collect($this->columns)
-            ->filter(fn ($column) => filled(data_get($column, 'filters')))->count() > 0;
+                ->filter(fn ($column) => filled(data_get($column, 'filters')))->count() > 0;
     }
 
     #[Computed]

--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -104,7 +104,7 @@ class PowerGridComponent extends Component
     public function hasColumnFilters(): bool
     {
         return collect($this->columns)
-                ->filter(fn ($column) => filled(data_get($column, 'filters')))->count() > 0;
+           ->filter(fn ($column) => filled(data_get($column, 'filters')))->count() > 0;
     }
 
     #[Computed]


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [x] New feature
- [ ] Breaking change

#### Description

This pull-request adds the functionality of setting default values for filters.

#### Usage

Simply chain `->default()` to any filter with the appropriate value for that filter type:

```php
public function filters(): array
{
    return [
        // Select filter - single value
        Filter::select('status', 'status')
            ->dataSource([...])
            ->default('active'),

        // Multi-select filter - array of values
        Filter::multiSelect('category_id', 'category_id')
            ->dataSource(Category::all())
            ->optionValue('id')
            ->optionLabel('name')
            ->default([1, 2, 3]),

        // Boolean filter - bool true, false, or string 'all'
        Filter::boolean('is_active', 'is_active')
            ->default(true),

        // Input text filter - string or array with no operators
        Filter::inputText('name', 'name')
            ->operators(),
            ->default('laptop'),

        // Input text with operator
        Filter::inputText('sku', 'sku')
            ->operators(['contains', 'starts_with'])
            ->default([
                'value' => 'PRD',
                'operator' => 'starts_with',
            ]),

        // Number filter - single value or range
        Filter::number('price', 'price')
            ->default(50), // minimum price

        // Number filter - range
        Filter::number('stock', 'stock')
            ->default([
                'start' => 10,
                'end' => 1000,
            ]),

        // Date filter - just start and end dates
        Filter::datepicker('created_at', 'created_at')
            ->default([
                'start' => '2025-01-01',
                'end' => '2025-12-31',
                'formatted' => '01.01.2023 bis 01.01.2025',
            ]),
    ];
}
```

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
