### PR TITLE
feat: add sortUsing function to column for custom sorting

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -73,6 +73,9 @@ final class Column implements Wireable
 
     public array $customContent = [];
 
+    /** @var \Closure|null */
+    public ?\Closure $sortCallback = null;
+
     /**
      * Adds a new Column
      */
@@ -171,6 +174,23 @@ final class Column implements Wireable
         $this->enableSort();
 
         $this->sortable = true;
+
+        return $this;
+    }
+
+    /**
+     * Sets a custom sorting callback for this column.
+     * The callback receives the query builder and sort direction.
+     *
+     * @param \Closure $callback function($query, string $direction): void
+     */
+    public function sortUsing(\Closure $callback): Column
+    {
+        $this->enableSort();
+
+        $this->sortable = true;
+
+        $this->sortCallback = $callback;
 
         return $this;
     }
@@ -289,7 +309,12 @@ final class Column implements Wireable
 
     public function toLivewire(): array
     {
-        return (array) $this;
+        $data = (array) $this;
+
+        // Closures cannot be serialized, exclude them
+        unset($data['sortCallback']);
+
+        return $data;
     }
 
     public static function fromLivewire($value)

--- a/src/Column.php
+++ b/src/Column.php
@@ -2,6 +2,7 @@
 
 namespace PowerComponents\LivewirePowerGrid;
 
+use Closure;
 use Illuminate\Support\Traits\Macroable;
 use Livewire\Wireable;
 
@@ -41,6 +42,8 @@ final class Column implements Wireable
 
     public bool $sortable = false;
 
+    public ?Closure $sortCallback = null;
+
     public bool $index = false;
 
     public array $properties = [];
@@ -72,9 +75,6 @@ final class Column implements Wireable
     public mixed $filters = null;
 
     public array $customContent = [];
-
-    /** @var \Closure|null */
-    public ?\Closure $sortCallback = null;
 
     /**
      * Adds a new Column
@@ -181,10 +181,8 @@ final class Column implements Wireable
     /**
      * Sets a custom sorting callback for this column.
      * The callback receives the query builder and sort direction.
-     *
-     * @param \Closure $callback function($query, string $direction): void
      */
-    public function sortUsing(\Closure $callback): Column
+    public function sortUsing(Closure $callback): Column
     {
         $this->enableSort();
 

--- a/src/Concerns/Sorting.php
+++ b/src/Concerns/Sorting.php
@@ -115,4 +115,23 @@ trait Sorting
             data_set($this->setUp, 'lazy.items', 0);
         }
     }
+
+    /**
+     * Get the sort callback for a given field from the columns definition.
+     * Returns null if no custom callback is defined.
+     */
+    public function getSortCallback(string $field): ?\Closure
+    {
+        $columns = $this->columns();
+
+        foreach ($columns as $column) {
+            $columnDataField = data_get($column, 'dataField');
+
+            if ($columnDataField === $field && data_get($column, 'sortCallback') instanceof \Closure) {
+                return $column->sortCallback;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/DataSource/Processors/Collection/Pipelines/Sorting.php
+++ b/src/DataSource/Processors/Collection/Pipelines/Sorting.php
@@ -17,19 +17,52 @@ final class Sorting
         }
 
         if ($this->component->multiSort) {
-            $sortArray = [];
-
-            foreach ($this->component->sortArray as $sortField => $sortDirection) {
-                $sortArray[] = [$sortField, $sortDirection];
-            }
-
-            return $next($collection->sortBy($sortArray));
+            return $next($this->applyMultipleSort($collection));
         }
 
-        $isDescending = $this->component->sortDirection === 'desc';
+        return $next($this->applySingleSort($collection, $this->component->sortField, $this->component->sortDirection));
+    }
 
-        $sorted = $collection->sortBy($this->component->sortField, SORT_REGULAR, $isDescending);
+    private function applySingleSort(Collection $collection, string $sortField, string $direction): Collection
+    {
+        $sortCallback = $this->component->getSortCallback($sortField);
 
-        return $next($sorted);
+        if ($sortCallback !== null) {
+            return $sortCallback($collection, $direction);
+        }
+
+        $isDescending = $direction === 'desc';
+
+        return $collection->sortBy($sortField, SORT_REGULAR, $isDescending);
+    }
+
+    private function applyMultipleSort(Collection $collection): Collection
+    {
+        $sortArray = [];
+        $callbackFields = [];
+
+        foreach ($this->component->sortArray as $sortField => $sortDirection) {
+            $sortCallback = $this->component->getSortCallback($sortField);
+
+            if ($sortCallback !== null) {
+                $callbackFields[] = ['field' => $sortField, 'direction' => $sortDirection, 'callback' => $sortCallback];
+
+                continue;
+            }
+
+            $sortArray[] = [$sortField, $sortDirection];
+        }
+
+        // Apply standard sorting first
+        if (filled($sortArray)) {
+            $collection = $collection->sortBy($sortArray);
+        }
+
+        // Apply callback sorting
+        foreach ($callbackFields as $callbackField) {
+            $collection = $callbackField['callback']($collection, $callbackField['direction']);
+        }
+
+        return $collection;
     }
 }

--- a/src/DataSource/Processors/Database/Pipelines/Sorting.php
+++ b/src/DataSource/Processors/Database/Pipelines/Sorting.php
@@ -23,19 +23,37 @@ class Sorting
             if ($this->component->multiSort) {
                 $this->applyMultipleSort($query);
             } else {
-                $query->orderBy(
-                    $this->makeSortField($this->component->sortField),
-                    $this->component->sortDirection
-                );
+                $this->applySingleSort($query, $this->component->sortField, $this->component->sortDirection);
             }
         }
 
         return $next($query);
     }
 
+    private function applySingleSort(EloquentBuilder|MorphToMany|QueryBuilder $query, string $sortField, string $direction): void
+    {
+        $sortCallback = $this->component->getSortCallback($sortField);
+
+        if ($sortCallback !== null) {
+            $sortCallback($query, $direction);
+
+            return;
+        }
+
+        $query->orderBy($this->makeSortField($sortField), $direction);
+    }
+
     private function applyMultipleSort(EloquentBuilder|MorphToMany|QueryBuilder $results): void
     {
         foreach ($this->component->sortArray as $sortField => $direction) {
+            $sortCallback = $this->component->getSortCallback($sortField);
+
+            if ($sortCallback !== null) {
+                $sortCallback($results, $direction);
+
+                continue;
+            }
+
             $results->orderBy($this->makeSortField($sortField), $direction);
         }
     }

--- a/tests/Concerns/Components/DishesCustomSortCollectionTable.php
+++ b/tests/Concerns/Components/DishesCustomSortCollectionTable.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests\Concerns\Components;
+
+use Illuminate\Support\Collection;
+use PowerComponents\LivewirePowerGrid\{Column, Facades\PowerGrid, PowerGridComponent, PowerGridFields};
+
+class DishesCustomSortCollectionTable extends PowerGridComponent
+{
+    public string $tableName = 'dishes-custom-sort-collection-table';
+
+    public function datasource(): Collection
+    {
+        return collect([
+            ['id' => 1, 'name' => 'Zebra Dish', 'price' => 100.00, 'calories' => 300],
+            ['id' => 2, 'name' => 'Apple Pie', 'price' => 50.00, 'calories' => 200],
+            ['id' => 3, 'name' => 'Banana Split', 'price' => 75.00, 'calories' => 400],
+            ['id' => 4, 'name' => 'Cherry Tart', 'price' => 25.00, 'calories' => 100],
+            ['id' => 5, 'name' => 'Donut', 'price' => 10.00, 'calories' => 500],
+        ]);
+    }
+
+    public function setUp(): array
+    {
+        return [
+            PowerGrid::header()
+                ->showSearchInput(),
+
+            PowerGrid::footer()
+                ->showPerPage()
+                ->showRecordCount(),
+        ];
+    }
+
+    public function fields(): PowerGridFields
+    {
+        return PowerGrid::fields()
+            ->add('id')
+            ->add('name')
+            ->add('price')
+            ->add('calories');
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::make('Id', 'id')
+                ->sortable(),
+
+            Column::make('Name', 'name')
+                ->sortable(),
+
+            Column::make('Price', 'price')
+                ->sortUsing(function (Collection $collection, string $direction) {
+                    // Custom sort: sort by price with rounding to nearest 50
+                    return $collection->sortBy(function ($item) {
+                        return round(data_get($item, 'price') / 50) * 50;
+                    }, SORT_REGULAR, $direction === 'desc');
+                }),
+
+            Column::make('Calories', 'calories')
+                ->sortUsing(function (Collection $collection, string $direction) {
+                    // Custom sort: sort by calories in groups (low/medium/high)
+                    return $collection->sortBy(function ($item) {
+                        $calories = data_get($item, 'calories');
+                        if ($calories <= 200) {
+                            return 1; // Low
+                        }
+                        if ($calories <= 400) {
+                            return 2; // Medium
+                        }
+
+                        return 3; // High
+                    }, SORT_REGULAR, $direction === 'desc');
+                }),
+
+            Column::action('Action'),
+        ];
+    }
+
+    public function setTestThemeClass(string $themeClass): void
+    {
+        config(['livewire-powergrid.theme' => $themeClass]);
+    }
+}

--- a/tests/Concerns/Components/DishesCustomSortTable.php
+++ b/tests/Concerns/Components/DishesCustomSortTable.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests\Concerns\Components;
+
+use Illuminate\Database\Eloquent\Builder;
+use PowerComponents\LivewirePowerGrid\{Column, Facades\PowerGrid, PowerGridComponent, PowerGridFields};
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Models\Dish;
+
+class DishesCustomSortTable extends PowerGridComponent
+{
+    public string $tableName = 'dishes-custom-sort-table';
+
+    public function setUp(): array
+    {
+        return [
+            PowerGrid::header()
+                ->showSearchInput(),
+
+            PowerGrid::footer()
+                ->showPerPage()
+                ->showRecordCount(),
+        ];
+    }
+
+    public function datasource(): Builder
+    {
+        return Dish::query();
+    }
+
+    public function fields(): PowerGridFields
+    {
+        return PowerGrid::fields()
+            ->add('id')
+            ->add('name')
+            ->add('price')
+            ->add('calories');
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::make('Id', 'id')
+                ->sortable(),
+
+            Column::make('Name', 'name')
+                ->sortable(),
+
+            Column::make('Price', 'price')
+                ->sortUsing(function ($query, string $direction) {
+                    // Custom sort: sort by price, but nulls go last
+                    $query->orderByRaw("price IS NULL, price {$direction}");
+                }),
+
+            Column::make('Calories', 'calories')
+                ->sortUsing(function ($query, string $direction) {
+                    // Custom sort: multiply calories by a factor and sort
+                    $query->orderByRaw("calories * 2 {$direction}");
+                }),
+
+            Column::action('Action'),
+        ];
+    }
+
+    public function setTestThemeClass(string $themeClass): void
+    {
+        config(['livewire-powergrid.theme' => $themeClass]);
+    }
+}

--- a/tests/Feature/CustomSortTest.php
+++ b/tests/Feature/CustomSortTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Components\{DishesCustomSortCollectionTable, DishesCustomSortTable};
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\TestDatabase;
+
+use function PowerComponents\LivewirePowerGrid\Tests\Plugins\livewire;
+
+beforeEach(function () {
+    TestDatabase::seed(customSortDishes());
+});
+
+it('uses custom sort callback for database queries', function (string $component, object $params) {
+    livewire($component)
+        ->call('setTestThemeClass', $params->theme)
+        ->set('setUp.footer.perPage', '10')
+        ->call('sortBy', 'calories')
+        ->assertSee('Dish A')
+        ->assertSee('Dish B')
+        ->call('sortBy', 'calories')
+        ->assertSee('Dish A')
+        ->assertSee('Dish B');
+})->with('custom sort');
+
+it('enables sort when using sortUsing callback', function () {
+    $component = livewire(DishesCustomSortTable::class);
+
+    // Get the columns and check that price column has sorting enabled
+    $columns = $component->instance()->columns();
+
+    $priceColumn = collect($columns)->firstWhere('field', 'price');
+
+    expect($priceColumn->enableSort)->toBeTrue()
+        ->and($priceColumn->sortable)->toBeTrue()
+        ->and($priceColumn->sortCallback)->toBeInstanceOf(Closure::class);
+});
+
+it('uses custom sort callback for collection datasource', function () {
+    livewire(DishesCustomSortCollectionTable::class)
+        ->set('setUp.footer.perPage', '10')
+        ->call('sortBy', 'calories')
+        ->set('sortDirection', 'asc')
+        ->assertSeeInOrder(['Cherry Tart', 'Apple Pie', 'Zebra Dish', 'Banana Split', 'Donut'])
+        ->call('sortBy', 'calories')
+        ->set('sortDirection', 'desc')
+        ->assertSeeInOrder(['Donut', 'Banana Split', 'Zebra Dish', 'Apple Pie', 'Cherry Tart']);
+});
+
+it('getSortCallback returns null for regular sortable columns', function () {
+    $component = livewire(DishesCustomSortTable::class)->instance();
+
+    // Regular sortable column should return null
+    expect($component->getSortCallback('id'))->toBeNull()
+        ->and($component->getSortCallback('name'))->toBeNull();
+});
+
+it('getSortCallback returns closure for columns with custom sort', function () {
+    $component = livewire(DishesCustomSortTable::class)->instance();
+
+    // Columns with custom sort callback should return the closure
+    expect($component->getSortCallback('price'))->toBeInstanceOf(Closure::class)
+        ->and($component->getSortCallback('calories'))->toBeInstanceOf(Closure::class);
+});
+
+it('sortCallback is excluded from toLivewire serialization', function () {
+    $component = livewire(DishesCustomSortTable::class)->instance();
+    $columns = $component->columns();
+
+    $priceColumn = collect($columns)->firstWhere('field', 'price');
+
+    // Ensure sortCallback exists on the column object
+    expect($priceColumn->sortCallback)->toBeInstanceOf(Closure::class);
+
+    // But it should be excluded from the serialized array
+    $serialized = $priceColumn->toLivewire();
+    expect($serialized)->not->toHaveKey('sortCallback');
+});
+
+dataset('custom sort', [
+    'tailwind' => [DishesCustomSortTable::class, (object) ['theme' => \PowerComponents\LivewirePowerGrid\Themes\Tailwind::class]],
+    'bootstrap' => [DishesCustomSortTable::class, (object) ['theme' => \PowerComponents\LivewirePowerGrid\Themes\Bootstrap5::class]],
+]);
+
+function customSortDishes(): array
+{
+    return [
+        [
+            'name' => 'Dish A',
+            'category_id' => 7,
+            'price' => 100.00,
+            'stored_at' => '1',
+            'calories' => 100,
+            'serving_at' => 'pool bar',
+            'diet' => 1,
+            'in_stock' => true,
+            'produced_at' => '2021-10-01',
+        ],
+        [
+            'name' => 'Dish B',
+            'category_id' => 7,
+            'price' => 200.00,
+            'stored_at' => '2',
+            'calories' => 200,
+            'serving_at' => 'pool bar',
+            'diet' => 1,
+            'in_stock' => true,
+            'produced_at' => '2021-10-02',
+        ],
+        [
+            'name' => 'Dish C',
+            'category_id' => 7,
+            'price' => 300.00,
+            'stored_at' => '3',
+            'calories' => 300,
+            'serving_at' => 'pool bar',
+            'diet' => 1,
+            'in_stock' => true,
+            'produced_at' => '2021-10-03',
+        ],
+        [
+            'name' => 'Dish D',
+            'category_id' => 7,
+            'price' => null,
+            'stored_at' => '4',
+            'calories' => 400,
+            'serving_at' => 'pool bar',
+            'diet' => 1,
+            'in_stock' => true,
+            'produced_at' => '2021-10-04',
+        ],
+        [
+            'name' => 'Dish E',
+            'category_id' => 7,
+            'price' => 500.00,
+            'stored_at' => '5',
+            'calories' => 500,
+            'serving_at' => 'pool bar',
+            'diet' => 1,
+            'in_stock' => true,
+            'produced_at' => '2021-10-05',
+        ],
+    ];
+}

--- a/tests/Feature/CustomSortTest.php
+++ b/tests/Feature/CustomSortTest.php
@@ -39,10 +39,10 @@ it('uses custom sort callback for collection datasource', function () {
         ->set('setUp.footer.perPage', '10')
         ->call('sortBy', 'calories')
         ->set('sortDirection', 'asc')
-        ->assertSeeInOrder(['Cherry Tart', 'Apple Pie', 'Zebra Dish', 'Banana Split', 'Donut'])
+        ->assertSeeInOrder(['Apple Pie', 'Cherry Tart', 'Zebra Dish', 'Banana Split', 'Donut'])
         ->call('sortBy', 'calories')
         ->set('sortDirection', 'desc')
-        ->assertSeeInOrder(['Donut', 'Banana Split', 'Zebra Dish', 'Apple Pie', 'Cherry Tart']);
+        ->assertSeeInOrder(['Donut', 'Zebra Dish', 'Banana Split', 'Apple Pie', 'Cherry Tart']);
 });
 
 it('getSortCallback returns null for regular sortable columns', function () {
@@ -119,7 +119,7 @@ function customSortDishes(): array
         [
             'name' => 'Dish D',
             'category_id' => 7,
-            'price' => null,
+            'price' => 150.00,
             'stored_at' => '4',
             'calories' => 400,
             'serving_at' => 'pool bar',


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [ ] Bug fix
- [ ] Enhancement
- [x] New feature
- [ ] Breaking change

#### Description

Allows sorting columns by a callback giving flexibility to create completely custom sorts.

Examples of what can you do with it:

```
            Column::make('Price', 'price')
                ->sortUsing(function ($query, string $direction) {
                    // Custom sort: sort by price, but nulls go last
                    $query->orderByRaw("price IS NULL, price {$direction}");
                }),
```

```            
            Column::make('Live Value ('.$currencySymbol.')', 'live_value')
                ->sortUsing(function ($query, $direction) {
                    $query->selectRaw('account_balances.*, (
                        SELECT cp.price * account_balances.amount
                        FROM cryptos c
                        JOIN crypto_prices cp ON cp.crypto_id = c.id
                        WHERE c.provider_id = account_balances.asset_id
                        ORDER BY cp.created_at DESC
                        LIMIT 1
                    ) AS live_value_computed')
                        ->orderBy('live_value_computed', $direction);
                }),
```
```
            Column::make('Calories', 'calories')
                ->sortUsing(function (Collection $collection, string $direction) {
                    // Custom sort: sort by calories in groups (low/medium/high)
                    return $collection->sortBy(function ($item) {
                        $calories = data_get($item, 'calories');
                        if ($calories <= 200) {
                            return 1; // Low
                        }
                        if ($calories <= 400) {
                            return 2; // Medium
                        }

                        return 3; // High
                    }, SORT_REGULAR, $direction === 'desc');
                }),
```

#### Related Issue(s): 

https://github.com/Power-Components/livewire-powergrid/discussions/1850

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
