### PR TITLE
[6.x] Fix export sorting for joined alias columns

### DIFF
--- a/src/Concerns/Sorting.php
+++ b/src/Concerns/Sorting.php
@@ -116,6 +116,15 @@ trait Sorting
         }
     }
 
+    public function resolveSortField(string $sortField): string
+    {
+        if (str_contains($sortField, '.') || $this->ignoreTablePrefix) {
+            return $sortField;
+        }
+
+        return $this->currentTable.'.'.$sortField;
+    }
+
     /**
      * Get the sort callback for a given field from the columns definition.
      * Returns null if no custom callback is defined.

--- a/src/DataSource/Processors/Database/Pipelines/Sorting.php
+++ b/src/DataSource/Processors/Database/Pipelines/Sorting.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Query\Builder as QueryBuilder;
-use Illuminate\Support\Str;
 use PowerComponents\LivewirePowerGrid\PowerGridComponent;
 
 class Sorting
@@ -40,7 +39,7 @@ class Sorting
             return;
         }
 
-        $query->orderBy($this->makeSortField($sortField), $direction);
+        $query->orderBy($this->component->resolveSortField($sortField), $direction);
     }
 
     private function applyMultipleSort(EloquentBuilder|MorphToMany|QueryBuilder $results): void
@@ -54,16 +53,7 @@ class Sorting
                 continue;
             }
 
-            $results->orderBy($this->makeSortField($sortField), $direction);
+            $results->orderBy($this->component->resolveSortField($sortField), $direction);
         }
-    }
-
-    private function makeSortField(string $sortField): string
-    {
-        if (Str::of($sortField)->contains('.') || $this->component->ignoreTablePrefix) {
-            return $sortField;
-        }
-
-        return $this->component->currentTable.'.'.$sortField;
     }
 }

--- a/src/Traits/ExportableJob.php
+++ b/src/Traits/ExportableJob.php
@@ -52,7 +52,14 @@ trait ExportableJob
 
         $filtered = $processDataSource->component->filtered ?? [];
         $currentTable = $processDataSource->component->currentTable;
+
+        /** @var array{sortField?: string, sortDirection?: string} $queryOptions */
         $queryOptions = data_get($this->exportable, 'queryOptions', []);
+
+        // data_get's default only applies when the key is missing, so guard against malformed query options.
+        if (! is_array($queryOptions)) {
+            $queryOptions = [];
+        }
 
         $property = function (string $property) use ($processDataSource, $currentTable) {
             $property = $processDataSource->component->{$property};
@@ -64,7 +71,9 @@ trait ExportableJob
 
         $sortField = $queryOptions['sortField']
             ?? $processDataSource->component->resolveSortField($processDataSource->component->sortField);
-        $sortDirection = $queryOptions['sortDirection'] ?? $processDataSource->component->sortDirection;
+
+        $sortDirection = $queryOptions['sortDirection']
+            ?? $processDataSource->component->sortDirection;
 
         $results = $processDataSource->datasource
             ->where(function ($query) {

--- a/src/Traits/ExportableJob.php
+++ b/src/Traits/ExportableJob.php
@@ -52,6 +52,7 @@ trait ExportableJob
 
         $filtered = $processDataSource->component->filtered ?? [];
         $currentTable = $processDataSource->component->currentTable;
+        $queryOptions = data_get($this->exportable, 'queryOptions', []);
 
         $property = function (string $property) use ($processDataSource, $currentTable) {
             $property = $processDataSource->component->{$property};
@@ -60,6 +61,10 @@ trait ExportableJob
                 ? $property
                 : $currentTable.'.'.$property;
         };
+
+        $sortField = $queryOptions['sortField']
+            ?? $processDataSource->component->resolveSortField($processDataSource->component->sortField);
+        $sortDirection = $queryOptions['sortDirection'] ?? $processDataSource->component->sortDirection;
 
         $results = $processDataSource->datasource
             ->where(function ($query) {
@@ -73,7 +78,7 @@ trait ExportableJob
             })
             ->offset($this->offset)
             ->limit($this->limit)
-            ->orderBy($property('sortField'), $processDataSource->component->sortDirection)
+            ->orderBy($sortField, $sortDirection)
             ->get();
 
         $dataTransformer = new DataTransformer($processDataSource->component);

--- a/src/Traits/WithExport.php
+++ b/src/Traits/WithExport.php
@@ -206,7 +206,8 @@ trait WithExport
                 return $query->whereIn($property('primaryKey'), $filtered);
             })
             ->when($this->sortField, function ($query) use ($property, $processDataSource, $queryOptions) {
-                $sortField = $queryOptions['sortField'] ?? $property('sortField');
+                $sortField = $queryOptions['sortField']
+                    ?? $processDataSource->component->resolveSortField($processDataSource->component->sortField);
                 $sortDirection = $queryOptions['sortDirection'] ?? $processDataSource->component->sortDirection;
 
                 return $query->orderBy($sortField, $sortDirection);

--- a/src/Traits/WithExport.php
+++ b/src/Traits/WithExport.php
@@ -205,7 +205,7 @@ trait WithExport
             ->when($filtered, function ($query, $filtered) use ($property) {
                 return $query->whereIn($property('primaryKey'), $filtered);
             })
-            ->when($this->sortField, function ($query) use ($property, $processDataSource, $queryOptions) {
+            ->when($this->sortField, function ($query) use ($processDataSource, $queryOptions) {
                 $sortField = $queryOptions['sortField']
                     ?? $processDataSource->component->resolveSortField($processDataSource->component->sortField);
                 $sortDirection = $queryOptions['sortDirection'] ?? $processDataSource->component->sortDirection;

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use OpenSpout\Reader\XLSX\Reader;
 use PowerComponents\LivewirePowerGrid\{Button, Column, Components\SetUp\Exportable, PowerGridFields};
 use PowerComponents\LivewirePowerGrid\Facades\PowerGrid;
@@ -224,6 +225,50 @@ dataset('export_with_html', [
     'html' => [$exportWithHtml::class],
 ]);
 
+$exportWithJoinedAliasSort = new class() extends ExportTable
+{
+    public function datasource(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::datasource()
+            ->join('categories', function ($categories) {
+                $categories->on('dishes.category_id', '=', 'categories.id');
+            })
+            ->select('dishes.*', DB::raw('categories.name as category_name'));
+    }
+
+    public function fields(): PowerGridFields
+    {
+        return PowerGrid::fields()
+            ->add('category_name');
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::add()
+                ->title('Category')
+                ->field('category_name')
+                ->sortable(),
+        ];
+    }
+};
+
+it('properly prepares export data sorted by a joined alias column', function (string $component) {
+    $component = livewire($component)
+        ->set('checkboxValues', [
+            0 => '1',
+            1 => '3',
+        ])
+        ->call('sortBy', 'category_name');
+
+    expect($component->instance()->prepareToExport(true)->pluck('category_name')->values()->all())
+        ->toBe(['Carnes', 'Sobremesas']);
+})->with('export_with_joined_alias_sort');
+
+dataset('export_with_joined_alias_sort', [
+    'joined alias' => [$exportWithJoinedAliasSort::class],
+]);
+
 $exportWithQueryOptions = new class() extends ExportTable
 {
     public string $testSortField = '';
@@ -302,7 +347,7 @@ expect()->extend('toBeCsvDownload', function (array $headings, array $rows) {
         data_get($downloadEffect, 'name')
     );
 
-    $content = str_replace(PHP_EOL, '<csv-divider>', base64_decode(data_get($downloadEffect, 'content')));
+    $content = str_replace(["\r\n", "\n", "\r"], '<csv-divider>', base64_decode(data_get($downloadEffect, 'content')));
 
     $expected = collect(array_merge([$headings], $rows))
         ->transform(function ($heading) use ($delimiter, $separator) {

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use OpenSpout\Reader\XLSX\Reader;
 use PowerComponents\LivewirePowerGrid\{Button, Column, Components\SetUp\Exportable, PowerGridFields};
@@ -227,7 +228,7 @@ dataset('export_with_html', [
 
 $exportWithJoinedAliasSort = new class() extends ExportTable
 {
-    public function datasource(): \Illuminate\Database\Eloquent\Builder
+    public function datasource(): Builder
     {
         return parent::datasource()
             ->join('categories', function ($categories) {


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This PR fixes export sorting for joined or aliased database columns.

The normal table datasource query and the export query were resolving sort fields differently. The table query respected the existing `ignoreTablePrefix` behavior, so sorting by a selected alias such as `nom_complet` generated:

```sql
order by nom_complet asc
```

The export query always prefixed unqualified sort fields with the root table name, which generated:

```sql
order by lieu.nom_complet asc
```

That fails because `nom_complet` is a selected alias, not a real column on the root table.

The fix adds a shared sort-field resolver and uses it in the normal database sorting pipeline, synchronous exports, and queued exports. This keeps existing behavior for qualified fields like `categories.name`, preserves table-prefix behavior when `ignoreTablePrefix` is disabled, and keeps explicit export query options intact.

This PR also adds regression coverage for preparing export data sorted by a joined alias column.

The CSV export test helper was also adjusted to normalize `\r\n`, `\n`, and `\r` line endings instead of relying only on `PHP_EOL`. This makes the test assertion portable across environments and OpenSpout output line endings; it does not change export behavior.

#### Related Issue(s):

Aims to fix https://github.com/Power-Components/livewire-powergrid/discussions/2016

#### Documentation

This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
