### PR TITLE
Fix hasLazyEnabled check to be a method call

### DIFF
--- a/src/PowerGridComponent.php
+++ b/src/PowerGridComponent.php
@@ -76,7 +76,7 @@ class PowerGridComponent extends Component
     {
         $this->checkboxAll = false;
 
-        if (! app()->runningInConsole() && $this->hasLazyEnabled) {
+        if (! app()->runningInConsole() && $this->hasLazyEnabled()) {
             $this->additionalCacheKey = uniqid();
 
             data_set($this->setUp, 'lazy.items', 0);
@@ -91,7 +91,7 @@ class PowerGridComponent extends Component
     {
         $this->gotoPage(1, data_get($this->setUp, 'footer.pageName'));
 
-        if (! app()->runningInConsole() && $this->hasLazyEnabled) {
+        if (! app()->runningInConsole() && $this->hasLazyEnabled()) {
             $this->additionalCacheKey = uniqid();
 
             data_set($this->setUp, 'lazy.items', 0);


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

Fix for error: ```Property [$hasLazyEnabled] not found on component: []```

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
