### PR TITLE
In table changed set wire:key to full rowId

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -42,7 +42,7 @@
                         @endphp
 
                         <tbody
-                            wire:key="tbody-{{ substr($rowId, 0, 6) }}"
+                            wire:key="tbody-{{ $rowId }}"
                             class="{{ $class }}"
                         >
                             @include('livewire-powergrid::components.row', [


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

I changed to using the full id instead of just six characters by wire:key in table.blade.php. I had problems with pagination in table because I am using string id values in my model. For example: "120200201431", "120200201432", ...

This problem has been discussed here: Discussion https://github.com/Power-Components/livewire-powergrid/discussions/1942

Could you please test this change? If there were no problems, could you approve it?

Thank you..

#### Related Issue(s): 

Discussion https://github.com/Power-Components/livewire-powergrid/discussions/1942

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
