### PR TITLE
fix: drop the unmatched phpstan ignore in the Scout builder macro

### DIFF
--- a/src/Providers/Macros.php
+++ b/src/Providers/Macros.php
@@ -270,7 +270,7 @@ class Macros
     {
         if (class_exists(ScoutBuilder::class)) {
             Builder::macro('paginateSafe', function ($perPage = null, $pageName = 'page', $page = null) {
-                $engine = $this->engine(); // @phpstan-ignore-line
+                $engine = $this->engine();
 
                 if ($engine instanceof PaginatesEloquentModels) {
                     return $engine->paginate($this, $perPage, $page)->appends('query', $this->query);


### PR DESCRIPTION
## ⚡ PowerGrid - Pull Request

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

The engine() call is already covered by the global method.notFound ignore, so the inline @phpstan-ignore-line matched nothing and failed the analysis with ignore.unmatchedLine.

#### Related Issue(s): 

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
