### PR TITLE
Fix off-by-one in pgResponsive when any <th> is hidden

### DIFF
--- a/resources/js/components/pgResponsive/onResize.js
+++ b/resources/js/components/pgResponsive/onResize.js
@@ -47,7 +47,7 @@ function getItemsToHide(element, tableWidth) {
         if (fitsMoreItems && calc <= tableWidth && (calc + itemWidth <= tableWidth)) {
             calc += itemWidth;
         } else {
-            itemsToHide.push(visibleThs.indexOf(item) + 1)
+            itemsToHide.push(items.indexOf(item) + 1)
             fitsMoreItems = false
         }
     })
@@ -79,7 +79,7 @@ function fillTableExpand(element, hideItems) {
 
             if (!expandContainer) continue
 
-            let rowName = element.querySelector(`table thead tr th:nth-child(${hideItem}) span[data-value]`).textContent
+            let rowName = element.querySelector(`table thead tr th:nth-child(${hideItem}) span[data-value]`).textContent  ?? ''
 
             const rowValue = row.querySelector(`tr:last-child td:nth-child(${hideItem})`)?.innerHTML
 


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

PR #1940 introduced a regression that crashes `pgResponsive` with `null.textContent`. 
`getItemsToHide()` pushes `visibleThs.indexOf(item) + 1`, but the value is later used as a CSS `:nth-child(n)` selector — and `:nth-child` counts all siblings, including `display: none` ones. As soon as any `<th>` is hidden (which is always true on initial render due to the `x-show="hasHiddenElements"` toggle column in `tr.blade.php`), the indexes drift and `:nth-child` resolves to the wrong column.

Fix: index against the unfiltered `items` list, plus a defensive `?.textContent ?? ''` guard

The filtering from #1940 stays in place for the sort/iterate step, so hidden columns still don’t leak into the expand area — only the index used for :nth-child is corrected.

#### Related Issue(s): 
---

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
