### PR TITLE
[6.x] feat: source powergrid:create columns from the DB table

### DIFF
--- a/src/Commands/Actions/AskColumnSource.php
+++ b/src/Commands/Actions/AskColumnSource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Commands\Actions;
+
+use PowerComponents\LivewirePowerGrid\Commands\Enums\ColumnSource;
+
+use function Laravel\Prompts\select;
+
+/** @codeCoverageIgnore */
+final class AskColumnSource
+{
+    /** Asks where the generated fields should come from and returns the chosen ColumnSource case name. */
+    public static function handle(string $model, string $databaseTable): string
+    {
+        // Must pass options as array<int, "label"> to
+        // improve users experience when Laravel prompt falls back.
+        $options = collect([
+            ColumnSource::FILLABLE->name => '$fillable in ['.$model.'] Model',
+            ColumnSource::DATABASE_TABLE->name => 'Columns in ['.$databaseTable.'] DB table',
+        ]);
+
+        $choice = strval(select(
+            label: 'Where should the fields come from?',
+            options: $options->values()->toArray(), // @phpstan-ignore-line
+            default: 0
+        ));
+
+        return (string) $options->filter(fn (string $item): bool => $item === $choice)->keys()[0];
+    }
+}

--- a/src/Commands/Actions/BuildStubVars.php
+++ b/src/Commands/Actions/BuildStubVars.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Commands\Actions;
+
+use Illuminate\Support\{Collection, Str};
+
+/** Builds the fields, columns and filters stub variables from a set of typed columns. */
+final class BuildStubVars
+{
+    private bool $hasEscapeExample = false;
+
+    private string $fields = '';
+
+    private string $columns = "[\n";
+
+    private string $filters = "[\n";
+
+    /**
+     * @param  list<string>  $fields  Column names, in the order they should be generated.
+     * @param  Collection<string, string>  $types  Column name => normalized type bucket.
+     * @param  string  $model  Model class used to type-hint generated closures; empty leaves them untyped.
+     * @return array{'PowerGridFields': string, 'filters': string, 'columns': string}
+     */
+    public static function handle(array $fields, Collection $types, string $model = ''): array
+    {
+        return (new self())->build($fields, $types, $model);
+    }
+
+    /**
+     * @param  list<string>  $fields
+     * @param  Collection<string, string>  $types
+     * @return array{'PowerGridFields': string, 'filters': string, 'columns': string}
+     */
+    private function build(array $fields, Collection $types, string $model): array
+    {
+        $closure = $model === '' ? '$model' : $model.' $model';
+
+        foreach ($fields as $field) {
+            $type = $types->get($field);
+
+            if ($type === null) {
+                continue;
+            }
+
+            $title = Str::of($field)->replace('_', ' ')->ucfirst()->toString();
+
+            match ($type) {
+                'datetime' => $this->addDateTime($field, $title, $closure),
+                'date' => $this->addDate($field, $title, $closure),
+                'boolean' => $this->addBoolean($field, $title),
+                'integer' => $this->addInteger($field, $title),
+                'string' => $this->addString($field, $title, $closure),
+                default => $this->addUntyped($field, $title),
+            };
+        }
+
+        $this->columns .= '            Column::action(\'Action\')'."\n";
+
+        return [
+            'PowerGridFields' => $this->fields,
+            'filters' => $this->filters.'        ];',
+            'columns' => $this->columns.'        ];',
+        ];
+    }
+
+    private function addDateTime(string $field, string $title, string $closure): void
+    {
+        $this->columns .= '            Column::make(\''.$title.'\', \''.$field.'_formatted\', \''.$field.'\')'."\n".'                ->sortable(),'."\n\n";
+        $this->fields .= "\n".'            ->add(\''.$field.'_formatted\', fn ('.$closure.') => Carbon::parse($model->'.$field.')->format(\'d/m/Y H:i:s\'))';
+        $this->filters .= '            Filter::datetimepicker(\''.$field.'\'),'."\n";
+    }
+
+    private function addDate(string $field, string $title, string $closure): void
+    {
+        $this->columns .= '            Column::make(\''.$title.'\', \''.$field.'_formatted\', \''.$field.'\')'."\n".'                ->sortable(),'."\n\n";
+        $this->fields .= "\n".'            ->add(\''.$field.'_formatted\', fn ('.$closure.') => Carbon::parse($model->'.$field.')->format(\'d/m/Y\'))';
+        $this->filters .= '            Filter::datepicker(\''.$field.'\'),'."\n";
+    }
+
+    private function addBoolean(string $field, string $title): void
+    {
+        $this->fields .= "\n".'            ->add(\''.$field.'\')';
+        $this->columns .= '            Column::make(\''.$title.'\', \''.$field.'\')'."\n".'                ->toggleable(),'."\n\n";
+        $this->filters .= '            Filter::boolean(\''.$field.'\'),'."\n";
+    }
+
+    private function addInteger(string $field, string $title): void
+    {
+        $this->fields .= "\n".'            ->add(\''.$field.'\')';
+        $this->columns .= '            Column::make(\''.$title.'\', \''.$field.'\'),'."\n";
+    }
+
+    private function addString(string $field, string $title, string $closure): void
+    {
+        $this->fields .= "\n".'            ->add(\''.$field.'\')';
+        $this->columns .= '            Column::make(\''.$title.'\', \''.$field.'\')'."\n".'                ->sortable()'."\n".'                ->searchable(),'."\n\n";
+        $this->filters .= '            Filter::inputText(\''.$field.'\')->operators([\'contains\']),'."\n";
+
+        if (! $this->hasEscapeExample) {
+            $this->fields .= "\n\n           /** Example of custom column using a closure **/\n".'            ->add(\''.$field.'_lower\', fn ('.$closure.') => strtolower(e($model->'.$field.')))'."\n";
+            $this->hasEscapeExample = true;
+        }
+    }
+
+    /** Fallback for column types the generator has no opinion about: sortable and searchable, no filter. */
+    private function addUntyped(string $field, string $title): void
+    {
+        $this->fields .= "\n".'            ->add(\''.$field.'\')';
+        $this->columns .= '            Column::make(\''.$title.'\', \''.$field.'\')'."\n".'                ->sortable()'."\n".'                ->searchable(),'."\n\n";
+    }
+}

--- a/src/Commands/Actions/BuildStubVars.php
+++ b/src/Commands/Actions/BuildStubVars.php
@@ -27,6 +27,23 @@ final class BuildStubVars
     }
 
     /**
+     * Short summary of what is generated for a type, for the create command preview.
+     *
+     * Must mirror the arms of the match in build().
+     */
+    public static function describe(string $type): string
+    {
+        return match ($type) {
+            'datetime' => 'Sortable column, formatted d/m/Y H:i:s + datetime filter',
+            'date' => 'Sortable column, formatted d/m/Y + date filter',
+            'boolean' => 'Toggleable column + boolean filter',
+            'integer' => 'Plain column',
+            'string' => 'Sortable, searchable column + text filter',
+            default => 'Sortable, searchable column',
+        };
+    }
+
+    /**
      * @param  list<string>  $fields
      * @param  Collection<string, string>  $types
      * @return array{'PowerGridFields': string, 'filters': string, 'columns': string}

--- a/src/Commands/Actions/ConfirmGeneratedColumns.php
+++ b/src/Commands/Actions/ConfirmGeneratedColumns.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Commands\Actions;
+
+use function Laravel\Prompts\confirm;
+
+/** @codeCoverageIgnore */
+final class ConfirmGeneratedColumns
+{
+    /** Asks whether the previewed fields should be generated, before anything is written to disk. */
+    public static function handle(string $label = 'Generate the component with these fields?'): bool
+    {
+        return confirm(
+            label: $label
+        );
+    }
+}

--- a/src/Commands/Actions/GetStubVarsFromDbTable.php
+++ b/src/Commands/Actions/GetStubVarsFromDbTable.php
@@ -2,7 +2,7 @@
 
 namespace PowerComponents\LivewirePowerGrid\Commands\Actions;
 
-use PowerComponents\LivewirePowerGrid\Commands\Support\{PowerGridComponentMaker, SchemaColumns};
+use PowerComponents\LivewirePowerGrid\Commands\Support\PowerGridComponentMaker;
 
 /** @codeCoverageIgnore */
 class GetStubVarsFromDbTable
@@ -12,10 +12,8 @@ class GetStubVarsFromDbTable
      */
     public static function handle(PowerGridComponentMaker $component): array
     {
-        $types = SchemaColumns::handle($component->databaseTable);
+        $columns = ResolveGeneratedColumns::handle($component);
 
-        $fields = SchemaColumns::publicFields($types);
-
-        return BuildStubVars::handle($fields, $types);
+        return BuildStubVars::handle(array_values($columns->keys()->all()), $columns);
     }
 }

--- a/src/Commands/Actions/GetStubVarsFromDbTable.php
+++ b/src/Commands/Actions/GetStubVarsFromDbTable.php
@@ -14,10 +14,7 @@ class GetStubVarsFromDbTable
     {
         $types = SchemaColumns::handle($component->databaseTable);
 
-        $fields = $types->keys()
-            ->reject(fn (string $field): bool => in_array($field, SchemaColumns::SENSITIVE_COLUMNS, true))
-            ->values()
-            ->all();
+        $fields = SchemaColumns::publicFields($types);
 
         return BuildStubVars::handle($fields, $types);
     }

--- a/src/Commands/Actions/GetStubVarsFromDbTable.php
+++ b/src/Commands/Actions/GetStubVarsFromDbTable.php
@@ -2,95 +2,23 @@
 
 namespace PowerComponents\LivewirePowerGrid\Commands\Actions;
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
-use PowerComponents\LivewirePowerGrid\Commands\Support\PowerGridComponentMaker;
+use PowerComponents\LivewirePowerGrid\Commands\Support\{PowerGridComponentMaker, SchemaColumns};
 
 /** @codeCoverageIgnore */
 class GetStubVarsFromDbTable
 {
-    private static bool $hasEscapeExample = false;
-
     /**
      * @return array{'PowerGridFields': string, 'filters': string, 'columns': string}
      */
     public static function handle(PowerGridComponentMaker $component): array
     {
-        $columnListing = Schema::getColumnListing($component->databaseTable);
+        $types = SchemaColumns::handle($component->databaseTable);
 
-        $datasource = '';
-        $columns = "[\n";
-        $filters = "[\n";
+        $fields = $types->keys()
+            ->reject(fn (string $field): bool => in_array($field, SchemaColumns::SENSITIVE_COLUMNS, true))
+            ->values()
+            ->all();
 
-        $filteredColumns = collect($columnListing)
-            ->filter(function ($column) {
-                return ! in_array($column, ['password', 'remember_token', 'email_verified_at']);
-            })
-            ->toArray();
-
-        /** @var string $field */
-        foreach ($filteredColumns as $field) {
-            $columnType = Schema::getColumnType($component->databaseTable, $field);
-
-            $title = Str::of($field)->replace('_', ' ')->ucfirst();
-
-            if (in_array($columnType, ['datetime', 'date', 'timestamp'])) {
-                $columns .= '            Column::make(\''.$title.'\', \''.$field.'_formatted\', \''.$field.'\')'."\n".'                ->sortable(),'."\n\n";
-            }
-
-            if ($columnType === 'datetime') {
-                $datasource .= "\n".'            ->add(\''.$field.'_formatted\', fn ($model) => Carbon::parse($model->'.$field.')->format(\'d/m/Y H:i:s\'))';
-                $filters .= '            Filter::datetimepicker(\''.$field.'\'),'."\n";
-
-                continue;
-            }
-
-            if ($columnType === 'date') {
-                $datasource .= "\n".'            ->add(\''.$field.'_formatted\', fn ($model) => Carbon::parse($model->'.$field.')->format(\'d/m/Y\'))';
-                $filters .= '            Filter::datepicker(\''.$field.'\'),'."\n";
-
-                continue;
-            }
-
-            if ($columnType === 'boolean') {
-                $datasource .= "\n".'            ->add(\''.$field.'\')';
-                $columns .= '            Column::make(\''.$title.'\', \''.$field.'\')'."\n".'                ->toggleable(),'."\n\n";
-                $filters .= '            Filter::boolean(\''.$field.'\'),'."\n";
-
-                continue;
-            }
-
-            if (in_array($columnType, ['smallint', 'integer', 'bigint'])) {
-                $datasource .= "\n".'            ->add(\''.$field.'\')';
-                $columns .= '            Column::make(\''.$title.'\', \''.$field.'\'),'."\n";
-
-                continue;
-            }
-
-            if ($columnType === 'string') {
-                $datasource .= "\n".'            ->add(\''.$field.'\')';
-                $columns .= '            Column::make(\''.$title.'\', \''.$field.'\')'."\n".'                ->sortable()'."\n".'                ->searchable(),'."\n\n";
-                $filters .= '            Filter::inputText(\''.$field.'\')->operators([\'contains\']),'."\n";
-
-                if (! self::$hasEscapeExample) {
-                    $datasource .= "\n\n           /** Example of custom column using a closure **/\n".'            ->add(\''.$field.'_lower\', fn ($model) => strtolower(e($model->'.$field.')))'."\n";
-                    self::$hasEscapeExample = true;
-                }
-
-                continue;
-            }
-
-            $datasource .= "\n".'            ->add(\''.$field.'\')';
-            $columns .= '            Column::make(\''.$title.'\', \''.$field.'\')'."\n".'                ->sortable()'."\n".'                ->searchable(),'."\n\n";
-        }
-
-        $columns .= '        ];';
-        $filters .= '        ];';
-
-        return [
-            'PowerGridFields' => $datasource,
-            'filters' => $filters,
-            'columns' => $columns,
-        ];
+        return BuildStubVars::handle($fields, $types);
     }
 }

--- a/src/Commands/Actions/GetStubVarsFromFromModel.php
+++ b/src/Commands/Actions/GetStubVarsFromFromModel.php
@@ -2,9 +2,7 @@
 
 namespace PowerComponents\LivewirePowerGrid\Commands\Actions;
 
-use Illuminate\Database\Eloquent\Model;
-use PowerComponents\LivewirePowerGrid\Commands\Enums\ColumnSource;
-use PowerComponents\LivewirePowerGrid\Commands\Support\{PowerGridComponentMaker, SchemaColumns};
+use PowerComponents\LivewirePowerGrid\Commands\Support\PowerGridComponentMaker;
 
 /** @codeCoverageIgnore */
 class GetStubVarsFromFromModel
@@ -14,40 +12,8 @@ class GetStubVarsFromFromModel
      */
     public static function handle(PowerGridComponentMaker $component): array
     {
-        /** @var Model $model */
-        $model = new $component->modelFqn();
+        $columns = ResolveGeneratedColumns::handle($component);
 
-        $types = SchemaColumns::handle($model->getTable(), $model->getConnectionName());
-
-        $fields = $component->columnSource === ColumnSource::DATABASE_TABLE
-            ? SchemaColumns::publicFields($types)
-            : self::fromFillable($model);
-
-        $hidden = $model->getHidden();
-
-        $fields = array_values(array_filter(
-            $fields,
-            fn (string $field): bool => ! in_array($field, $hidden, true)
-        ));
-
-        return BuildStubVars::handle($fields, $types, $component->model);
-    }
-
-    /**
-     * Primary key first, then $fillable, then created_at - the historical order.
-     *
-     * @return list<string>
-     */
-    private static function fromFillable(Model $model): array
-    {
-        $fields = $model->getFillable();
-
-        if (filled($model->getKeyName())) {
-            array_unshift($fields, $model->getKeyName());
-        }
-
-        $fields[] = 'created_at';
-
-        return array_values(array_unique($fields));
+        return BuildStubVars::handle(array_values($columns->keys()->all()), $columns, $component->model);
     }
 }

--- a/src/Commands/Actions/GetStubVarsFromFromModel.php
+++ b/src/Commands/Actions/GetStubVarsFromFromModel.php
@@ -3,7 +3,6 @@
 namespace PowerComponents\LivewirePowerGrid\Commands\Actions;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Collection;
 use PowerComponents\LivewirePowerGrid\Commands\Enums\ColumnSource;
 use PowerComponents\LivewirePowerGrid\Commands\Support\{PowerGridComponentMaker, SchemaColumns};
 
@@ -21,7 +20,7 @@ class GetStubVarsFromFromModel
         $types = SchemaColumns::handle($model->getTable(), $model->getConnectionName());
 
         $fields = $component->columnSource === ColumnSource::DATABASE_TABLE
-            ? self::fromDatabaseTable($types)
+            ? SchemaColumns::publicFields($types)
             : self::fromFillable($model);
 
         $hidden = $model->getHidden();
@@ -32,17 +31,6 @@ class GetStubVarsFromFromModel
         ));
 
         return BuildStubVars::handle($fields, $types, $component->model);
-    }
-
-    /**
-     * @param  Collection<string, string>  $types
-     * @return list<string>
-     */
-    private static function fromDatabaseTable(Collection $types): array
-    {
-        return array_values($types->keys()
-            ->reject(fn (string $field): bool => in_array($field, SchemaColumns::SENSITIVE_COLUMNS, true))
-            ->all());
     }
 
     /**

--- a/src/Commands/Actions/GetStubVarsFromFromModel.php
+++ b/src/Commands/Actions/GetStubVarsFromFromModel.php
@@ -3,15 +3,13 @@
 namespace PowerComponents\LivewirePowerGrid\Commands\Actions;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
-use PowerComponents\LivewirePowerGrid\Commands\Support\PowerGridComponentMaker;
+use Illuminate\Support\Collection;
+use PowerComponents\LivewirePowerGrid\Commands\Enums\ColumnSource;
+use PowerComponents\LivewirePowerGrid\Commands\Support\{PowerGridComponentMaker, SchemaColumns};
 
 /** @codeCoverageIgnore */
 class GetStubVarsFromFromModel
 {
-    private static bool $hasEscapeExample = false;
-
     /**
      * @return array{'PowerGridFields': string, 'filters': string, 'columns': string}
      */
@@ -20,101 +18,48 @@ class GetStubVarsFromFromModel
         /** @var Model $model */
         $model = new $component->modelFqn();
 
-        $getFillable = $model->getFillable();
+        $types = SchemaColumns::handle($model->getTable(), $model->getConnectionName());
+
+        $fields = $component->columnSource === ColumnSource::DATABASE_TABLE
+            ? self::fromDatabaseTable($types)
+            : self::fromFillable($model);
+
+        $hidden = $model->getHidden();
+
+        $fields = array_values(array_filter(
+            $fields,
+            fn (string $field): bool => ! in_array($field, $hidden, true)
+        ));
+
+        return BuildStubVars::handle($fields, $types, $component->model);
+    }
+
+    /**
+     * @param  Collection<string, string>  $types
+     * @return list<string>
+     */
+    private static function fromDatabaseTable(Collection $types): array
+    {
+        return array_values($types->keys()
+            ->reject(fn (string $field): bool => in_array($field, SchemaColumns::SENSITIVE_COLUMNS, true))
+            ->all());
+    }
+
+    /**
+     * Primary key first, then $fillable, then created_at - the historical order.
+     *
+     * @return list<string>
+     */
+    private static function fromFillable(Model $model): array
+    {
+        $fields = $model->getFillable();
 
         if (filled($model->getKeyName())) {
-            $getFillable = array_merge([$model->getKeyName()], $getFillable);
+            array_unshift($fields, $model->getKeyName());
         }
 
-        $getFillable = array_merge(
-            $getFillable,
-            ['created_at']
-        );
+        $fields[] = 'created_at';
 
-        $datasource = '';
-        $columns = "[\n";
-        $filters = "[\n";
-
-        foreach ($getFillable as $field) {
-            if (in_array($field, $model->getHidden())) {
-                continue;
-            }
-
-            $connection = Schema::connection($model->getConnection()->getName());
-
-            $hasColumn = function () use ($model, $field, $connection) {
-                try {
-                    return $connection->hasColumn($model->getTable(), $field);
-                } catch (\Exception) {
-                    return Schema::hasColumn($model->getTable(), $field);
-                }
-            };
-
-            if ($hasColumn()) {
-                $columnType = $connection->getColumnType($model->getTable(), $field);
-
-                $title = Str::of($field)->replace('_', ' ')->ucfirst();
-
-                if (in_array($columnType, ['datetime', 'date', 'timestamp'])) {
-                    $columns .= '            Column::make(\''.$title.'\', \''.$field.'_formatted\', \''.$field.'\')'."\n".'                ->sortable(),'."\n\n";
-                }
-
-                if ($columnType === 'datetime') {
-                    $datasource .= "\n".'            ->add(\''.$field.'_formatted\', fn ('.$component->model.' $model) => Carbon::parse($model->'.$field.')->format(\'d/m/Y H:i:s\'))';
-                    $filters .= '            Filter::datetimepicker(\''.$field.'\'),'."\n";
-
-                    continue;
-                }
-
-                if ($columnType === 'date') {
-                    $datasource .= "\n".'            ->add(\''.$field.'_formatted\', fn ('.$component->model.' $model) => Carbon::parse($model->'.$field.')->format(\'d/m/Y\'))';
-                    $filters .= '            Filter::datepicker(\''.$field.'\'),'."\n";
-
-                    continue;
-                }
-
-                if ($columnType === 'boolean') {
-                    $datasource .= "\n".'            ->add(\''.$field.'\')';
-                    $columns .= '            Column::make(\''.$title.'\', \''.$field.'\')'."\n".'                ->toggleable(),'."\n\n";
-                    $filters .= '            Filter::boolean(\''.$field.'\'),'."\n";
-
-                    continue;
-                }
-
-                if (in_array($columnType, ['smallint', 'integer', 'bigint'])) {
-                    $datasource .= "\n".'            ->add(\''.$field.'\')';
-                    $columns .= '            Column::make(\''.$title.'\', \''.$field.'\'),'."\n";
-
-                    continue;
-                }
-
-                if ($columnType === 'string') {
-                    $datasource .= "\n".'            ->add(\''.$field.'\')';
-                    $columns .= '            Column::make(\''.$title.'\', \''.$field.'\')'."\n".'                ->sortable()'."\n".'                ->searchable(),'."\n\n";
-                    $filters .= '            Filter::inputText(\''.$field.'\')->operators([\'contains\']),'."\n";
-
-                    if (! self::$hasEscapeExample) {
-                        $datasource .= "\n\n           /** Example of custom column using a closure **/\n".'            ->add(\''.$field.'_lower\', fn ('.$component->model.' $model) => strtolower(e($model->'.$field.')))'."\n";
-                        self::$hasEscapeExample = true;
-                    }
-
-                    continue;
-                }
-
-                $datasource .= "\n".'            ->add(\''.$field.'\')';
-                $columns .= '            Column::make(\''.$title.'\', \''.$field.'\')'."\n".'                ->sortable()'."\n".'                ->searchable(),'."\n\n";
-            }
-        }
-
-        $columns .= '            Column::action(\'Action\')'."\n";
-
-        $columns .= '        ];';
-        $filters .= '        ];';
-
-        return [
-            'PowerGridFields' => $datasource,
-            'filters' => $filters,
-            'columns' => $columns,
-        ];
+        return array_values(array_unique($fields));
     }
 }

--- a/src/Commands/Actions/ResolveGeneratedColumns.php
+++ b/src/Commands/Actions/ResolveGeneratedColumns.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Commands\Actions;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use PowerComponents\LivewirePowerGrid\Commands\Enums\{ColumnSource, Datasource};
+use PowerComponents\LivewirePowerGrid\Commands\Support\{PowerGridComponentMaker, SchemaColumns};
+
+/** Resolves which columns a component will be generated with, according to its configured source. */
+final class ResolveGeneratedColumns
+{
+    /**
+     * Column name => normalized type bucket, in the order they should be generated.
+     *
+     * @return Collection<string, string>
+     */
+    public static function handle(PowerGridComponentMaker $component): Collection
+    {
+        [$types, $fields] = $component->datasource === Datasource::QUERY_BUILDER
+            ? self::fromDatabaseTable($component)
+            : self::fromModel($component);
+
+        return collect($fields)
+            ->filter(fn (string $field): bool => $types->has($field))
+            ->mapWithKeys(fn (string $field): array => [$field => strval($types->get($field))]);
+    }
+
+    /**
+     * @return array{0: Collection<string, string>, 1: list<string>}
+     */
+    private static function fromDatabaseTable(PowerGridComponentMaker $component): array
+    {
+        $types = SchemaColumns::handle($component->databaseTable);
+
+        return [$types, SchemaColumns::publicFields($types)];
+    }
+
+    /**
+     * @return array{0: Collection<string, string>, 1: list<string>}
+     */
+    private static function fromModel(PowerGridComponentMaker $component): array
+    {
+        /** @var Model $model */
+        $model = new $component->modelFqn();
+
+        $types = SchemaColumns::handle($model->getTable(), $model->getConnectionName());
+
+        $fields = $component->columnSource === ColumnSource::DATABASE_TABLE
+            ? SchemaColumns::publicFields($types)
+            : self::fromFillable($model);
+
+        $hidden = $model->getHidden();
+
+        $fields = array_values(array_filter(
+            $fields,
+            fn (string $field): bool => ! in_array($field, $hidden, true)
+        ));
+
+        return [$types, $fields];
+    }
+
+    /**
+     * Primary key first, then $fillable, then created_at - the historical order.
+     *
+     * @return list<string>
+     */
+    private static function fromFillable(Model $model): array
+    {
+        $fields = $model->getFillable();
+
+        if (filled($model->getKeyName())) {
+            array_unshift($fields, $model->getKeyName());
+        }
+
+        $fields[] = 'created_at';
+
+        return array_values(array_unique($fields));
+    }
+}

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -11,6 +11,7 @@ use PowerComponents\LivewirePowerGrid\Commands\Actions\{AskColumnSource,
     BuildStubVars,
     CheckIfDatabaseHasTables,
     ConfirmAutoImportFields,
+    ConfirmGeneratedColumns,
     ResolveGeneratedColumns};
 use PowerComponents\LivewirePowerGrid\Commands\Actions\AskComponentDatasource;
 use PowerComponents\LivewirePowerGrid\Commands\Concerns\RenderAscii;
@@ -113,20 +114,30 @@ class CreateCommand extends Command
             );
         }
 
-        $this->previewColumns();
+        if ($this->previewColumns() && ConfirmGeneratedColumns::handle() === false) {
+            $this->component->setAutoCreateColumns(false);
+
+            // There is nothing else to read the fields from in this run:
+            // re-run the command to generate them from the other source.
+            warning('🚫 Fields discarded. Only the Action column will be generated.');
+        }
 
         return $this;
     }
 
-    /** Shows which columns the chosen source will generate, before the component is written. */
-    private function previewColumns(): void
+    /**
+     * Shows which columns the chosen source will generate, before the component is written.
+     *
+     * @return bool Whether the source has any field to generate.
+     */
+    private function previewColumns(): bool
     {
         $columns = ResolveGeneratedColumns::handle($this->component);
 
         if ($columns->isEmpty()) {
             warning("🚫 No fields found in {$this->columnSourceLabel()}. Only the Action column will be generated.");
 
-            return;
+            return false;
         }
 
         note("👀 Preview of the fields from {$this->columnSourceLabel()}:");
@@ -137,6 +148,8 @@ class CreateCommand extends Command
                 fn (string $type, string $field): array => [$field, $type, BuildStubVars::describe($type)]
             )->values()->all()
         );
+
+        return true;
     }
 
     private function columnSourceLabel(): string

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -8,14 +8,16 @@ use PowerComponents\LivewirePowerGrid\Commands\Actions\{AskColumnSource,
     AskComponentName,
     AskDatabaseTableName,
     AskModelName,
+    BuildStubVars,
     CheckIfDatabaseHasTables,
-    ConfirmAutoImportFields};
+    ConfirmAutoImportFields,
+    ResolveGeneratedColumns};
 use PowerComponents\LivewirePowerGrid\Commands\Actions\AskComponentDatasource;
 use PowerComponents\LivewirePowerGrid\Commands\Concerns\RenderAscii;
 use PowerComponents\LivewirePowerGrid\Commands\Enums\{ColumnSource, Datasource};
 use PowerComponents\LivewirePowerGrid\Commands\Support\PowerGridComponentMaker;
 
-use function Laravel\Prompts\{error, info, note};
+use function Laravel\Prompts\{error, info, note, warning};
 
 /** @codeCoverageIgnore */
 class CreateCommand extends Command
@@ -111,7 +113,41 @@ class CreateCommand extends Command
             );
         }
 
+        $this->previewColumns();
+
         return $this;
+    }
+
+    /** Shows which columns the chosen source will generate, before the component is written. */
+    private function previewColumns(): void
+    {
+        $columns = ResolveGeneratedColumns::handle($this->component);
+
+        if ($columns->isEmpty()) {
+            warning("🚫 No fields found in {$this->columnSourceLabel()}. Only the Action column will be generated.");
+
+            return;
+        }
+
+        note("👀 Preview of the fields from {$this->columnSourceLabel()}:");
+
+        $this->table(
+            ['Field', 'Type', 'Generated as'],
+            $columns->map(
+                fn (string $type, string $field): array => [$field, $type, BuildStubVars::describe($type)]
+            )->values()->all()
+        );
+    }
+
+    private function columnSourceLabel(): string
+    {
+        if ($this->component->requiresDatabaseTableName()) {
+            return "the [{$this->component?->databaseTable}] table";
+        }
+
+        return $this->component?->columnSource === ColumnSource::DATABASE_TABLE
+            ? "the [{$this->component->modelTable()}] table"
+            : "\$fillable in [{$this->component?->model}]";
     }
 
     private function step6(): self

--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -4,14 +4,15 @@ namespace PowerComponents\LivewirePowerGrid\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
-use PowerComponents\LivewirePowerGrid\Commands\Actions\AskComponentDatasource;
-use PowerComponents\LivewirePowerGrid\Commands\Actions\{AskComponentName,
+use PowerComponents\LivewirePowerGrid\Commands\Actions\{AskColumnSource,
+    AskComponentName,
     AskDatabaseTableName,
     AskModelName,
     CheckIfDatabaseHasTables,
     ConfirmAutoImportFields};
+use PowerComponents\LivewirePowerGrid\Commands\Actions\AskComponentDatasource;
 use PowerComponents\LivewirePowerGrid\Commands\Concerns\RenderAscii;
-use PowerComponents\LivewirePowerGrid\Commands\Enums\Datasource;
+use PowerComponents\LivewirePowerGrid\Commands\Enums\{ColumnSource, Datasource};
 use PowerComponents\LivewirePowerGrid\Commands\Support\PowerGridComponentMaker;
 
 use function Laravel\Prompts\{error, info, note};
@@ -101,6 +102,15 @@ class CreateCommand extends Command
 
         $this->component->setAutoCreateColumns(true);
 
+        // Query Builder has only one possible source, so it is not asked.
+        if ($this->component->canHaveModel()) {
+            $this->component->setColumnSource(
+                ColumnSource::from(
+                    AskColumnSource::handle($this->component?->model, $this->component->modelTable())
+                )
+            );
+        }
+
         return $this;
     }
 
@@ -140,7 +150,7 @@ class CreateCommand extends Command
         (
             $this->component->requiresDatabaseTableName() ?
                  "[{$this->component?->databaseTable}] table?" :
-                 "\$fillable in [{$this->component?->model}] Model?"
+                 "[{$this->component?->model}] Model?"
         );
     }
 }

--- a/src/Commands/Enums/ColumnSource.php
+++ b/src/Commands/Enums/ColumnSource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Commands\Enums;
+
+/** Where a generated component's fields are read from. */
+enum ColumnSource
+{
+    case FILLABLE;
+
+    case DATABASE_TABLE;
+
+    public static function from(string $columnSource): mixed
+    {
+        return constant("self::{$columnSource}");
+    }
+}

--- a/src/Commands/Support/PowerGridComponentMaker.php
+++ b/src/Commands/Support/PowerGridComponentMaker.php
@@ -3,11 +3,12 @@
 namespace PowerComponents\LivewirePowerGrid\Commands\Support;
 
 use Exception;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use PowerComponents\LivewirePowerGrid\Commands\Actions\{GetStubVarsFromDbTable, GetStubVarsFromFromModel};
 use PowerComponents\LivewirePowerGrid\Commands\Actions\SanitizeComponentName;
-use PowerComponents\LivewirePowerGrid\Commands\Enums\Datasource;
+use PowerComponents\LivewirePowerGrid\Commands\Enums\{ColumnSource, Datasource};
 
 /**
  * @property-read PowerGridStub $stub;
@@ -22,6 +23,7 @@ use PowerComponents\LivewirePowerGrid\Commands\Enums\Datasource;
  * @property-read string $model
  * @property-read string $modelFqn
  * @property-read bool $autoCreateColumns
+ * @property-read ColumnSource $columnSource
  * @property-read bool $usesCustomStub
  * @property-read bool $isProcessed
  */
@@ -52,6 +54,8 @@ final class PowerGridComponentMaker
     private string $tableName = '';
 
     private bool $autoCreateColumns = false;
+
+    private ColumnSource $columnSource = ColumnSource::FILLABLE;
 
     private bool $usesCustomStub = false;
 
@@ -116,6 +120,19 @@ final class PowerGridComponentMaker
         return $this;
     }
 
+    /** Table name of the configured model, or an empty string when there is no model. */
+    public function modelTable(): string
+    {
+        if ($this->modelFqn === '') {
+            return '';
+        }
+
+        /** @var Model $model */
+        $model = new $this->modelFqn();
+
+        return $model->getTable();
+    }
+
     public function loadCustomStub(string $path): self
     {
         $this->usesCustomStub = true;
@@ -143,6 +160,13 @@ final class PowerGridComponentMaker
     public function setAutoCreateColumns(bool $autoCreateColumns = true): self
     {
         $this->autoCreateColumns = $autoCreateColumns;
+
+        return $this;
+    }
+
+    public function setColumnSource(ColumnSource $columnSource): self
+    {
+        $this->columnSource = $columnSource;
 
         return $this;
     }

--- a/src/Commands/Support/SchemaColumns.php
+++ b/src/Commands/Support/SchemaColumns.php
@@ -12,8 +12,8 @@ use Illuminate\Support\Facades\Schema;
  */
 final class SchemaColumns
 {
-    /** Columns never worth generating into a grid. */
-    public const SENSITIVE_COLUMNS = ['password', 'remember_token', 'email_verified_at'];
+    /** Columns never generated when the source is the database table. */
+    public const SENSITIVE_COLUMNS = ['password', 'remember_token', 'email_verified_at', 'two_factor_secret', 'two_factor_recovery_codes', 'api_token'];
 
     private const DATETIME_TYPES = ['datetime', 'datetime2', 'timestamp', 'timestamptz', 'datetimeoffset'];
 
@@ -45,6 +45,19 @@ final class SchemaColumns
         ]);
     }
 
+    /**
+     * Column names with the sensitive ones removed, in table column order.
+     *
+     * @param  Collection<string, string>  $types
+     * @return list<string>
+     */
+    public static function publicFields(Collection $types): array
+    {
+        return array_values($types->keys()->reject(
+            fn (string $field): bool => in_array($field, self::SENSITIVE_COLUMNS, true)
+        )->all());
+    }
+
     private static function normalize(string $typeName, string $type): string
     {
         if ($typeName === 'date') {
@@ -57,7 +70,9 @@ final class SchemaColumns
 
         // MySQL and SQLite both report a boolean as `tinyint`; only the
         // display width in the full type tells it apart from an integer.
-        if (in_array($typeName, self::BOOLEAN_TYPES, true) || str_starts_with($type, 'tinyint(1)')) {
+        // Match `tinyint(1)` exactly (or with a trailing modifier such as
+        // ` unsigned`) so `tinyint(10)`..`tinyint(19)` aren't mistaken for it.
+        if (in_array($typeName, self::BOOLEAN_TYPES, true) || $type === 'tinyint(1)' || str_starts_with($type, 'tinyint(1) ')) {
             return 'boolean';
         }
 

--- a/src/Commands/Support/SchemaColumns.php
+++ b/src/Commands/Support/SchemaColumns.php
@@ -21,7 +21,8 @@ final class SchemaColumns
 
     private const INTEGER_TYPES = ['int', 'integer', 'int2', 'int4', 'int8', 'smallint', 'mediumint', 'bigint', 'tinyint', 'serial', 'bigserial', 'smallserial'];
 
-    private const STRING_TYPES = ['varchar', 'char', 'nvarchar', 'nchar', 'text', 'tinytext', 'mediumtext', 'longtext', 'ntext', 'citext', 'uuid', 'enum', 'string'];
+    // `bpchar` is how PostgreSQL reports a blank-padded `char(n)`.
+    private const STRING_TYPES = ['varchar', 'char', 'bpchar', 'nvarchar', 'nchar', 'text', 'tinytext', 'mediumtext', 'longtext', 'ntext', 'citext', 'uuid', 'enum', 'string'];
 
     /**
      * Column name => normalized type bucket, in table column order.

--- a/src/Commands/Support/SchemaColumns.php
+++ b/src/Commands/Support/SchemaColumns.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Commands\Support;
+
+use Exception;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Reads a table's schema in a single query and normalizes native database
+ * type names into the generic buckets the component generator understands.
+ */
+final class SchemaColumns
+{
+    /** Columns never worth generating into a grid. */
+    public const SENSITIVE_COLUMNS = ['password', 'remember_token', 'email_verified_at'];
+
+    private const DATETIME_TYPES = ['datetime', 'datetime2', 'timestamp', 'timestamptz', 'datetimeoffset'];
+
+    private const BOOLEAN_TYPES = ['bool', 'boolean', 'bit'];
+
+    private const INTEGER_TYPES = ['int', 'integer', 'int2', 'int4', 'int8', 'smallint', 'mediumint', 'bigint', 'tinyint', 'serial', 'bigserial', 'smallserial'];
+
+    private const STRING_TYPES = ['varchar', 'char', 'nvarchar', 'nchar', 'text', 'tinytext', 'mediumtext', 'longtext', 'ntext', 'citext', 'uuid', 'enum', 'string'];
+
+    /**
+     * Column name => normalized type bucket, in table column order.
+     *
+     * @return Collection<string, string>
+     */
+    public static function handle(string $table, ?string $connection = null): Collection
+    {
+        try {
+            $columns = Schema::connection($connection)->getColumns($table);
+        } catch (Exception) {
+            // Component may be created before the database exists or is migrated.
+            return collect();
+        }
+
+        return collect($columns)->mapWithKeys(fn (array $column): array => [
+            strval($column['name']) => self::normalize(
+                strtolower(strval($column['type_name'])),
+                strtolower(strval($column['type'])),
+            ),
+        ]);
+    }
+
+    private static function normalize(string $typeName, string $type): string
+    {
+        if ($typeName === 'date') {
+            return 'date';
+        }
+
+        if (in_array($typeName, self::DATETIME_TYPES, true)) {
+            return 'datetime';
+        }
+
+        // MySQL and SQLite both report a boolean as `tinyint`; only the
+        // display width in the full type tells it apart from an integer.
+        if (in_array($typeName, self::BOOLEAN_TYPES, true) || str_starts_with($type, 'tinyint(1)')) {
+            return 'boolean';
+        }
+
+        if (in_array($typeName, self::INTEGER_TYPES, true)) {
+            return 'integer';
+        }
+
+        if (in_array($typeName, self::STRING_TYPES, true)) {
+            return 'string';
+        }
+
+        return 'other';
+    }
+}

--- a/tests/Concerns/Fixtures/Models/Waiter.php
+++ b/tests/Concerns/Fixtures/Models/Waiter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests\Concerns\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Fixture for the column generator tests.
+ *
+ * Lives outside Concerns\Models on purpose: ListModelsTest asserts the exact
+ * contents of that directory.
+ */
+class Waiter extends Model
+{
+    protected $table = 'waiters';
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    protected $hidden = [
+        'password',
+        'internal_note',
+    ];
+}

--- a/tests/Concerns/Fixtures/Models/WaiterWithKeyInFillable.php
+++ b/tests/Concerns/Fixtures/Models/WaiterWithKeyInFillable.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PowerComponents\LivewirePowerGrid\Tests\Concerns\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/** Fixture whose $fillable already repeats the primary key and created_at. */
+class WaiterWithKeyInFillable extends Model
+{
+    protected $table = 'waiters';
+
+    protected $fillable = [
+        'id',
+        'name',
+        'created_at',
+    ];
+}

--- a/tests/Feature/Actions/AskColumnSourceTest.php
+++ b/tests/Feature/Actions/AskColumnSourceTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Laravel\Prompts\{Key, Prompt};
+use PowerComponents\LivewirePowerGrid\Commands\Actions\AskColumnSource;
+
+test('selecting the model $fillable as field source', function () {
+    Prompt::fake([Key::ENTER]);
+
+    expect(AskColumnSource::handle('Dish', 'dishes'))->toBe('FILLABLE');
+});
+
+test('selecting the database table as field source', function () {
+    Prompt::fake([Key::DOWN, Key::ENTER]);
+
+    expect(AskColumnSource::handle('Dish', 'dishes'))->toBe('DATABASE_TABLE');
+});

--- a/tests/Feature/Actions/BuildStubVarsTest.php
+++ b/tests/Feature/Actions/BuildStubVarsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use PowerComponents\LivewirePowerGrid\Commands\Actions\BuildStubVars;
+
+it('generates a searchable, sortable column with a text filter for a string', function () {
+    $vars = BuildStubVars::handle(['name'], collect(['name' => 'string']));
+
+    expect($vars['columns'])->toContain("Column::make('Name', 'name')\n                ->sortable()\n                ->searchable(),")
+        ->and($vars['PowerGridFields'])->toContain("->add('name')")
+        ->and($vars['filters'])->toContain("Filter::inputText('name')->operators(['contains']),");
+});
+
+it('generates a plain column without a filter for an integer', function () {
+    $vars = BuildStubVars::handle(['votes'], collect(['votes' => 'integer']));
+
+    expect($vars['columns'])->toContain("Column::make('Votes', 'votes'),")
+        ->and($vars['PowerGridFields'])->toContain("->add('votes')")
+        ->and($vars['filters'])->not->toContain('votes');
+});
+
+it('generates a toggleable column with a boolean filter for a boolean', function () {
+    $vars = BuildStubVars::handle(['in_stock'], collect(['in_stock' => 'boolean']));
+
+    expect($vars['columns'])->toContain("Column::make('In stock', 'in_stock')\n                ->toggleable(),")
+        ->and($vars['PowerGridFields'])->toContain("->add('in_stock')")
+        ->and($vars['filters'])->toContain("Filter::boolean('in_stock'),");
+});
+
+it('generates a formatted column with a date filter for a date', function () {
+    $vars = BuildStubVars::handle(['published_on'], collect(['published_on' => 'date']));
+
+    expect($vars['columns'])->toContain("Column::make('Published on', 'published_on_formatted', 'published_on')")
+        ->and($vars['PowerGridFields'])->toContain("->add('published_on_formatted', fn (\$model) => Carbon::parse(\$model->published_on)->format('d/m/Y'))")
+        ->and($vars['filters'])->toContain("Filter::datepicker('published_on'),");
+});
+
+it('generates a formatted column with a datetime filter for a datetime', function () {
+    $vars = BuildStubVars::handle(['created_at'], collect(['created_at' => 'datetime']));
+
+    expect($vars['columns'])->toContain("Column::make('Created at', 'created_at_formatted', 'created_at')")
+        ->and($vars['PowerGridFields'])->toContain("->add('created_at_formatted', fn (\$model) => Carbon::parse(\$model->created_at)->format('d/m/Y H:i:s'))")
+        ->and($vars['filters'])->toContain("Filter::datetimepicker('created_at'),");
+});
+
+it('falls back to a searchable column without a filter for an unknown type', function () {
+    $vars = BuildStubVars::handle(['payload'], collect(['payload' => 'other']));
+
+    expect($vars['columns'])->toContain("Column::make('Payload', 'payload')\n                ->sortable()\n                ->searchable(),")
+        ->and($vars['PowerGridFields'])->toContain("->add('payload')")
+        ->and($vars['filters'])->toBe("[\n        ];");
+});
+
+it('adds the closure example to the first string field only', function () {
+    $vars = BuildStubVars::handle(['name', 'email'], collect(['name' => 'string', 'email' => 'string']));
+
+    expect(substr_count($vars['PowerGridFields'], 'Example of custom column using a closure'))->toBe(1)
+        ->and($vars['PowerGridFields'])->toContain("->add('name_lower', fn (\$model) => strtolower(e(\$model->name)))")
+        ->and($vars['PowerGridFields'])->not->toContain('email_lower');
+});
+
+it('type-hints the model in generated closures', function () {
+    $vars = BuildStubVars::handle(['name', 'created_at'], collect(['name' => 'string', 'created_at' => 'datetime']), 'Dish');
+
+    expect($vars['PowerGridFields'])
+        ->toContain('fn (Dish $model) => strtolower(e($model->name))')
+        ->toContain('fn (Dish $model) => Carbon::parse($model->created_at)');
+});
+
+it('skips fields that have no known column type', function () {
+    $vars = BuildStubVars::handle(['name', 'ghost'], collect(['name' => 'string']));
+
+    expect($vars['PowerGridFields'])->not->toContain('ghost')
+        ->and($vars['columns'])->not->toContain('ghost');
+});
+
+it('keeps the given field order', function () {
+    $vars = BuildStubVars::handle(['votes', 'id'], collect(['id' => 'integer', 'votes' => 'integer']));
+
+    expect($vars['columns'])->toContain("Column::make('Votes', 'votes'),\n            Column::make('Id', 'id'),");
+});
+
+it('always closes the component with an action column', function () {
+    $vars = BuildStubVars::handle([], collect());
+
+    expect($vars['columns'])->toBe("[\n            Column::action('Action')\n        ];")
+        ->and($vars['filters'])->toBe("[\n        ];")
+        ->and($vars['PowerGridFields'])->toBe('');
+});

--- a/tests/Feature/Actions/GetStubVarsFromDbTableTest.php
+++ b/tests/Feature/Actions/GetStubVarsFromDbTableTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use PowerComponents\LivewirePowerGrid\Commands\Actions\GetStubVarsFromDbTable;
+use PowerComponents\LivewirePowerGrid\Commands\Enums\Datasource;
+use PowerComponents\LivewirePowerGrid\Commands\Support\PowerGridComponentMaker;
+
+beforeEach(fn () => createWaitersTable());
+
+afterEach(fn () => Schema::dropIfExists('waiters'));
+
+function waiterQueryBuilderComponent(): PowerGridComponentMaker
+{
+    return PowerGridComponentMaker::make('WaiterTable')
+        ->setDatasource(Datasource::QUERY_BUILDER)
+        ->setDatabaseTable('waiters')
+        ->setAutoCreateColumns();
+}
+
+it('reads every column of the given table', function () {
+    $vars = GetStubVarsFromDbTable::handle(waiterQueryBuilderComponent());
+
+    expect($vars['PowerGridFields'])
+        ->toContain("->add('id')")
+        ->toContain("->add('name')")
+        ->toContain("->add('email')")
+        ->toContain("->add('tips')")
+        ->toContain("->add('hired_at_formatted'")
+        ->toContain("->add('created_at_formatted'");
+});
+
+it('drops sensitive columns', function () {
+    $vars = GetStubVarsFromDbTable::handle(waiterQueryBuilderComponent());
+
+    expect($vars)->each->not->toContain('password')
+        ->and($vars)->each->not->toContain('remember_token');
+});
+
+it('has no model to hide columns with, unlike the Eloquent source', function () {
+    $vars = GetStubVarsFromDbTable::handle(waiterQueryBuilderComponent());
+
+    expect($vars['PowerGridFields'])->toContain("->add('internal_note')");
+});
+
+it('leaves the generated closures untyped', function () {
+    $vars = GetStubVarsFromDbTable::handle(waiterQueryBuilderComponent());
+
+    expect($vars['PowerGridFields'])->toContain('fn ($model)');
+});
+
+it('generates nothing when the table does not exist', function () {
+    $component = PowerGridComponentMaker::make('GhostTable')
+        ->setDatasource(Datasource::QUERY_BUILDER)
+        ->setDatabaseTable('table_that_does_not_exist')
+        ->setAutoCreateColumns();
+
+    expect(GetStubVarsFromDbTable::handle($component)['PowerGridFields'])->toBe('');
+});
+
+it('renders the generated columns into the query builder stub', function () {
+    $component = waiterQueryBuilderComponent()->loadPowerGridStub();
+
+    $code = $component->saveToString();
+
+    expect($code)
+        ->toContain("return DB::table('waiters');")
+        ->toContain("->add('tips')")
+        ->toContain("Column::make('Email', 'email')")
+        ->toContain("Filter::inputText('email')->operators(['contains'])")
+        ->toContain("Column::action('Action')")
+        ->not->toContain('{{ columns }}')
+        ->not->toContain('password');
+});

--- a/tests/Feature/Actions/GetStubVarsFromFromModelTest.php
+++ b/tests/Feature/Actions/GetStubVarsFromFromModelTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use PowerComponents\LivewirePowerGrid\Commands\Actions\GetStubVarsFromFromModel;
+use PowerComponents\LivewirePowerGrid\Commands\Enums\{ColumnSource, Datasource};
+use PowerComponents\LivewirePowerGrid\Commands\Support\PowerGridComponentMaker;
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Fixtures\Models\{Waiter, WaiterWithKeyInFillable};
+
+beforeEach(fn () => createWaitersTable());
+
+afterEach(fn () => Schema::dropIfExists('waiters'));
+
+function waiterComponent(ColumnSource $columnSource, string $modelFqn = Waiter::class): PowerGridComponentMaker
+{
+    return PowerGridComponentMaker::make('WaiterTable')
+        ->setDatasource(Datasource::ELOQUENT_BUILDER)
+        ->setModelWithFqn('Waiter', $modelFqn)
+        ->setAutoCreateColumns()
+        ->setColumnSource($columnSource);
+}
+
+it('reads the primary key, $fillable and created_at when the source is the model', function () {
+    $vars = GetStubVarsFromFromModel::handle(waiterComponent(ColumnSource::FILLABLE));
+
+    expect($vars['PowerGridFields'])
+        ->toContain("->add('id')")
+        ->toContain("->add('name')")
+        ->toContain("->add('email')")
+        ->toContain("->add('created_at_formatted'");
+});
+
+it('ignores columns outside $fillable when the source is the model', function () {
+    $vars = GetStubVarsFromFromModel::handle(waiterComponent(ColumnSource::FILLABLE));
+
+    expect($vars['PowerGridFields'])
+        ->not->toContain('tips')
+        ->not->toContain('hired_at')
+        ->not->toContain('updated_at');
+});
+
+it('reads every table column when the source is the database table', function () {
+    $vars = GetStubVarsFromFromModel::handle(waiterComponent(ColumnSource::DATABASE_TABLE));
+
+    expect($vars['PowerGridFields'])
+        ->toContain("->add('id')")
+        ->toContain("->add('name')")
+        ->toContain("->add('email')")
+        ->toContain("->add('tips')")
+        ->toContain("->add('hired_at_formatted'")
+        ->toContain("->add('updated_at_formatted'");
+});
+
+it('types the columns it read from the database table', function () {
+    $vars = GetStubVarsFromFromModel::handle(waiterComponent(ColumnSource::DATABASE_TABLE));
+
+    expect($vars['columns'])
+        ->toContain("Column::make('Tips', 'tips'),")
+        ->toContain("Column::make('Hired at', 'hired_at_formatted', 'hired_at')")
+        ->and($vars['filters'])
+        ->toContain("Filter::datepicker('hired_at'),")
+        ->toContain("Filter::inputText('name')->operators(['contains']),");
+});
+
+it('never generates a sensitive column from the database table', function (string $source) {
+    $vars = GetStubVarsFromFromModel::handle(waiterComponent(ColumnSource::from($source)));
+
+    expect($vars)->each->not->toContain('password')
+        ->and($vars)->each->not->toContain('remember_token');
+})->with(['FILLABLE', 'DATABASE_TABLE']);
+
+it('never generates a $hidden column', function (string $source) {
+    $vars = GetStubVarsFromFromModel::handle(waiterComponent(ColumnSource::from($source)));
+
+    expect($vars)->each->not->toContain('internal_note');
+})->with(['FILLABLE', 'DATABASE_TABLE']);
+
+it('does not repeat a field listed in both $fillable and the historical order', function () {
+    $vars = GetStubVarsFromFromModel::handle(
+        waiterComponent(ColumnSource::FILLABLE, WaiterWithKeyInFillable::class)
+    );
+
+    expect(substr_count($vars['PowerGridFields'], "->add('id')"))->toBe(1)
+        ->and(substr_count($vars['PowerGridFields'], "->add('created_at_formatted'"))->toBe(1);
+});
+
+it('type-hints the model in the generated closures', function () {
+    $vars = GetStubVarsFromFromModel::handle(waiterComponent(ColumnSource::DATABASE_TABLE));
+
+    expect($vars['PowerGridFields'])->toContain('fn (Waiter $model)')
+        ->not->toContain('fn ($model)');
+});
+
+it('generates nothing when the table has not been migrated yet', function () {
+    Schema::dropIfExists('waiters');
+
+    $vars = GetStubVarsFromFromModel::handle(waiterComponent(ColumnSource::DATABASE_TABLE));
+
+    expect($vars['PowerGridFields'])->toBe('')
+        ->and($vars['filters'])->toBe("[\n        ];")
+        ->and($vars['columns'])->toBe("[\n            Column::action('Action')\n        ];");
+});

--- a/tests/Feature/Enums/ColumnSourceTest.php
+++ b/tests/Feature/Enums/ColumnSourceTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use PowerComponents\LivewirePowerGrid\Commands\Enums\ColumnSource;
+
+test('cases', function () {
+    expect(ColumnSource::cases())->toBe([
+        ColumnSource::FILLABLE,
+        ColumnSource::DATABASE_TABLE,
+    ]);
+});
+
+test('make ColumnSource from string', function (string $name, ColumnSource $case) {
+    expect(ColumnSource::from($name))->toBe($case);
+})->with([
+    ['FILLABLE', ColumnSource::FILLABLE],
+    ['DATABASE_TABLE', ColumnSource::DATABASE_TABLE],
+]);

--- a/tests/Feature/Support/PowerGridMakerTest.php
+++ b/tests/Feature/Support/PowerGridMakerTest.php
@@ -1,7 +1,9 @@
 <?php
 
-use PowerComponents\LivewirePowerGrid\Commands\Enums\Datasource;
+use Illuminate\Support\Facades\Schema;
+use PowerComponents\LivewirePowerGrid\Commands\Enums\{ColumnSource, Datasource};
 use PowerComponents\LivewirePowerGrid\Commands\Support\{PowerGridComponentMaker, PowerGridStub};
+use PowerComponents\LivewirePowerGrid\Tests\Concerns\Fixtures\Models\Waiter;
 
 it('can make an eloquent component', function () {
     $component = PowerGridComponentMaker::make('UserTable')
@@ -172,4 +174,49 @@ it('tableName appends Table to the end of the name', function () {
     $component = PowerGridComponentMaker::make('System/Office/Users/Admin/Active/List');
 
     expect($component->tableName)->toBe('listTable');
+});
+
+it('sources columns from the model $fillable by default', function () {
+    expect(PowerGridComponentMaker::make('UserTable'))->columnSource->toBe(ColumnSource::FILLABLE);
+});
+
+it('can source columns from the database table', function () {
+    $component = PowerGridComponentMaker::make('UserTable')
+        ->setColumnSource(ColumnSource::DATABASE_TABLE);
+
+    expect($component)->columnSource->toBe(ColumnSource::DATABASE_TABLE);
+});
+
+it('resolves the table name of the configured model', function () {
+    $component = PowerGridComponentMaker::make('WaiterTable')
+        ->setModelWithFqn('Waiter', Waiter::class);
+
+    expect($component->modelTable())->toBe('waiters');
+});
+
+it('has no model table when there is no model', function () {
+    expect(PowerGridComponentMaker::make('UserTable')->modelTable())->toBe('');
+});
+
+it('renders database table columns into the eloquent stub', function () {
+    createWaitersTable();
+
+    $code = PowerGridComponentMaker::make('WaiterTable')
+        ->setDatasource(Datasource::ELOQUENT_BUILDER)
+        ->setModelWithFqn('Waiter', Waiter::class)
+        ->setAutoCreateColumns()
+        ->setColumnSource(ColumnSource::DATABASE_TABLE)
+        ->loadPowerGridStub()
+        ->saveToString();
+
+    Schema::dropIfExists('waiters');
+
+    expect($code)
+        ->toContain('return Waiter::query();')
+        ->toContain('use '.Waiter::class.';')
+        ->toContain("->add('tips')")
+        ->toContain("Column::make('Hired at', 'hired_at_formatted', 'hired_at')")
+        ->toContain('fn (Waiter $model)')
+        ->not->toContain('password')
+        ->not->toContain('internal_note');
 });

--- a/tests/Feature/Support/SchemaColumnsTest.php
+++ b/tests/Feature/Support/SchemaColumnsTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\{DB, Schema};
+use PowerComponents\LivewirePowerGrid\Commands\Support\SchemaColumns;
+
+beforeEach(function () {
+    Schema::dropIfExists('schema_probe');
+
+    Schema::create('schema_probe', function (Blueprint $table) {
+        $table->id();
+        $table->string('name');
+        $table->char('initials', 2);
+        $table->text('description');
+        $table->uuid('external_id');
+        $table->enum('status', ['draft', 'published']);
+        $table->integer('votes');
+        $table->bigInteger('views');
+        $table->smallInteger('rank');
+        $table->tinyInteger('stars');
+        $table->boolean('is_active');
+        $table->date('published_on');
+        $table->dateTime('reviewed_at');
+        $table->timestamp('archived_at')->nullable();
+        $table->decimal('price', 8, 2);
+        $table->double('weight');
+        $table->json('payload')->nullable();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('schema_probe');
+});
+
+it('normalizes native column types into generic buckets', function (string $column, string $bucket) {
+    expect(SchemaColumns::handle('schema_probe')->get($column))->toBe($bucket);
+})->with([
+    'auto increment key' => ['id', 'integer'],
+    'varchar' => ['name', 'string'],
+    'char' => ['initials', 'string'],
+    'text' => ['description', 'string'],
+    'uuid' => ['external_id', 'string'],
+    'enum' => ['status', 'string'],
+    'integer' => ['votes', 'integer'],
+    'big integer' => ['views', 'integer'],
+    'small integer' => ['rank', 'integer'],
+    'tiny integer' => ['stars', 'integer'],
+    'boolean' => ['is_active', 'boolean'],
+    'date' => ['published_on', 'date'],
+    'datetime' => ['reviewed_at', 'datetime'],
+    'timestamp' => ['archived_at', 'datetime'],
+    'decimal' => ['price', 'other'],
+    'double' => ['weight', 'other'],
+]);
+
+it('tells a boolean apart from a tiny integer', function () {
+    // MySQL and SQLite report both as `tinyint`; only the display width differs.
+    expect(SchemaColumns::handle('schema_probe'))
+        ->get('is_active')->toBe('boolean')
+        ->get('stars')->toBe('integer');
+});
+
+it('normalizes json to the type the driver actually stores it as', function () {
+    // SQLite has no json type: the column is created as text.
+    $expected = DB::getDriverName() === 'sqlite' ? 'string' : 'other';
+
+    expect(SchemaColumns::handle('schema_probe')->get('payload'))->toBe($expected);
+});
+
+it('keeps the table column order', function () {
+    expect(SchemaColumns::handle('schema_probe')->keys()->take(5)->all())
+        ->toBe(['id', 'name', 'initials', 'description', 'external_id']);
+});
+
+it('reads a table on a named connection', function () {
+    expect(SchemaColumns::handle('schema_probe', 'testbench')->get('name'))->toBe('string');
+});
+
+it('returns no columns when the table does not exist', function () {
+    // A component may be generated before the database is migrated.
+    expect(SchemaColumns::handle('table_that_does_not_exist'))->toBeEmpty();
+});
+
+it('returns no columns when the connection is unusable', function () {
+    config()->set('database.connections.broken', [
+        'driver' => 'sqlite',
+        'database' => '/does/not/exist/powergrid.sqlite',
+        'prefix' => '',
+    ]);
+
+    expect(SchemaColumns::handle('schema_probe', 'broken'))->toBeEmpty();
+});
+
+it('rejects sensitive columns from the public field list', function (string $column) {
+    $types = collect(['id' => 'integer', $column => 'string', 'name' => 'string']);
+
+    expect(SchemaColumns::publicFields($types))->toBe(['id', 'name']);
+})->with(SchemaColumns::SENSITIVE_COLUMNS);
+
+it('keeps every other column in table order', function () {
+    $types = SchemaColumns::handle('schema_probe');
+
+    expect(SchemaColumns::publicFields($types))->toBe($types->keys()->all());
+});
+
+it('only rejects an exact sensitive column name', function () {
+    $types = collect(['password_changed_at' => 'datetime', 'user_password' => 'string']);
+
+    expect(SchemaColumns::publicFields($types))->toBe(['password_changed_at', 'user_password']);
+});

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -1,10 +1,35 @@
 <?php
 
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 function getLaravelDir(): string
 {
     return __DIR__.'/../vendor/orchestra/testbench-core/laravel/';
+}
+
+/**
+ * Creates the `waiters` table backing the column generator tests.
+ *
+ * It deliberately mixes columns that are fillable, hidden, sensitive and
+ * database-only, so the different field sources can be told apart.
+ */
+function createWaitersTable(): void
+{
+    Schema::dropIfExists('waiters');
+
+    Schema::create('waiters', function (Blueprint $table) {
+        $table->id();
+        $table->string('name');
+        $table->string('email');
+        $table->string('password');
+        $table->string('remember_token')->nullable();
+        $table->string('internal_note')->nullable();
+        $table->integer('tips');
+        $table->date('hired_at');
+        $table->timestamps();
+    });
 }
 
 function expectInputText(object $params, mixed $component, string $value, string $type)


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [x] Enhancement
- [x] New feature
- [ ] Breaking change

#### Description

`powergrid:create` could only read a component's fields from the model's `$fillable`.
That is a poor default for models that keep `$fillable` short (or empty and rely on
`$guarded`), because the generated component then ships with almost no columns and
the fields have to be typed out by hand.

When the datasource is an Eloquent model, the command now asks where the fields
should come from:

```
Where should the fields come from?
> $fillable in [User] Model
  Columns in [users] DB table
```

Before writing anything to disk it prints what it is about to generate and asks
for confirmation, so a wrong answer costs nothing:

```
 👀 Preview of the fields from the [users] table:

 +------------+----------+-----------------------------------------------------+
 | Field      | Type     | Generated as                                        |
 +------------+----------+-----------------------------------------------------+
 | id         | integer  | Plain column                                        |
 | name       | string   | Sortable, searchable column + text filter           |
 | is_active  | boolean  | Toggleable column + boolean filter                  |
 | created_at | datetime | Sortable column, formatted d/m/Y H:i:s + datetime … |
 +------------+----------+-----------------------------------------------------+

 ┌ Generate the component with these fields? ───────────────────┐
 │ ● Yes / ○ No                                                 │
 └──────────────────────────────────────────────────────────────┘
```

Declining generates the component with only the Action column, the same result as
declining auto-import in the first place; re-run the command to try the other
source. Query Builder components are not asked where the fields come from - the
table is their only possible source - but they get the same preview and
confirmation.

Along the way the two generators were collapsed into one code path. `GetStubVarsFromDbTable`
and `GetStubVarsFromFromModel` were near-identical 100-line copies of the same
if-chain that had already drifted apart; they are now thin wrappers over
`ResolveGeneratedColumns` (which fields, and their types) and `BuildStubVars`
(what to render for each type). Type detection lives in `SchemaColumns`, which
reads the whole table with a single `Schema::getColumns()` call instead of one
`getColumnType()` query per column, and maps native type names onto the buckets
the generator understands.

#### Behaviour changes

- Query Builder components now get the trailing `Column::action('Action')` that
  model-based components always had. The DB-table generator was simply missing it.
- The sensitive-column denylist grew from `password`, `remember_token` and
  `email_verified_at` to also cover `two_factor_secret`, `two_factor_recovery_codes`
  and `api_token`, and now applies to model-sourced components too.
- A primary key listed in `$fillable` is no longer emitted twice.
- Native types that used to fall through to the untyped branch are now recognised:
  `text`, `uuid`, `enum`, `citext` and friends generate a text filter like any
  other string column, and PostgreSQL's `bpchar` (how it reports `char(n)`) is
  treated as a string rather than an unknown type.
- `tinyint(1)` is read as a boolean on MySQL and SQLite, while `tinyint(10)` and
  wider stay integers.
- If the table cannot be read - the database is not migrated yet, for instance -
  the command warns and generates a component with only the Action column instead
  of failing.

#### Tests

`SchemaColumns` and the generators are covered against the real driver, so the
type normalisation is verified on SQLite, MySQL and PostgreSQL alike rather than
against a mocked schema.

#### Related Issue(s):

#### Documentation

This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [x] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.