### PR TITLE
fix: two rows placement Bootstrap5 filters (input-text, number).

### DIFF
--- a/resources/views/components/frameworks/bootstrap5/filters/input-text.blade.php
+++ b/resources/views/components/frameworks/bootstrap5/filters/input-text.blade.php
@@ -51,10 +51,10 @@
             @if (!$inline)
                 <label class="form-label fw-semibold mb-1">{{ $title }}</label>
             @endif
-            <div class="d-flex flex-row gap-2 align-items-center">
+                <div @class(["d-flex", "flex-row gap-2 align-items-center" => !$inline, "flex-column align-items-start gap-1" => $inline])>
                 @if ($showSelectOptions)
                     <select
-                        class="form-select form-select-sm w-auto"
+                        @class(["form-select form-select-sm", "w-auto" => !$inline, "w-full" => $inline])
                         style="{{ data_get($column, 'headerStyle') }}"
                         {{ $defaultAttributes['selectAttributes'] }}
                     >

--- a/resources/views/components/frameworks/bootstrap5/filters/number.blade.php
+++ b/resources/views/components/frameworks/bootstrap5/filters/number.blade.php
@@ -33,7 +33,7 @@
         @if (!$inline)
             <label class="form-label fw-semibold mb-1">{{ $title ?? '' }}</label>
         @endif
-        <div class="d-flex flex-row gap-2 align-items-center">
+            <div @class(["d-flex", "flex-row gap-2 align-items-center" => !$inline, "flex-column align-items-start gap-1" => $inline])>
             <div>
                 <input
                     {{ $defaultAttributes['inputStartAttributes'] }}


### PR DESCRIPTION
For inline filters for bootstrap5 this fix too wide column width.

Two row placement make filter view the same as in 6.3 version