### PR TITLE
SearchHandler can now be replaced by your own implementation

### DIFF
--- a/src/DataSource/Processors/Database/Handlers/SearchHandler.php
+++ b/src/DataSource/Processors/Database/Handlers/SearchHandler.php
@@ -11,10 +11,10 @@ use PowerComponents\LivewirePowerGrid\Support\PowerGridTableCache;
 use stdClass;
 use Throwable;
 
-class SearchHandler
+class SearchHandler implements SearchHandlerContract
 {
     public function __construct(
-        private readonly PowerGridComponent $component
+        protected readonly PowerGridComponent $component
     ) {}
 
     public function apply(EloquentBuilder|QueryBuilder $query): EloquentBuilder|QueryBuilder
@@ -56,7 +56,7 @@ class SearchHandler
         return $query;
     }
 
-    private function filterRelation(EloquentBuilder $query, string $search): void
+    protected function filterRelation(EloquentBuilder $query, string $search): void
     {
         foreach ($this->component->relationSearch() as $table => $columns) {
             if (is_array($columns)) {
@@ -72,7 +72,7 @@ class SearchHandler
         }
     }
 
-    private function filterNestedRelation(EloquentBuilder $query, string $table, array $columns, string $search): void
+    protected function filterNestedRelation(EloquentBuilder $query, string $table, array $columns, string $search): void
     {
         foreach ($columns as $nestedTable => $nestedColumns) {
             if (is_array($nestedColumns)) {
@@ -113,7 +113,7 @@ class SearchHandler
         }
     }
 
-    private function getColumnList(EloquentBuilder|QueryBuilder $query, string $modelTable): array
+    protected function getColumnList(EloquentBuilder|QueryBuilder $query, string $modelTable): array
     {
         $connection = $query instanceof EloquentBuilder
             ? $query->getModel()->getConnection()->getName()
@@ -131,12 +131,12 @@ class SearchHandler
         }
     }
 
-    private function getDataField(Column|stdClass|array $column): string
+    protected function getDataField(Column|stdClass|array $column): string
     {
         return strval(data_get($column, 'dataField')) ?: strval(data_get($column, 'field'));
     }
 
-    private function getBeforeSearchMethod(string $field, ?string $search): ?string
+    protected function getBeforeSearchMethod(string $field, ?string $search): ?string
     {
         $method = 'beforeSearch'.str($field)->headline()->replace(' ', '');
 
@@ -151,7 +151,7 @@ class SearchHandler
         return $search;
     }
 
-    private function splitField(EloquentBuilder|QueryBuilder $query, string $field): array
+    protected function splitField(EloquentBuilder|QueryBuilder $query, string $field): array
     {
         $table = $query instanceof QueryBuilder ? $query->from : $query->getModel()->getTable();
 

--- a/src/DataSource/Processors/Database/Handlers/SearchHandlerContract.php
+++ b/src/DataSource/Processors/Database/Handlers/SearchHandlerContract.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\DataSource\Processors\Database\Handlers;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+interface SearchHandlerContract
+{
+    public function apply(EloquentBuilder|QueryBuilder $query): EloquentBuilder|QueryBuilder;
+}

--- a/src/DataSource/Processors/Database/Pipelines/Filters.php
+++ b/src/DataSource/Processors/Database/Pipelines/Filters.php
@@ -3,7 +3,7 @@
 namespace PowerComponents\LivewirePowerGrid\DataSource\Processors\Database\Pipelines;
 
 use Closure;
-use PowerComponents\LivewirePowerGrid\DataSource\Processors\Database\Handlers\{FilterHandler, SearchHandler};
+use PowerComponents\LivewirePowerGrid\DataSource\Processors\Database\Handlers\{FilterHandler, SearchHandlerContract};
 use PowerComponents\LivewirePowerGrid\PowerGridComponent;
 
 class Filters
@@ -12,7 +12,9 @@ class Filters
 
     public function handle(mixed $query, Closure $next): mixed
     {
-        (new SearchHandler($this->component))->apply($query);
+        app()->makeWith(SearchHandlerContract::class, [
+            'component' => $this->component,
+        ])->apply($query);
         (new FilterHandler($this->component))->apply($query);
 
         return $next($query);

--- a/src/Providers/PowerGridServiceProvider.php
+++ b/src/Providers/PowerGridServiceProvider.php
@@ -11,7 +11,9 @@ use Livewire\Livewire;
 use PowerComponents\LivewirePowerGrid\Commands\{CreateCommand, PublishCommand, UpdateCommand};
 use PowerComponents\LivewirePowerGrid\Components\Filters\FilterManager;
 use PowerComponents\LivewirePowerGrid\Components\Rules\RuleManager;
-use PowerComponents\LivewirePowerGrid\{Livewire\Detail,
+use PowerComponents\LivewirePowerGrid\{DataSource\Processors\Database\Handlers\SearchHandler,
+    DataSource\Processors\Database\Handlers\SearchHandlerContract,
+    Livewire\Detail,
     Livewire\LazyChild,
     Livewire\PerformanceCard,
     PowerGridManager,
@@ -70,6 +72,10 @@ class PowerGridServiceProvider extends ServiceProvider
         Macros::builder();
 
         $this->app->singleton(SupportLivewireVersions::class, fn () => new SupportLivewireVersions());
+
+        $this->app->bind(SearchHandlerContract::class, function ($app, array $params) {
+            return new SearchHandler($params['component']);
+        });
     }
 
     private function publishViews(): void

--- a/src/Traits/ExportableJob.php
+++ b/src/Traits/ExportableJob.php
@@ -7,7 +7,7 @@ use Illuminate\Support\{Collection, Str, Stringable};
 use PowerComponents\LivewirePowerGrid\{DataSource\DataTransformer,
     DataSource\ProcessDataSource,
     DataSource\Processors\Database\Handlers\FilterHandler,
-    DataSource\Processors\Database\Handlers\SearchHandler,
+    DataSource\Processors\Database\Handlers\SearchHandlerContract,
     PowerGridComponent};
 
 /** @codeCoverageIgnore */
@@ -63,7 +63,9 @@ trait ExportableJob
 
         $results = $this->componentTable->datasource($this->properties ?? []) // @phpstan-ignore-line
             ->where(function ($query) {
-                (new SearchHandler($this->componentTable))->apply($query);
+                app()->makeWith(SearchHandlerContract::class, [
+                    'component' => $this->componentTable,
+                ])->apply($query);
                 (new FilterHandler($this->componentTable))->apply($query);
             })
             ->when($filtered, function ($query, $filtered) use ($property) {

--- a/src/Traits/WithExport.php
+++ b/src/Traits/WithExport.php
@@ -13,7 +13,7 @@ use PowerComponents\LivewirePowerGrid\{Components\SetUp\Exportable,
     DataSource\DataTransformer,
     DataSource\ProcessDataSource,
     DataSource\Processors\Database\Handlers\FilterHandler,
-    DataSource\Processors\Database\Handlers\SearchHandler};
+    DataSource\Processors\Database\Handlers\SearchHandlerContract};
 use PowerComponents\LivewirePowerGrid\Jobs\ExportJob;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Throwable;
@@ -197,7 +197,9 @@ trait WithExport
 
         $results = $processDataSource->component->datasource()
             ->where(function ($query) {
-                (new SearchHandler($this))->apply($query);
+                app()->makeWith(SearchHandlerContract::class, [
+                    'component' => $this,
+                ])->apply($query);
                 (new FilterHandler($this))->apply($query);
             })
             ->when($filtered, function ($query, $filtered) use ($property) {


### PR DESCRIPTION
This is now resolved via the Laravel container

## ⚡ PowerGrid - Pull Request

- [x] Enhancement

#### Description

I needed some adjustments in the way the global search was working. I extracted it to a handler which can be resolved through the Laravel container. So anyone can now make it's own implementation while adding this to their own ServiceProvider:

```
use PowerComponents\LivewirePowerGrid\DataSource\Processors\Database\Handlers\SearchHandlerContract;
use App\Support\Powergrid\Handlers\SearchHandler;

$this->app->bind(SearchHandlerContract::class, function ($app, array $params) {
    return new SearchHandler($params['component']);
});
```

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] No
