### PR TITLE
Github Actions Fixes

### DIFF
--- a/src/Livewire/LazyChild.php
+++ b/src/Livewire/LazyChild.php
@@ -67,9 +67,9 @@ class LazyChild extends Component
         return app($parentComponent)->shouldShowToggleable($column, $row);
     }
 
-    private function getComponentAlias(): string
+    private function getComponentAlias(): ?string
     {
-        if (app()->has(ComponentRegistry::class)) {
+        if (class_exists(\Livewire\Mechanisms\ComponentRegistry::class)) {
 
             return app(ComponentRegistry::class)->getClass($this->parentName);
         }

--- a/tests/cypress/cypress/e2e/actions/attributes.cy.js
+++ b/tests/cypress/cypress/e2e/actions/attributes.cy.js
@@ -16,21 +16,16 @@ describe('render javascript actions attributes', () => {
                 '</svg>')
             .should('contain.text', 'View')
 
-        cy.intercept('POST', '/livewire/update', (req) => {
-            expect(req.body.components[0].calls[0])
-                .to.deep
-                .equal({
-                    path: "",
-                    method: "__dispatch",
-                    params: [
-                        "clickToEdit",
-                        {
-                            action: "view",
-                            name: "Luan"
-                        }
-                    ]
-                });
-
+        cy.intercept('POST', '**/livewire*/update', (req) => {
+            const call = req.body.components[0].calls[0];
+            expect(call.method).to.equal("__dispatch");
+            expect(call.params).to.deep.equal([
+                "clickToEdit",
+                {
+                    action: "view",
+                    name: "Luan"
+                }
+            ]);
         }).as('requestIntercept');
 
         cy.get('[data-cy=btn-view-1]').click()
@@ -55,21 +50,16 @@ describe('render javascript actions attributes', () => {
                 '</svg>')
             .should('contain.text', 'Edit')
 
-        cy.intercept('POST', '/livewire/update', (req) => {
-            expect(req.body.components[0].calls[0])
-                .to.deep
-                .equal({
-                    path: "",
-                    method: "__dispatch",
-                    params: [
-                        "clickToEdit",
-                        {
-                            action: "edit",
-                            name: "Luan"
-                        }
-                    ]
-                });
-
+        cy.intercept('POST', '**/livewire*/update', (req) => {
+            const call = req.body.components[0].calls[0];
+            expect(call.method).to.equal("__dispatch");
+            expect(call.params).to.deep.equal([
+                "clickToEdit",
+                {
+                    action: "edit",
+                    name: "Luan"
+                }
+            ]);
         }).as('requestIntercept');
 
         cy.get('[data-cy=btn-edit-1]').click()
@@ -77,10 +67,10 @@ describe('render javascript actions attributes', () => {
         cy.wait('@requestIntercept')
             .its('response.body')
             .should((response) => {
-            expect(response.components[0].effects.xjs[0].expression)
-                .to.deep
-                .equal('console.log("Editing #edit -  Luan")');
-        });
+                expect(response.components[0].effects.xjs[0].expression)
+                    .to.deep
+                    .equal('console.log("Editing #edit -  Luan")');
+            });
     });
 
     it('can render view button and click for row 2', () => {
@@ -93,18 +83,16 @@ describe('render javascript actions attributes', () => {
                 '    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>\n' +
                 '</svg>')
 
-        cy.intercept('POST', '/livewire/update', (req) => {
-            expect(req.body.components[0].calls[0]).to.deep.equal({
-                path: "",
-                method: "__dispatch",
-                params: [
-                    "clickToEdit",
-                    {
-                        action: "view",
-                        name: "Daniel"
-                    }
-                ]
-            });
+        cy.intercept('POST', '**/livewire*/update', (req) => {
+            const call = req.body.components[0].calls[0];
+            expect(call.method).to.equal("__dispatch");
+            expect(call.params).to.deep.equal([
+                "clickToEdit",
+                {
+                    action: "view",
+                    name: "Daniel"
+                }
+            ]);
         }).as('requestIntercept');
 
         cy.get('[data-cy=btn-view-2').click()
@@ -112,10 +100,10 @@ describe('render javascript actions attributes', () => {
         cy.wait('@requestIntercept')
             .its('response.body')
             .should((response) => {
-            expect(response.components[0].effects.xjs[0].expression)
-                .to.deep
-                .equal('console.log("Editing #view -  Daniel")');
-        });
+                expect(response.components[0].effects.xjs[0].expression)
+                    .to.deep
+                    .equal('console.log("Editing #view -  Daniel")');
+            });
     })
 
     it('can render "Edit" button and click for row 2', () => {
@@ -130,19 +118,16 @@ describe('render javascript actions attributes', () => {
                 '</svg>')
             .should('contain.text', 'Edit')
 
-        cy.intercept('POST', '/livewire/update', (req) => {
-            expect(req.body.components[0].calls[0]).to.deep.equal({
-                path: "",
-                method: "__dispatch",
-                params: [
-                    "clickToEdit",
-                    {
-                        action: "edit",
-                        name: "Daniel"
-                    }
-                ]
-            });
-
+        cy.intercept('POST', '**/livewire*/update', (req) => {
+            const call = req.body.components[0].calls[0];
+            expect(call.method).to.equal("__dispatch");
+            expect(call.params).to.deep.equal([
+                "clickToEdit",
+                {
+                    action: "edit",
+                    name: "Daniel"
+                }
+            ]);
         }).as('requestIntercept');
 
         cy.get('[data-cy=btn-edit-2]').click()
@@ -150,9 +135,9 @@ describe('render javascript actions attributes', () => {
         cy.wait('@requestIntercept')
             .its('response.body')
             .should((response) => {
-            expect(response.components[0].effects.xjs[0].expression)
-                .to.deep
-                .equal('console.log("Editing #edit -  Daniel")');
-        });
+                expect(response.components[0].effects.xjs[0].expression)
+                    .to.deep
+                    .equal('console.log("Editing #edit -  Daniel")');
+            });
     });
 })


### PR DESCRIPTION
This pull request includes improvements to both the backend PHP code and frontend Cypress tests. The main focus is on making the codebase more robust and flexible, particularly around component alias resolution and test request interception.

**Backend improvements:**

* Enhanced the `getComponentAlias` method in `LazyChild.php` to return `null` instead of a string when appropriate, and switched from checking the application container for `ComponentRegistry` to using `class_exists` for `\Livewire\Mechanisms\ComponentRegistry`. This increases compatibility and reliability when resolving component aliases.

**Frontend test improvements:**

* Updated Cypress tests in `attributes.cy.js` to use a more flexible URL pattern (`**/livewire*/update`) for intercepting POST requests, making the tests less brittle to URL changes. [[1]](diffhunk://#diff-209c1b678e132fc3fdedaca174e9c6bf31ffb9f4380f7313f2ea76ef0e334902L19-R28) [[2]](diffhunk://#diff-209c1b678e132fc3fdedaca174e9c6bf31ffb9f4380f7313f2ea76ef0e334902L58-R62) [[3]](diffhunk://#diff-209c1b678e132fc3fdedaca174e9c6bf31ffb9f4380f7313f2ea76ef0e334902L96-R95) [[4]](diffhunk://#diff-209c1b678e132fc3fdedaca174e9c6bf31ffb9f4380f7313f2ea76ef0e334902L133-R130)
* Refactored the intercepted request assertions in the Cypress tests to check only the relevant `method` and `params` properties of the call, improving clarity and maintainability. [[1]](diffhunk://#diff-209c1b678e132fc3fdedaca174e9c6bf31ffb9f4380f7313f2ea76ef0e334902L19-R28) [[2]](diffhunk://#diff-209c1b678e132fc3fdedaca174e9c6bf31ffb9f4380f7313f2ea76ef0e334902L58-R62) [[3]](diffhunk://#diff-209c1b678e132fc3fdedaca174e9c6bf31ffb9f4380f7313f2ea76ef0e334902L96-R95) [[4]](diffhunk://#diff-209c1b678e132fc3fdedaca174e9c6bf31ffb9f4380f7313f2ea76ef0e334902L133-R130)