### PR TITLE
Fix global search for JOIN columns with dataField

### DIFF
--- a/src/DataSource/Processors/Database/Handlers/SearchHandler.php
+++ b/src/DataSource/Processors/Database/Handlers/SearchHandler.php
@@ -43,7 +43,11 @@ class SearchHandler
                         return;
                     }
 
-                    if (isset($columnList[$field]) || ! $hasRelationSearch) {
+
+                    if (str_contains($field, '.') || data_get($column, 'dataField')) {
+                        $subQuery->orWhere("{$table}.{$field}", Sql::like($subQuery), "%{$search}%");
+                    }
+                    else if (isset($columnList[$field]) || ! $hasRelationSearch) {
                         $subQuery->orWhere("{$table}.{$field}", Sql::like($subQuery), "%{$search}%");
                     }
                 });


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description
The search process returns 0 rows when involving joined columns because it only validates the original columns in the model, and the joined columns are silently ignored during the search.

Queries that use JOINs can be more efficient than multiple separate queries (like lazzy loading or relationship searchs) because they allow the database to optimize execution internally.
...

#### Related Issue(s): 

https://github.com/Power-Components/livewire-powergrid/issues/1592

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
