### PR TITLE
fix: improve Indonesian translation for datatable

### DIFF
--- a/resources/lang/id/datatable.php
+++ b/resources/lang/id/datatable.php
@@ -3,7 +3,7 @@
 return [
     'buttons' => [
         'filter' => 'Filter',
-        'clear_all_filters' => 'Clear all',
+        'clear_all_filters' => 'Hapus semua',
     ],
     'labels' => [
         'action' => 'Aksi',
@@ -66,10 +66,10 @@ return [
     ],
     'buttons_macros' => [
         'confirm' => [
-            'message' => 'Are you sure you want to perform this action?',
+            'message' => 'Apakah anda yakin ingin melakukan tindakan ini?',
         ],
         'confirm_prompt' => [
-            'message' => "Are you sure you want to perform this action? \n\n Enter :confirmValue to confirm.",
+            'message' => "Apakah anda yakin ingin melakukan tindakan ini? \n\n Ketik :confirmValue untuk mengonfirmasi.",
         ],
     ],
 ];


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change


### Description

This pull request improves the Indonesian (id) translation for the datatable language file.
Remaining English strings have been replaced with proper Bahasa Indonesia to provide a more consistent user experience.


### Related Issue(s)

N/A

### Documentation

This PR requires [Documentation ](https://github.com/Power-Components/powergrid-doc)update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
