### PR TITLE
fix clearFilter method with dot-notation in field name

### DIFF
--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -72,7 +72,12 @@ trait Filter
                         $explodeField = explode('.', $field);
 
                         $currentArray = &$this->filters[$key];
-                        unset($currentArray[$explodeField[0]]);
+
+                        Arr::forget($currentArray[$explodeField[0]], $explodeField[1]);
+
+                        if (isset($currentArray[$explodeField[0]]) && count($currentArray[$explodeField[0]]) === 0) {
+                            unset($currentArray[$explodeField[0]]);
+                        }
                     }
 
                     unset($this->filters[$key][$field]);

--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -73,13 +73,7 @@ trait Filter
 
                         $currentArray = &$this->filters[$key];
 
-                        if (isset($currentArray[$explodeField[0]]) && isset($currentArray[$explodeField[0]][$explodeField[1]])) {
-                            unset($currentArray[$explodeField[0]][$explodeField[1]]);
-                        }
-
-                        if (isset($currentArray[$explodeField[0]]) && count($currentArray[$explodeField[0]]) === 0) {
-                            unset($currentArray[$explodeField[0]]);
-                        }
+                        $this->removeNestedArrayKey($currentArray, $explodeField[0], $explodeField[1]);
                     }
 
                     unset($this->filters[$key][$field]);
@@ -525,5 +519,16 @@ trait Filter
         }
 
         return $queryString;
+    }
+
+    private function removeNestedArrayKey(array &$array, string $parent, string $child): void
+    {
+        if (isset($array[$parent][$child])) {
+            unset($array[$parent][$child]);
+        }
+
+        if (isset($array[$parent]) && empty($array[$parent])) {
+            unset($array[$parent]);
+        }
     }
 }

--- a/src/Concerns/Filter.php
+++ b/src/Concerns/Filter.php
@@ -73,7 +73,9 @@ trait Filter
 
                         $currentArray = &$this->filters[$key];
 
-                        Arr::forget($currentArray[$explodeField[0]], $explodeField[1]);
+                        if (isset($currentArray[$explodeField[0]]) && isset($currentArray[$explodeField[0]][$explodeField[1]])) {
+                            unset($currentArray[$explodeField[0]][$explodeField[1]]);
+                        }
 
                         if (isset($currentArray[$explodeField[0]]) && count($currentArray[$explodeField[0]]) === 0) {
                             unset($currentArray[$explodeField[0]]);


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Function that fixes the issue that occurred when you cleared the filter with a name like 'user.firstname'. It also cleared 'user.surname'. As the filter cleared all the 'user' input-text from the array. This only occurred with fields with the same filtertypes

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
