### PR TITLE
Added alpine x-data and x-bind to <tbody> in table where is used detail

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -42,7 +42,7 @@
                         @endphp
 
                         <tbody
-                            wire:key="tbody-{{ substr($rowId, 0, 6) }}"
+                            wire:key="tbody-{{ $rowId }}"
                             class="{{ $class }}"
                         >
                             @include('livewire-powergrid::components.row', [

--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -44,6 +44,8 @@
                         <tbody
                             wire:key="tbody-{{ $rowId }}"
                             class="{{ $class }}"
+                            x-data="pgRowAttributes({ rowId: @js($rowId), rules: @js($row->__powergrid_rules) })"
+                            x-bind="getAttributes"
                         >
                             @include('livewire-powergrid::components.row', [
                                 'rowIndex' => $loop->index + 1,


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

There was issue that rules with setting CSS attributes did not work when was in setUp detail(). This caused missing x-bind="getAttributes" in each row in table.

I added x-bind and x-data to the <tbody> attribute for each row and after this change it worked for me. Could you do tests for this change please?

#### Related Issue(s): 

#1931

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
